### PR TITLE
Right overflow on small size phone

### DIFF
--- a/lib/modules/paint_editor/paint_editor.dart
+++ b/lib/modules/paint_editor/paint_editor.dart
@@ -7,7 +7,6 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
 // Project imports:
 import 'package:pro_image_editor/mixins/converted_callbacks.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
@@ -16,8 +15,7 @@ import 'package:pro_image_editor/utils/content_recorder.dart/utils/record_invisi
 import 'package:pro_image_editor/widgets/auto_image.dart';
 import 'package:pro_image_editor/widgets/extended/extended_interactive_viewer.dart';
 import 'package:pro_image_editor/widgets/layer_stack.dart';
-import '../../utils/transparent_image_bytes.dart';
-import '../filter_editor/widgets/filtered_image.dart';
+
 import '/mixins/converted_configs.dart';
 import '/mixins/standalone_editor.dart';
 import '/models/crop_rotate_editor/transform_factors.dart';
@@ -27,13 +25,15 @@ import '/utils/theme_functions.dart';
 import '/widgets/bottom_sheets_header_row.dart';
 import '/widgets/platform_popup_menu.dart';
 import '/widgets/transform/transformed_content_generator.dart';
+import '../../utils/transparent_image_bytes.dart';
+import '../filter_editor/widgets/filtered_image.dart';
 import 'utils/paint_controller.dart';
 import 'utils/paint_desktop_interaction_manager.dart';
 import 'widgets/painting_canvas.dart';
 
+export '/models/paint_editor/paint_bottom_bar_item.dart';
 export './utils/paint_editor_enum.dart';
 export './widgets/draw_painting.dart';
-export '/models/paint_editor/paint_bottom_bar_item.dart';
 
 /// The `PaintingEditor` widget allows users to editing images with painting
 /// tools.
@@ -711,10 +711,9 @@ class PaintingEditorState extends State<PaintingEditor>
           icon: Icon(icons.backButton),
           onPressed: close,
         ),
+        const Spacer(),
         ...[
           if (constraints.maxWidth >= 300) ...[
-            if (constraints.maxWidth >= 380) const SizedBox(width: 80),
-            const Spacer(),
             if (paintEditorConfigs.canChangeLineWidth)
               StreamBuilder(
                   stream: _uiAppbarIconsStream.stream,
@@ -759,7 +758,7 @@ class PaintingEditorState extends State<PaintingEditor>
                       onPressed: openOpacityBottomSheet,
                     );
                   }),
-            if (constraints.maxWidth >= 380) const Spacer(),
+            if (constraints.maxWidth >= 720) const Spacer(),
             StreamBuilder(
                 stream: _uiAppbarIconsStream.stream,
                 builder: (context, snapshot) {

--- a/lib/modules/paint_editor/paint_editor.dart
+++ b/lib/modules/paint_editor/paint_editor.dart
@@ -758,7 +758,7 @@ class PaintingEditorState extends State<PaintingEditor>
                       onPressed: openOpacityBottomSheet,
                     );
                   }),
