### PR TITLE
Add Change Font Scale feature to text editor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,7 +914,7 @@ Creates a `ProImageEditor` widget for editing an image from a network URL.
 | `canToggleBackgroundMode`    | Determines if the background mode can be toggled.        | `true`                                         |
 | `canChangeFontScale`         | Determines if the font scale can be change.              | `true`                                         |
 | `initFontSize`               | The initial font size for text.                          | `24.0`                                         |
-| `initialFontSize`            | The initial font scale for text.                         | `1.0`                                          |
+| `initFontScale`              | The initial font scale for text.                         | `1.0`                                          |
 | `maxFontScale`               | The max font scale for text.                             | `3.0`                                          |
 | `minFontSize`                | The min font scale for text.                             | `0.3`                                          |
 | `initialTextAlign`           | The initial text alignment for the layer.                | `TextAlign.center`                             |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The ProImageEditor is a Flutter widget designed for image editing within your ap
 - ✅ Text-Editor
   - ✅ Color picker
   - ✅ Align-Text => left, right and center
+  - ✅ Change Text Scale
   - ✅ Multiple background modes like in whatsapp
 - ✅ Crop-Rotate-Editor
 - ✅ Filter-Editor
@@ -640,15 +641,16 @@ Creates a `ProImageEditor` widget for editing an image from a network URL.
 
 #### `i18n textEditor`
 
-| Property                 | Description                                        | Default Value      |
-|--------------------------|----------------------------------------------------|--------------------|
-| `bottomNavigationBarText`| Text for the bottom navigation bar item            | `'Text'`             |
-| `inputHintText`          | Placeholder text displayed in the text input field| `'Enter text'`       |
-| `done`                   | Text for the "Done" button                          | `'Done'`             |
-| `back`                   | Text for the "Back" button                          | `'Back'`             |
-| `textAlign`              | Text for the "Align text" setting                   | `'Align text'`       |
-| `backgroundMode`         | Text for the "Background mode" setting              | `'Background mode'`  |
-| `smallScreenMoreTooltip` | Tooltip text for the "More" option on small screens| `'More'`             |
+| Property                  | Description                                         | Default Value       |
+|---------------------------|-----------------------------------------------------|---------------------|
+| `bottomNavigationBarText` | Text for the bottom navigation bar item             | `'Text'`            |
+| `inputHintText`           | Placeholder text displayed in the text input field  | `'Enter text'`      |
+| `done`                    | Text for the "Done" button                          | `'Done'`            |
+| `back`                    | Text for the "Back" button                          | `'Back'`            |
+| `textAlign`               | Text for the "Align text" setting                   | `'Align text'`      |
+| `fontScale`               | Text for the "Font Scale" setting                   | `'Font Scale'`      |
+| `backgroundMode`          | Text for the "Background mode" setting              | `'Background mode'` |
+| `smallScreenMoreTooltip`  | Tooltip text for the "More" option on small screens | `'More'`            |
 
 
 #### `i18n cropRotateEditor`
@@ -842,13 +844,15 @@ Creates a `ProImageEditor` widget for editing an image from a network URL.
 | `dashLine`     | The icon for the dashed line drawing tool.      | `Icons.power_input`   |
 
 #### icons textEditor
-| Property        | Description                               | Default Value                        |
-| --------------- | ----------------------------------------- | ------------------------------------ |
-| `bottomNavBar`  | The icon for the bottom navigation bar.   | `Icons.text_fields`                  |
-| `alignLeft`     | The icon for aligning text to the left.   | `Icons.align_horizontal_left_rounded` |
-| `alignCenter`   | The icon for aligning text to the center. | `Icons.align_horizontal_center_rounded` |
-| `alignRight`    | The icon for aligning text to the right.  | `Icons.align_horizontal_right_rounded` |
-| `backgroundMode`| The icon for toggling background mode.    | `Icons.layers_rounded`               |
+| Property         | Description                                        | Default Value                           |
+|------------------|----------------------------------------------------|-----------------------------------------|
+| `bottomNavBar`   | The icon for the bottom navigation bar.            | `Icons.text_fields`                     |
+| `alignLeft`      | The icon for aligning text to the left.            | `Icons.align_horizontal_left_rounded`   |
+| `alignCenter`    | The icon for aligning text to the center.          | `Icons.align_horizontal_center_rounded` |
+| `alignRight`     | The icon for aligning text to the right.           | `Icons.align_horizontal_right_rounded`  |
+| `fontScale`      | The icon for changing font scale.                  | `Icons.format_size_rounded`             |
+| `resetFontScale` | The icon for resetting font scale to preset value. | `Icons.refresh_rounded`                 |
+| `backgroundMode` | The icon for toggling background mode.             | `Icons.layers_rounded`                  |
 
 
 #### icons cropRotateEditor
