### PR TITLE
BoxConstraints support when opening editors in bottom sheets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ migrate_working_dir/
 /example/.flutter-plugins-dependencies
 /example/pubspec.lock
 build/
+
+# Ignoring all of the Cocoapods files in the example app.
+Podfile
+Podfile.*

--- a/example/ios/Flutter/Debug.xcconfig
+++ b/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Flutter/Release.xcconfig
+++ b/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/macos/Flutter/Flutter-Debug.xcconfig
+++ b/example/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/example/macos/Flutter/Flutter-Release.xcconfig
+++ b/example/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -21,12 +21,14 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		29E42C06D375D59C5934CAD3 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C16932C72FA2052ACA1D9642 /* Pods_Runner.framework */; };
 		331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C80D7294CF71000263BE5 /* RunnerTests.swift */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		A7A7A215853DDF9E53F0E372 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25C1FA62F8261CD5DC2C644 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,7 +66,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -77,7 +79,15 @@
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		968A8C9118B1839D172A3D53 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		A2E102A2EAC2BF5831915418 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		B16AA3578AA64CF79F57284A /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		C16932C72FA2052ACA1D9642 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C25C1FA62F8261CD5DC2C644 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C4A06DABEF9BF51F9D201D2E /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		ED3031CFEC488A1F79275A13 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		F119323D017F1E1792C108C7 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A7A7A215853DDF9E53F0E372 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				29E42C06D375D59C5934CAD3 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +137,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				B26281FD5E1130E7B8C4D935 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -172,9 +185,24 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		B26281FD5E1130E7B8C4D935 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				968A8C9118B1839D172A3D53 /* Pods-Runner.debug.xcconfig */,
+				B16AA3578AA64CF79F57284A /* Pods-Runner.release.xcconfig */,
+				C4A06DABEF9BF51F9D201D2E /* Pods-Runner.profile.xcconfig */,
+				A2E102A2EAC2BF5831915418 /* Pods-RunnerTests.debug.xcconfig */,
+				ED3031CFEC488A1F79275A13 /* Pods-RunnerTests.release.xcconfig */,
+				F119323D017F1E1792C108C7 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C16932C72FA2052ACA1D9642 /* Pods_Runner.framework */,
+				C25C1FA62F8261CD5DC2C644 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -186,6 +214,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				E8C503F5894DD3736AF5E718 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +233,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				A4C93D90E99893693B80703E /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				FBA70FF2A6E27408ECB5ED77 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -329,6 +360,67 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
+		A4C93D90E99893693B80703E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E8C503F5894DD3736AF5E718 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FBA70FF2A6E27408ECB5ED77 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -380,6 +472,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A2E102A2EAC2BF5831915418 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +487,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = ED3031CFEC488A1F79275A13 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +502,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F119323D017F1E1792C108C7 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -483,6 +578,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -615,6 +711,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -635,6 +732,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};

--- a/example/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/example/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/example/macos/Runner/DebugProfile.entitlements
+++ b/example/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+    <true/>
 </dict>
 </plist>

--- a/example/macos/Runner/Release.entitlements
+++ b/example/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+    <true/>
 </dict>
 </plist>

--- a/lib/designs/whatsapp/whatsapp_appbar.dart
+++ b/lib/designs/whatsapp/whatsapp_appbar.dart
@@ -106,6 +106,7 @@ class _WhatsAppAppBarState extends State<WhatsAppAppBar> {
                     tooltip: widget
                         .configs.i18n.stickerEditor.bottomNavigationBarText,
                     onPressed: widget.onTapStickerEditor,
+                    key: const ValueKey('whatsapp-open-sticker-editor-btn'),
                     icon: Icon(widget.configs.icons.stickerEditor.bottomNavBar),
                     style: whatsAppButtonStyle,
                   ),

--- a/lib/models/editor_configs/emoji_editor_configs.dart
+++ b/lib/models/editor_configs/emoji_editor_configs.dart
@@ -1,5 +1,4 @@
-import 'package:emoji_picker_flutter/emoji_picker_flutter.dart'
-    show CategoryEmoji, defaultEmojiSet;
+import '../../pro_image_editor.dart';
 
 export 'package:emoji_picker_flutter/emoji_picker_flutter.dart'
     show CategoryEmoji, defaultEmojiSet;
