### PR TITLE
feat: improve default app bar layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.1.2
+- **STYLE(AppBar)**: moved close action to AppBar's leading parameter for improved layout consistency.
+- **STYLE(AppBar)**: updated IconButtons to use default 8-point all-around padding, enhancing visual balance.
+- **STYLE(AppBar)**: adjusted loading indicator padding to a multiple of 2 to align with design system standards.
+
 ## 6.1.1
 - **FIX**(CustomWidgets): resolve issue preventing user from using custom widget `removeLayerArea`.
 

--- a/lib/modules/main_editor/main_editor.dart
+++ b/lib/modules/main_editor/main_editor.dart
@@ -2009,21 +2009,17 @@ class ProImageEditorState extends State<ProImageEditor>
             configs.layerInteraction.hideToolbarOnInteraction
         ? null
         : AppBar(
-            automaticallyImplyLeading: false,
             foregroundColor: imageEditorTheme.appBarForegroundColor,
             backgroundColor: imageEditorTheme.appBarBackgroundColor,
+            leading: IconButton(
+              tooltip: i18n.cancel,
+              icon: Icon(icons.closeEditor),
+              onPressed: closeEditor,
+            ),
             actions: [
-              IconButton(
-                tooltip: i18n.cancel,
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                icon: Icon(icons.closeEditor),
-                onPressed: closeEditor,
-              ),
-              const Spacer(),
               IconButton(
                 key: const ValueKey('MainEditorUndoButton'),
                 tooltip: i18n.undo,
-                padding: const EdgeInsets.symmetric(horizontal: 8),
                 icon: Icon(
                   icons.undoAction,
                   color: stateManager.position > 0
@@ -2035,7 +2031,6 @@ class ProImageEditorState extends State<ProImageEditor>
               IconButton(
                 key: const ValueKey('MainEditorRedoButton'),
                 tooltip: i18n.redo,
-                padding: const EdgeInsets.symmetric(horizontal: 8),
                 icon: Icon(
                   icons.redoAction,
                   color: stateManager.position < stateHistory.length - 1
@@ -2046,7 +2041,7 @@ class ProImageEditorState extends State<ProImageEditor>
               ),
               !_initialized
                   ? Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 11.0),
+                      padding: const EdgeInsets.symmetric(horizontal: 12.0),
                       child: SizedBox.square(
                         dimension: 22,
                         child:
@@ -2056,7 +2051,6 @@ class ProImageEditorState extends State<ProImageEditor>
                   : IconButton(
                       key: const ValueKey('MainEditorDoneButton'),
                       tooltip: i18n.done,
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
                       icon: Icon(icons.doneIcon),
                       iconSize: 28,
                       onPressed: doneEditing,

--- a/lib/modules/main_editor/main_editor.dart
+++ b/lib/modules/main_editor/main_editor.dart
@@ -2041,9 +2041,9 @@ class ProImageEditorState extends State<ProImageEditor>
               ),
               !_initialized
                   ? Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+                      padding: const EdgeInsets.symmetric(horizontal: 10.0),
                       child: SizedBox.square(
-                        dimension: 22,
+                        dimension: 24,
                         child:
                             PlatformCircularProgressIndicator(configs: configs),
                       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 6.1.1
+version: 6.1.2
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 issue_tracker: https://github.com/hm21/pro_image_editor/issues/


### PR DESCRIPTION
Hello,

This PR aims to slightly improve the default app bar's layout. Specifically, its actions.

I moved the close action to the AppBar's `leading` parameter.
I removed the padding from the IconButtons, since the default one provides a more rounded padding (instead of just horizontal padding, we have all around 8 points)
I changed the padding of the loading indicator to be a multiple of 2, since most design systems work with even numbers.