@@ -903,14 +907,18 @@ Creates a `ProImageEditor` widget for editing an image from a network URL.
 <details>
   <summary><b>textEditorConfigs</b></summary>
 
-| Property                    | Description                                          | Default Value                              |
-|-----------------------------|------------------------------------------------------|--------------------------------------------|
-| `enabled`                   | Indicates whether the text editor is enabled.        | `true`                                     |
-| `canToggleTextAlign`        | Determines if the text alignment options can be toggled. | `true`                                  |
-| `canToggleBackgroundMode`   | Determines if the background mode can be toggled.    | `true`                                     |
-| `initFontSize`              | The initial font size for text.                      | `24.0`                                     |
-| `initialTextAlign`          | The initial text alignment for the layer.            | `TextAlign.center`                         |
-| `initialBackgroundColorMode`| The initial background color mode for the layer.      | `LayerBackgroundColorModeE.backgroundAndColor` |
+| Property                     | Description                                              | Default Value                                  |
+|------------------------------|----------------------------------------------------------|------------------------------------------------|
+| `enabled`                    | Indicates whether the text editor is enabled.            | `true`                                         |
+| `canToggleTextAlign`         | Determines if the text alignment options can be toggled. | `true`                                         |
+| `canToggleBackgroundMode`    | Determines if the background mode can be toggled.        | `true`                                         |
+| `canChangeFontScale`         | Determines if the font scale can be change.              | `true`                                         |
+| `initFontSize`               | The initial font size for text.                          | `24.0`                                         |
+| `initialFontSize`            | The initial font scale for text.                         | `1.0`                                          |
+| `maxFontScale`               | The max font scale for text.                             | `3.0`                                          |
+| `minFontSize`                | The min font scale for text.                             | `0.3`                                          |
+| `initialTextAlign`           | The initial text alignment for the layer.                | `TextAlign.center`                             |
+| `initialBackgroundColorMode` | The initial background color mode for the layer.         | `LayerBackgroundColorModeE.backgroundAndColor` |
 </details>
 
 <details>

--- a/lib/models/editor_configs/text_editor_configs.dart
+++ b/lib/models/editor_configs/text_editor_configs.dart
@@ -24,6 +24,9 @@ class TextEditorConfigs {
   /// Determines if the text alignment options can be toggled.
   final bool canToggleTextAlign;
 
+  /// Determines if the font scale can be change.
+  final bool canChangeFontScale;
+
   /// Determines if the background mode can be toggled.
   final bool canToggleBackgroundMode;
 
@@ -32,6 +35,15 @@ class TextEditorConfigs {
 
   /// The initial text alignment for the layer.
   final TextAlign initialTextAlign;
+
+  /// The initial font scale for text.
+  final double initFontScale;
+
+  /// The max font font scale for text.
+  final double maxFontScale;
+
+  /// The min font font scale for text.
+  final double minFontScale;
 
   /// The initial background color mode for the layer.
   final LayerBackgroundColorModeE initialBackgroundColorMode;
@@ -44,8 +56,12 @@ class TextEditorConfigs {
     this.enabled = true,
     this.canToggleTextAlign = true,
     this.canToggleBackgroundMode = true,
+    this.canChangeFontScale = true,
     this.initFontSize = 24.0,
     this.initialTextAlign = TextAlign.center,
+    this.initFontScale = 1.0,
+    this.maxFontScale = 3.0,
+    this.minFontScale = 0.3,
     this.initialBackgroundColorMode =
         LayerBackgroundColorModeE.backgroundAndColor,
   });

--- a/lib/models/i18n/i18n_text_editor.dart
+++ b/lib/models/i18n/i18n_text_editor.dart
@@ -15,6 +15,9 @@ class I18nTextEditor {
   /// Text for the "Align text" setting.
   final String textAlign;
 
+  /// Text for the "Text scale" setting.
+  final String fontScale;
+
   /// Text for the "Background mode" setting.
   final String backgroundMode;
 
@@ -45,6 +48,7 @@ class I18nTextEditor {
     this.back = 'Back',
     this.done = 'Done',
     this.textAlign = 'Align text',
+    this.fontScale = 'Font scale',
     this.backgroundMode = 'Background mode',
     this.smallScreenMoreTooltip = 'More',
   });

--- a/lib/models/icons/icons_text_editor.dart
+++ b/lib/models/icons/icons_text_editor.dart
@@ -17,6 +17,12 @@ class IconsTextEditor {
   /// The icon for toggling background mode.
   final IconData backgroundMode;
 
+  /// The icon for changing font scale.
+  final IconData fontScale;
+
+  /// The icon for resetting font scale to preset value.
+  final IconData resetFontScale;
+
   /// Creates an instance of [IconsTextEditor] with customizable icon settings.
   ///
   /// You can provide custom icons for various actions in the Text Editor component.
@@ -45,6 +51,8 @@ class IconsTextEditor {
     this.alignLeft = Icons.align_horizontal_left_rounded,
     this.alignCenter = Icons.align_horizontal_center_rounded,
     this.alignRight = Icons.align_horizontal_right_rounded,
+    this.fontScale = Icons.format_size_rounded,
+    this.resetFontScale = Icons.refresh_rounded,
     this.backgroundMode = Icons.layers_rounded,
   });
 }