@@ -33,6 +32,13 @@ class EmojiEditorConfigs {
   /// Custom emojis; if set, overrides default emojis provided by the library.
   final List<CategoryEmoji> emojiSet;
 
+  /// Use this to build custom [BoxConstraints] that will be applied to
+  /// the modal bottom sheet displaying the [EmojiEditor].
+  ///
+  /// Otherwise, it falls back to
+  /// [ProImageEditorConfigs.editorBoxConstraintsBuilder].
+  final EditorBoxConstraintsBuilder? editorBoxConstraintsBuilder;
+
   /// Creates an instance of EmojiEditorConfigs with optional settings.
   ///
   /// By default, the editor is enabled, and other properties are set to
@@ -42,5 +48,6 @@ class EmojiEditorConfigs {
     this.initScale = 5.0,
     this.checkPlatformCompatibility = true,
     this.emojiSet = defaultEmojiSet,
+    this.editorBoxConstraintsBuilder,
   });
 }

--- a/lib/models/editor_configs/pro_image_editor_configs.dart
+++ b/lib/models/editor_configs/pro_image_editor_configs.dart
@@ -1,30 +1,39 @@
 import 'package:flutter/material.dart';
 import 'package:pro_image_editor/models/import_export/import_state_history.dart';
 
+import '../../utils/design_mode.dart';
 import '../custom_widgets.dart';
-import 'crop_rotate_editor_configs.dart';
-import 'emoji_editor_configs.dart';
-import 'filter_editor_configs.dart';
-import 'blur_editor_configs.dart';
-import 'layer_interaction_configs.dart';
-import 'paint_editor_configs.dart';
-import 'text_editor_configs.dart';
-import 'helper_lines_configs.dart';
-import 'sticker_editor_configs.dart';
 import '../i18n/i18n.dart';
 import '../icons/icons.dart';
 import '../theme/theme.dart';
-import '../../utils/design_mode.dart';
+import 'blur_editor_configs.dart';
+import 'crop_rotate_editor_configs.dart';
+import 'emoji_editor_configs.dart';
+import 'filter_editor_configs.dart';
+import 'helper_lines_configs.dart';
+import 'layer_interaction_configs.dart';
+import 'paint_editor_configs.dart';
+import 'sticker_editor_configs.dart';
+import 'text_editor_configs.dart';
 
-export 'helper_lines_configs.dart';
-export 'paint_editor_configs.dart';
-export 'text_editor_configs.dart';
-export 'crop_rotate_editor_configs.dart';
-export 'filter_editor_configs.dart';
-export 'emoji_editor_configs.dart';
-export 'sticker_editor_configs.dart';
 export 'blur_editor_configs.dart';
+export 'crop_rotate_editor_configs.dart';
+export 'emoji_editor_configs.dart';
+export 'filter_editor_configs.dart';
+export 'helper_lines_configs.dart';
 export 'layer_interaction_configs.dart';
