### PR TITLE
Adjust layer scale and offset using screen size instead

### DIFF
--- a/lib/models/import_export/export_state_history.dart
+++ b/lib/models/import_export/export_state_history.dart
@@ -27,6 +27,7 @@ class ExportStateHistory {
     required this.stateHistory,
     required this.imageInfos,
     required this.imgSize,
+    required this.lastScreenSize,
     required this.editorPosition,
     required this.contentRecorderCtrl,
     required this.context,
@@ -45,6 +46,12 @@ class ExportStateHistory {
   /// This [Size] object specifies the dimensions of the image being edited,
   /// providing a reference for transformations and layout adjustments.
   final Size imgSize;
+
+  /// The size of the screen the last time the editor was used.
+  /// 
+  /// This [Size] object specifies the dimensions of the screen the last time
+  /// the editor was used, providing a reference for transformations and layout
+  final Size lastScreenSize;
 
   /// The list of editor state history entries.
   ///
@@ -147,6 +154,10 @@ class ExportStateHistory {
       'imgSize': {
         'width': imageInfos.rawSize.width,
         'height': imageInfos.rawSize.height,
+      },
+      'lastScreenSize': {
+        'width': lastScreenSize.width,
+        'height': lastScreenSize.height,
       },
     };
   }

--- a/lib/models/import_export/import_state_history.dart
+++ b/lib/models/import_export/import_state_history.dart
@@ -31,6 +31,7 @@ class ImportStateHistory {
   ImportStateHistory._({
     required this.editorPosition,
     required this.imgSize,
+    required this.lastScreenSize,
     required this.stateHistory,
     required this.configs,
     required this.version,
@@ -116,6 +117,10 @@ class ImportStateHistory {
       editorPosition: map['position'],
       imgSize:
           Size(map['imgSize']?['width'] ?? 0, map['imgSize']?['height'] ?? 0),
+      lastScreenSize: map['lastScreenSize'] != null
+          ? Size(map['lastScreenSize']?['width'] ?? 0,
+              map['lastScreenSize']?['height'] ?? 0)
+          : Size(map['imgSize']?['width'] ?? 0, map['imgSize']?['height'] ?? 0),
       stateHistory: stateHistory,
       configs: configs,
       version: version,
@@ -135,6 +140,9 @@ class ImportStateHistory {
 
   /// The size of the imported image.
   final Size imgSize;
+
+  /// The size of the last used screen.
+  final Size lastScreenSize;
 
   /// The state history of each editor state in the session.
   final List<EditorStateHistory> stateHistory;

--- a/lib/models/import_export/import_state_history.dart
+++ b/lib/models/import_export/import_state_history.dart
@@ -120,7 +120,7 @@ class ImportStateHistory {
       lastScreenSize: map['lastScreenSize'] != null
           ? Size(map['lastScreenSize']?['width'] ?? 0,
               map['lastScreenSize']?['height'] ?? 0)
-          : Size(map['imgSize']?['width'] ?? 0, map['imgSize']?['height'] ?? 0),
+          : Size.zero,
       stateHistory: stateHistory,
       configs: configs,
       version: version,

--- a/lib/modules/main_editor/main_editor.dart
+++ b/lib/modules/main_editor/main_editor.dart
@@ -1816,15 +1816,16 @@ class ProImageEditorState extends State<ProImageEditor>
     /// Recalculate position and size
     if (import.configs.recalculateSizeAndPosition ||
         import.version == ExportImportVersion.version_1_0_0) {
-      Size imgSize = import.imgSize / (_imageInfos?.pixelRatio ?? 1);
       for (EditorStateHistory el in import.stateHistory) {
         for (Layer layer in el.layers) {
           if (import.configs.recalculateSizeAndPosition) {
             // Calculate scaling factors for width and height
             double scaleWidth =
-                sizesManager.decodedImageSize.width / imgSize.width;
+                sizesManager.lastScreenSize.width /
+                  import.lastScreenSize.width;
             double scaleHeight =
-                sizesManager.decodedImageSize.height / imgSize.height;
+                sizesManager.lastScreenSize.height /
+                  import.lastScreenSize.height;
 
             if (scaleWidth == 0 || scaleWidth.isInfinite) scaleWidth = 1;
             if (scaleHeight == 0 || scaleHeight.isInfinite) scaleHeight = 1;
@@ -1924,6 +1925,7 @@ class ProImageEditorState extends State<ProImageEditor>
       stateHistory: stateManager.stateHistory,
       imageInfos: _imageInfos!,
       imgSize: sizesManager.decodedImageSize,
+      lastScreenSize: sizesManager.lastScreenSize,
       editorPosition: stateManager.position,
       configs: configs,
       contentRecorderCtrl: _controllers.screenshot,


### PR DESCRIPTION
Hello,

I am honestly not sure if this is the right approach, as I am a bit new around here. But, this solves a problem where editing image states across different screen size/devices would not properly adjust layer scale and position.

This also alters the data structure of import of export, so checking whether the default values are sane is also appreciated. So far I have used a Size.zero absence of this field in previous JSON files for retro-compatibility. The recalculate function takes care of this case so it works fine (in my testing) with older versions.

**However:** The proper calculation will only work in newly exported images, since we didn't have the original aspect ratio of the image state in the past.

**Note 2:** It is not 100% accurate, but it does a much better job imho. Not sure if any calculations could be better done?

### Before (problem)
![image](https://github.com/user-attachments/assets/f94dca3b-ada3-491a-8908-e86bd2346d3d)
![image](https://github.com/user-attachments/assets/1e913dbe-0203-417a-b0dc-e1bec323f484)

### After (solution)
![image](https://github.com/user-attachments/assets/314563d9-86fb-4c18-a0a0-f2333902397e)
![image](https://github.com/user-attachments/assets/9a2633c3-8d1f-46a8-bf54-199979d14c0a)
