### PR TITLE
Add currently selected color to color custom widgets

### DIFF
--- a/lib/models/custom_widgets.dart
+++ b/lib/models/custom_widgets.dart
@@ -207,11 +207,13 @@ typedef CropEditorAspectRatioOptions = Widget Function(
 
 /// A function type that defines a custom color picker widget.
 ///
-/// The function takes one parameter:
+/// The function takes two parameters:
+/// - `currentColor`: The currently selected [Color].
 /// - `color`: A function that will be called with the selected [Color].
 ///
 /// Returns a [Widget] that allows the user to pick a color.
-typedef CustomColorPicker = Widget Function(Function(Color color) setColor);
+typedef CustomColorPicker = Widget Function(
+    Color currentColor, void Function(Color color) setColor);
 
 /// A function type that defines a custom slider widget.
 ///

--- a/lib/modules/paint_editor/paint_editor.dart
+++ b/lib/modules/paint_editor/paint_editor.dart
@@ -953,7 +953,8 @@ class PaintingEditorState extends State<PaintingEditor>
       child: StreamBuilder(
           stream: _uiPickerStream.stream,
           builder: (context, snapshot) {
-            return customWidgets.colorPickerPaintEditor?.call(_colorChanged) ??
+            return customWidgets.colorPickerPaintEditor
+                    ?.call(_paintCtrl.color, _colorChanged) ??
                 BarColorPicker(
                   configs: configs,
                   length: min(

--- a/lib/modules/text_editor/text_editor.dart
+++ b/lib/modules/text_editor/text_editor.dart
@@ -463,32 +463,33 @@ class TextEditorState extends State<TextEditor>
                 padding: EdgeInsets.symmetric(
                   vertical: barPickerPadding,
                 ),
-                child:
-                    customWidgets.colorPickerTextEditor?.call(_colorChanged) ??
-                        BarColorPicker(
-                          configs: widget.configs,
-                          length: min(
-                            isWhatsAppDesign ? 200 : 350,
-                            MediaQuery.of(context).size.height -
-                                MediaQuery.of(context).viewInsets.bottom -
-                                kToolbarHeight -
-                                kBottomNavigationBarHeight -
-                                barPickerPadding * 2 -
-                                MediaQuery.of(context).padding.top,
-                          ),
-                          onPositionChange: (value) {
-                            _colorPosition = value;
-                          },
-                          initPosition: _colorPosition,
-                          initialColor: _primaryColor,
-                          horizontal: false,
-                          thumbColor: Colors.white,
-                          cornerRadius: 10,
-                          pickMode: PickMode.color,
-                          colorListener: (int value) {
-                            _colorChanged(Color(value));
-                          },
-                        ),
+                child: customWidgets.colorPickerTextEditor?.call(
+                        selectedTextStyle.color ?? _primaryColor,
+                        _colorChanged) ??
+                    BarColorPicker(
+                      configs: widget.configs,
+                      length: min(
+                        isWhatsAppDesign ? 200 : 350,
+                        MediaQuery.of(context).size.height -
+                            MediaQuery.of(context).viewInsets.bottom -
+                            kToolbarHeight -
+                            kBottomNavigationBarHeight -
+                            barPickerPadding * 2 -
+                            MediaQuery.of(context).padding.top,
+                      ),
+                      onPositionChange: (value) {
+                        _colorPosition = value;
+                      },
+                      initPosition: _colorPosition,
+                      initialColor: _primaryColor,
+                      horizontal: false,
+                      thumbColor: Colors.white,
+                      cornerRadius: 10,
+                      pickMode: PickMode.color,
+                      colorListener: (int value) {
+                        _colorChanged(Color(value));
+                      },
+                    ),
               ),
             ),
           customWidgets.bottomBarTextEditor ??


### PR DESCRIPTION
Expanding on issue #70 and commit [#83e0d](https://github.com/hm21/pro_image_editor/commit/83e0d7708365d145878c558e25a944d40bd3de45).



Pass through the currently selected color so the custom color widgets can be built with the existing color already selected.

Maybe this was possible before but I couldn't find a way, but I think it's cleaner to pass through the color to the widget being built directly either way :)