+export 'paint_editor_configs.dart';
+export 'sticker_editor_configs.dart';
+export 'text_editor_configs.dart';
+
+///
+/// Creates custom [BoxConstraints] to use when displaying
+/// editors in modal bottom sheets.
+///
+typedef EditorBoxConstraintsBuilder = BoxConstraints? Function(
+  BuildContext context,
+  ProImageEditorConfigs configs,
+);
 
 /// A class representing configuration options for the Image Editor.
 class ProImageEditorConfigs {
@@ -82,6 +91,11 @@ class ProImageEditorConfigs {
   /// Holds the initial state history of the Image Editor.
   final ImportStateHistory? initStateHistory;
 
+  /// Use this to build custom [BoxConstraints] that will be applied
+  /// globally to the modal bottom sheet when opening various editors
+  /// from this library.
+  final EditorBoxConstraintsBuilder? editorBoxConstraintsBuilder;
+
   /// Creates an instance of [ProImageEditorConfigs].
   /// - The `theme` specifies the theme for the Image Editor.
   /// - The `heroTag` is a unique tag for the Image Editor widget. By default, it is 'Pro-Image-Editor-Hero'.
@@ -100,6 +114,7 @@ class ProImageEditorConfigs {
   /// - The `stickerEditorConfigs` configures the Sticker Editor. By default, it uses an empty `stickerEditorConfigs` instance.
   /// - The `designMode` specifies the design mode for the Image Editor. By default, it is `ImageEditorDesignMode.material`.
   /// - The `initStateHistory` holds the initial state history of the Image Editor.
+  /// - The `editorBoxConstraintsBuilder` configures global [BoxConstraints] to use when opening editors in modal bottom sheets.
   const ProImageEditorConfigs({
     this.theme,
     this.heroTag = 'Pro-Image-Editor-Hero',
@@ -119,5 +134,6 @@ class ProImageEditorConfigs {
     this.stickerEditorConfigs,
     this.designMode = ImageEditorDesignModeE.material,
     this.initStateHistory,
+    this.editorBoxConstraintsBuilder,
   });
 }

--- a/lib/models/editor_configs/sticker_editor_configs.dart
+++ b/lib/models/editor_configs/sticker_editor_configs.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/widgets.dart';
 
+import '../../pro_image_editor.dart';
+
 /// Configuration options for a sticker editor.
 ///
 /// `StickerEditorConfigs` allows you to define various settings for a sticker
@@ -42,6 +44,20 @@ class StickerEditorConfigs {
   /// This callback is activated exclusively when the editor mode is set to 'WhatsApp'.
   final Function(String value)? onSearchChanged;
 
+  /// Use this to build custom [BoxConstraints] that will be applied to
+  /// the modal bottom sheet displaying the [StickerEditor].
+  ///
+  /// Otherwise, it falls back to
+  /// [ProImageEditorConfigs.editorBoxConstraintsBuilder].
+  final EditorBoxConstraintsBuilder? editorBoxConstraintsBuilder;
+
+  /// Use this to build custom [BoxConstraints] that will be applied to
+  /// the modal bottom sheet displaying the [WhatsAppStickerPage].
+  ///
+  /// Otherwise, it falls back to either [editorBoxConstraintsBuilder] or
+  /// [ProImageEditorConfigs.editorBoxConstraintsBuilder] in that order.
+  final EditorBoxConstraintsBuilder? whatsAppEditorBoxConstraintsBuilder;
+
   /// Creates an instance of StickerEditorConfigs with optional settings.
   ///
   /// By default, the editor is disabled (if not specified), and other properties
@@ -51,6 +67,8 @@ class StickerEditorConfigs {
     this.onSearchChanged,
     this.initWidth = 100,
     this.enabled = false,
+    this.editorBoxConstraintsBuilder,
+    this.whatsAppEditorBoxConstraintsBuilder,
   });
 }
 

--- a/lib/modules/sticker_editor.dart
+++ b/lib/modules/sticker_editor.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
-import '../models/layer.dart';
 import '../mixins/converted_configs.dart';
 import '../mixins/editor_configs_mixin.dart';
+import '../models/layer.dart';
 
 /// The `StickerEditor` class is responsible for creating a widget that allows users to select emojis.
 ///

--- a/test/pro_image_editor_test.dart
+++ b/test/pro_image_editor_test.dart
@@ -2,13 +2,15 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_image_editor/models/editor_configs/pro_image_editor_configs.dart';
+import 'package:pro_image_editor/models/theme/theme.dart';
 import 'package:pro_image_editor/modules/crop_rotate_editor/crop_rotate_editor.dart';
 import 'package:pro_image_editor/modules/emoji_editor/emoji_editor.dart';
 import 'package:pro_image_editor/modules/filter_editor/filter_editor.dart';
-import 'package:pro_image_editor/modules/paint_editor/paint_editor.dart';
-
 import 'package:pro_image_editor/modules/main_editor/main_editor.dart';
+import 'package:pro_image_editor/modules/paint_editor/paint_editor.dart';
 import 'package:pro_image_editor/modules/text_editor/text_editor.dart';
+import 'package:pro_image_editor/utils/design_mode.dart';
 import 'package:pro_image_editor/widgets/layer_widget.dart';
 
 import 'fake/fake_image.dart';
@@ -107,6 +109,279 @@ void main() {
       await tester.pump(const Duration(seconds: 1)); // Wait for it to finish
 
       expect(find.byType(EmojiEditor), findsOneWidget);
+    });
+
+    group("When applying constraints to the opened bottom sheet", () {
+      const widgetKey = ValueKey("example-widget");
+      const expectedConstraints = BoxConstraints(
+        maxWidth: 720,
+      );
+
+      testWidgets('ProImageEditor opens StickerEditor with constraints',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: ProImageEditor.memory(
+              fakeMemoryImage,
+              onImageEditingComplete: (Uint8List bytes) async {},
+              configs: ProImageEditorConfigs(
+                emojiEditorConfigs: const EmojiEditorConfigs(
+                  enabled: false,
+                ),
+                stickerEditorConfigs: StickerEditorConfigs(
+                  enabled: true,
+                  buildStickers: (setLayer) => Container(
+                    key: widgetKey,
+                  ),
+                  editorBoxConstraintsBuilder: (context, configs) =>
+                      expectedConstraints,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final openBtn = find.byKey(const ValueKey('open-sticker-editor-btn'));
+        expect(openBtn, findsOneWidget);
+        await tester.tap(openBtn);
+
+        // Wait for the modal bottom sheet animation to complete
+        await tester.pump(); // Start the animation
+        await tester.pump(const Duration(seconds: 1)); // Wait for it to finish
+
+        expect(find.byKey(widgetKey), findsOneWidget);
+        expect(
+          tester.getRect(find.byKey(widgetKey)).width,
+          expectedConstraints.maxWidth,
+        );
+      });
+
+      testWidgets('ProImageEditor opens StickerEditor with global constraints',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: ProImageEditor.memory(
+              fakeMemoryImage,
+              onImageEditingComplete: (Uint8List bytes) async {},
+              configs: ProImageEditorConfigs(
+                editorBoxConstraintsBuilder: (context, configs) =>
+                    expectedConstraints,
+                emojiEditorConfigs: const EmojiEditorConfigs(
+                  enabled: false,
+                ),
+                stickerEditorConfigs: StickerEditorConfigs(
+                  enabled: true,
+                  buildStickers: (setLayer) => Container(
+                    key: widgetKey,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final openBtn = find.byKey(const ValueKey('open-sticker-editor-btn'));
+        expect(openBtn, findsOneWidget);
+        await tester.tap(openBtn);
+
+        // Wait for the modal bottom sheet animation to complete
+        await tester.pump(); // Start the animation
+        await tester.pump(const Duration(seconds: 1)); // Wait for it to finish
+
+        expect(find.byKey(widgetKey), findsOneWidget);
+        expect(
+          tester.getRect(find.byKey(widgetKey)).width,
+          expectedConstraints.maxWidth,
+        );
+      });
+
+      group("When opening the WhatsApp StickerEditor", () {
+        late ImageEditorTheme imageEditorTheme;
+
+        setUp(() {
+          imageEditorTheme = const ImageEditorTheme(
+            editorMode: ThemeEditorMode.whatsapp,
+          );
+        });
+
+        testWidgets(
+            'ProImageEditor opens StickerEditor with WhatsApp specific constraints',
+            (WidgetTester tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: ProImageEditor.memory(
+                fakeMemoryImage,
+                onImageEditingComplete: (Uint8List bytes) async {},
+                configs: ProImageEditorConfigs(
+                  designMode: ImageEditorDesignModeE.cupertino,
+                  imageEditorTheme: imageEditorTheme,
+                  emojiEditorConfigs: const EmojiEditorConfigs(
+                    enabled: false,
+                  ),
+                  stickerEditorConfigs: StickerEditorConfigs(
+                    enabled: true,
+                    buildStickers: (setLayer) => Container(
+                      key: widgetKey,
+                    ),
+                    whatsAppEditorBoxConstraintsBuilder: (context, configs) =>
+                        expectedConstraints,
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          final openBtn =
+              find.byKey(const ValueKey('whatsapp-open-sticker-editor-btn'));
+          expect(openBtn, findsOneWidget);
+          await tester.tap(openBtn);
+
+          // Wait for the modal bottom sheet animation to complete
+          await tester.pump(); // Start the animation
+          await tester
+              .pump(const Duration(seconds: 1)); // Wait for it to finish
+
+          expect(find.byKey(widgetKey), findsOneWidget);
+          final actualRect = tester.getRect(find.byKey(widgetKey));
+          expect(actualRect.width, expectedConstraints.maxWidth);
+        });
+
+        testWidgets('ProImageEditor opens StickerEditor with constraints',
+            (WidgetTester tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: ProImageEditor.memory(
+                fakeMemoryImage,
+                onImageEditingComplete: (Uint8List bytes) async {},
+                configs: ProImageEditorConfigs(
+                  imageEditorTheme: imageEditorTheme,
+                  designMode: ImageEditorDesignModeE.cupertino,
+                  emojiEditorConfigs: const EmojiEditorConfigs(
+                    enabled: false,
+                  ),
+                  stickerEditorConfigs: StickerEditorConfigs(
+                    buildStickers: (setLayer) => Container(
+                      key: widgetKey,
+                    ),
+                    editorBoxConstraintsBuilder: (context, configs) =>
+                        expectedConstraints,
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          final openBtn =
+              find.byKey(const ValueKey('whatsapp-open-sticker-editor-btn'));
+          expect(openBtn, findsOneWidget);
+          await tester.tap(openBtn);
+
+          // Wait for the modal bottom sheet animation to complete
+          await tester.pump(); // Start the animation
+          await tester
+              .pump(const Duration(seconds: 1)); // Wait for it to finish
+
+          final actualRect = tester.getRect(find.byKey(widgetKey));
+          expect(actualRect.width, expectedConstraints.maxWidth);
+        });
+
+        testWidgets(
+            'ProImageEditor opens StickerEditor with global constraints',
+            (WidgetTester tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: ProImageEditor.memory(
+                fakeMemoryImage,
+                onImageEditingComplete: (Uint8List bytes) async {},
+                configs: ProImageEditorConfigs(
+                  imageEditorTheme: imageEditorTheme,
+                  designMode: ImageEditorDesignModeE.cupertino,
+                  editorBoxConstraintsBuilder: (context, configs) =>
+                      expectedConstraints,
+                  emojiEditorConfigs: const EmojiEditorConfigs(
+                    enabled: false,
+                  ),
+                  stickerEditorConfigs: StickerEditorConfigs(
+                    enabled: true,
+                    buildStickers: (setLayer) => Container(
+                      key: widgetKey,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          final openBtn =
+              find.byKey(const ValueKey('whatsapp-open-sticker-editor-btn'));
+          expect(openBtn, findsOneWidget);
+          await tester.tap(openBtn);
+
+          // Wait for the modal bottom sheet animation to complete
+          await tester.pump(); // Start the animation
+          await tester
+              .pump(const Duration(seconds: 1)); // Wait for it to finish
+
+          final actualRect = tester.getRect(find.byKey(widgetKey));
+          expect(actualRect.width, expectedConstraints.maxWidth);
+        });
+      });
+
+      testWidgets('ProImageEditor opens EmojiEditor with constraints',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+            home: ProImageEditor.memory(
+          fakeMemoryImage,
+          configs: ProImageEditorConfigs(
+            emojiEditorConfigs: EmojiEditorConfigs(
+              editorBoxConstraintsBuilder: (context, configs) =>
+                  expectedConstraints,
+            ),
+          ),
+          onImageEditingComplete: (Uint8List bytes) async {},
+        )));
+
+        final openBtn = find.byKey(const ValueKey('open-emoji-editor-btn'));
+        expect(openBtn, findsOneWidget);
+        await tester.tap(openBtn);
+
+        // Wait for the modal bottom sheet animation to complete
+        await tester.pump(); // Start the animation
+        await tester.pump(const Duration(seconds: 1)); // Wait for it to finish
+
+        expect(find.byType(EmojiEditor), findsOneWidget);
+        expect(
+          tester.getRect(find.byType(EmojiEditor)).width,
+          expectedConstraints.maxWidth,
+        );
+      });
+
+      testWidgets('ProImageEditor opens EmojiEditor with global constraints',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+            home: ProImageEditor.memory(
+          fakeMemoryImage,
+          configs: ProImageEditorConfigs(
+            editorBoxConstraintsBuilder: (context, configs) =>
+                expectedConstraints,
+          ),
+          onImageEditingComplete: (Uint8List bytes) async {},
+        )));
+
+        final openBtn = find.byKey(const ValueKey('open-emoji-editor-btn'));
+        expect(openBtn, findsOneWidget);
+        await tester.tap(openBtn);
+
+        // Wait for the modal bottom sheet animation to complete
+        await tester.pump(); // Start the animation
+        await tester.pump(const Duration(seconds: 1)); // Wait for it to finish
+
+        expect(find.byType(EmojiEditor), findsOneWidget);
+        expect(
+          tester.getRect(find.byType(EmojiEditor)).width,
+          expectedConstraints.maxWidth,
+        );
+      });
     });
   });
 


### PR DESCRIPTION
Short of injecting a custom `MaterialTheme` with a custom `BottomSheetThemeData`, this adds a convenient way to add `BoxConstraints` when displaying the Sticker, WhatsApp Sticker, and Emoji Editors.

Also cleaned up the macOS example app so that one can use it to evaluate this library.