### PR TITLE
feat: add the strokeWidthOnChanged callback. 

### DIFF
--- a/lib/models/editor_configs/paint_editor_configs.dart
+++ b/lib/models/editor_configs/paint_editor_configs.dart
@@ -82,6 +82,9 @@ class PaintEditorConfigs {
   /// Indicates the initial paint mode.
   final PaintModeE initialPaintMode;
 
+  /// The Function will call when the stroke width on changed.
+  final Function(double x)? strokeWidthOnChanged;
+
   /// Creates an instance of PaintEditorConfigs with optional settings.
   ///
   /// By default, the editor is enabled, and most drawing tools are enabled.
@@ -103,5 +106,6 @@ class PaintEditorConfigs {
     this.initialStrokeWidth = 10.0,
     this.initialColor = const Color(0xffff0000),
     this.initialPaintMode = PaintModeE.freeStyle,
+    this.strokeWidthOnChanged,
   });
 }

--- a/lib/models/editor_configs/paint_editor_configs.dart
+++ b/lib/models/editor_configs/paint_editor_configs.dart
@@ -82,7 +82,7 @@ class PaintEditorConfigs {
   /// Indicates the initial paint mode.
   final PaintModeE initialPaintMode;
 
-  /// The Function will call when the stroke width on changed.
+  /// A callback function that will be called when the stroke width on changed.
   final Function(double x)? strokeWidthOnChanged;
 
   /// Creates an instance of PaintEditorConfigs with optional settings.

--- a/lib/modules/paint_editor/painting_canvas.dart
+++ b/lib/modules/paint_editor/painting_canvas.dart
@@ -610,6 +610,7 @@ class PaintingCanvasState extends State<PaintingCanvas> {
                       onChanged: (value) {
                         _paintCtrl.setStrokeWidth(value);
                         setState(() {});
+                        if(widget.configs.strokeWidthOnChanged != null) widget.configs.strokeWidthOnChanged!(value);
                       },
                     );
                   }),


### PR DESCRIPTION
feat: add the strokeWidthOnChanged callback. A callback function that will be called when the stroke width on changed.  It is convenient without having to set different stroke width every time you in painting. Different widths for different people. Set once ,used the last width at any time.

```
paintEditorConfigs : PaintEditorConfigs(
   initialStrokeWidth: myLocalizedStorageWidth,
   strokeWidthOnChanged: (x){
     myLocalizedStorageWidth = x;
   }
 ),
```
<img width="572" alt="image" src="https://github.com/hm21/pro_image_editor/assets/18211498/1c932a32-999f-4fc0-8362-39db6536d227">
