### PR TITLE
Take into account SafeArea padding when detecting hovered remove button

### DIFF
--- a/lib/modules/main_editor/utils/layer_interaction_manager.dart
+++ b/lib/modules/main_editor/utils/layer_interaction_manager.dart
@@ -183,9 +183,10 @@ class LayerInteractionManager {
       activeLayer.offset.dy + detail.focalPointDelta.dy,
     );
 
-    bool hoveredRemoveBtn = detail.focalPoint.dx <= kToolbarHeight &&
+    bool hoveredRemoveBtn = detail.focalPoint.dx <=
+            kToolbarHeight + MediaQuery.of(context).padding.left &&
         detail.focalPoint.dy <=
-            kToolbarHeight + MediaQuery.of(context).viewPadding.top;
+            kToolbarHeight + MediaQuery.of(context).padding.top;
     if (hoverRemoveBtn != hoveredRemoveBtn) {
       hoverRemoveBtn = hoveredRemoveBtn;
       onHoveredRemoveBtn.call(hoverRemoveBtn);


### PR DESCRIPTION
When a device is in landscape, the SafeArea padding may be on the left hand side (instead of the top). This takes into account the left SafeArea padding when detecting the hovered remove button.

Also note, that for the top padding, I changed it from `.viewPadding.top;` to `.padding.top`. According to Gemini this is the correct value to use. I tested and it worked fine but please test as well.

 - `viewPadding.top` represents the padding above the system's top bar (status bar).
 - `padding.top` represents the padding above the safe area, which takes into account the status bar, notches, and any other obstructions.
 - This is important for accounting for things like the iPhone's notch, which may be obscuring the top area of the screen even when the app is not in full-screen mode.