--- a/lib/models/layer.dart
+++ b/lib/models/layer.dart
@@ -181,6 +181,9 @@ class TextLayerData extends Layer {
   /// The text alignment within the layer.
   TextAlign align;
 
+  /// The font scale for text, to make text bigger or smaller.
+  double fontScale;
+
   /// Creates a new text layer with customizable properties.
   ///
   /// The [text] parameter specifies the text content of the layer.
@@ -198,6 +201,7 @@ class TextLayerData extends Layer {
     this.color = Colors.white,
     this.background = Colors.transparent,
     this.align = TextAlign.left,
+    this.fontScale = 1.0,
     super.offset,
     super.rotation,
     super.scale,
@@ -216,6 +220,7 @@ class TextLayerData extends Layer {
       'background': background.value,
       'colorPickerPosition': colorPickerPosition ?? 0,
       'align': align.name,
+      'fontScale': fontScale,
       'type': 'text',
     };
   }

--- a/lib/pro_image_editor_main.dart
+++ b/lib/pro_image_editor_main.dart
@@ -753,6 +753,7 @@ class ProImageEditorState extends State<ProImageEditor> {
       id: layer.id,
       text: layer.text,
       align: layer.align,
+      fontScale: layer.fontScale,
       background: Color(layer.background.value),
       color: Color(layer.color.value),
       colorMode: layer.colorMode,
@@ -1169,6 +1170,7 @@ class ProImageEditorState extends State<ProImageEditor> {
         ..colorMode = layer.colorMode
         ..colorPickerPosition = layer.colorPickerPosition
         ..align = layer.align
+        ..fontScale = layer.fontScale
         ..id = layerData.id
         ..flipX = layerData.flipX
         ..flipY = layerData.flipY

--- a/lib/widgets/layer_widget.dart
+++ b/lib/widgets/layer_widget.dart
@@ -287,7 +287,7 @@ class _LayerWidgetState extends State<LayerWidget> {
     var fontSize = widget.textFontSize * _layer.scale;
     var layer = _layer as TextLayerData;
     var style = TextStyle(
-      fontSize: fontSize,
+      fontSize: fontSize * layer.fontScale,
       fontWeight: FontWeight.w400,
       color: layer.color,
     );


### PR DESCRIPTION
Hello~ I also add a new feature to text editor.

A text scale button will be shown next to text align button. We can change text scale or reset to the pre-set value.

And these config has changed: 

##  textEditorConfigs

| Property                     | Description                                              | Default Value                                  |
|------------------------------|----------------------------------------------------------|------------------------------------------------|
| `canChangeFontScale`         | Determines if the font scale can be change.              | `true`                                         |
| `initFontScale`            | The initial font scale for text.                         | `1.0`                                          |
| `maxFontScale`               | The max font scale for text.                             | `3.0`                                          |
| `minFontSize`                | The min font scale for text.                             | `0.3`                                          |

## `i18n textEditor`

| Property                  | Description                                         | Default Value       |
|---------------------------|-----------------------------------------------------|---------------------|
| `fontScale`               | Text for the "Font Scale" setting                   | `'Font Scale'`      |


## icons textEditor

| Property         | Description                                        | Default Value                           |
|------------------|----------------------------------------------------|-----------------------------------------|
| `fontScale`      | The icon for changing font scale.                  | `Icons.format_size_rounded`             |
| `resetFontScale` | The icon for resetting font scale to preset value. | `Icons.refresh_rounded`                 |