-            if (constraints.maxWidth >= 720) const Spacer(),
+            if (constraints.maxWidth >= 640) const Spacer(),
             StreamBuilder(
                 stream: _uiAppbarIconsStream.stream,
                 builder: (context, snapshot) {

--- a/lib/modules/paint_editor/paint_editor.dart
+++ b/lib/modules/paint_editor/paint_editor.dart
@@ -789,7 +789,6 @@ class PaintingEditorState extends State<PaintingEditor>
                 }),
             _buildDoneBtn(),
           ] else ...[
-            const Spacer(),
             _buildDoneBtn(),
             PlatformPopupBtn(
               designMode: designMode,

--- a/lib/modules/text_editor/text_editor.dart
+++ b/lib/modules/text_editor/text_editor.dart
@@ -4,12 +4,12 @@ import 'dart:math';
 
 // Flutter imports:
 import 'package:flutter/material.dart';
-import 'package:pro_image_editor/plugins/rounded_background_text/src/rounded_background_text_field.dart';
-
 // Project imports:
 import 'package:pro_image_editor/mixins/converted_callbacks.dart';
 import 'package:pro_image_editor/mixins/converted_configs.dart';
+import 'package:pro_image_editor/plugins/rounded_background_text/src/rounded_background_text_field.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+
 import '../../mixins/editor_configs_mixin.dart';
 import '../../utils/theme_functions.dart';
 import '../../widgets/bottom_sheets_header_row.dart';
@@ -389,6 +389,13 @@ class TextEditorState extends State<TextEditor>
       return customWidgets.textEditor.appBar!
           .call(this, _rebuildController.stream);
     }
+
+    const int defaultIconButtonSize = 48;
+    final List<IconButton> configButtons = _getConfigButtons();
+
+    // Taking into account the back and done button
+    final iconButtonsSize = (2 + configButtons.length) * defaultIconButtonSize;
+
     return AppBar(
       automaticallyImplyLeading: false,
       backgroundColor: imageEditorTheme.textEditor.appBarBackgroundColor,
@@ -401,36 +408,11 @@ class TextEditorState extends State<TextEditor>
           onPressed: close,
         ),
         const Spacer(),
-        if (constraints.maxWidth >= 300) ...[
-          if (textEditorConfigs.canToggleTextAlign)
-            IconButton(
-              key: const ValueKey('TextAlignIconButton'),
-              tooltip: i18n.textEditor.textAlign,
-              onPressed: toggleTextAlign,
-              icon: Icon(align == TextAlign.left
-                  ? icons.textEditor.alignLeft
-                  : align == TextAlign.right
-                      ? icons.textEditor.alignRight
-                      : icons.textEditor.alignCenter),
-            ),
-          if (textEditorConfigs.canChangeFontScale)
-            IconButton(
-              key: const ValueKey('BackgroundModeFontScaleButton'),
-              tooltip: i18n.textEditor.fontScale,
-              onPressed: openFontScaleBottomSheet,
-              icon: Icon(icons.textEditor.fontScale),
-            ),
-          if (textEditorConfigs.canToggleBackgroundMode)
-            IconButton(
-              key: const ValueKey('BackgroundModeColorIconButton'),
-              tooltip: i18n.textEditor.backgroundMode,
-              onPressed: toggleBackgroundMode,
-              icon: Icon(icons.textEditor.backgroundMode),
-            ),
+        if (constraints.maxWidth >= iconButtonsSize) ...[
+          ...configButtons,
           const Spacer(),
           _buildDoneBtn(),
         ] else ...[
-          const Spacer(),
           _buildDoneBtn(),
           PlatformPopupBtn(
             designMode: designMode,
@@ -527,6 +509,34 @@ class TextEditorState extends State<TextEditor>
       ),
     );
   }
+
+  List<IconButton> _getConfigButtons() => [
+        if (textEditorConfigs.canToggleTextAlign)
+          IconButton(
+            key: const ValueKey('TextAlignIconButton'),
+            tooltip: i18n.textEditor.textAlign,
+            onPressed: toggleTextAlign,
+            icon: Icon(align == TextAlign.left
+                ? icons.textEditor.alignLeft
+                : align == TextAlign.right
+                    ? icons.textEditor.alignRight
+                    : icons.textEditor.alignCenter),
+          ),
+        if (textEditorConfigs.canChangeFontScale)
+          IconButton(
+            key: const ValueKey('BackgroundModeFontScaleButton'),
+            tooltip: i18n.textEditor.fontScale,
+            onPressed: openFontScaleBottomSheet,
+            icon: Icon(icons.textEditor.fontScale),
+          ),
+        if (textEditorConfigs.canToggleBackgroundMode)
+          IconButton(
+            key: const ValueKey('BackgroundModeColorIconButton'),
+            tooltip: i18n.textEditor.backgroundMode,
+            onPressed: toggleBackgroundMode,
+            icon: Icon(icons.textEditor.backgroundMode),
+          ),
+      ];
 
   /// Builds and returns an IconButton for applying changes.
   Widget _buildDoneBtn() {


### PR DESCRIPTION
I feel I'm not completely respecting your coding style so feel free to modify the code if you think it is needed.

On small size phone the condition constraints.maxWidth >= 300 wasn't true.
An iconButton size is about 48px by default.

I've chosen here to split the code into methods and to get actions into variables to calculate the iconButtonsSizes and so to reduce the charge of maintainability (feel free to change it if you do not like - 7 icons * 48px  -> 336px).

The painting app bar has now 3 states :
- Full action bar (all icons)
- Partial action bar (back - undo - redo - validate - more options)
- Shrunk action bar (back - validate - more options) 

Depending on the available space.

In the PopupMenuOption was missing the changement of opacity.

_I also might have failed my sync fork (sorry for that I don't have time rn to take a look at it)_