### PR TITLE
fix: Recalculate layer scaling using last rendered size scale factors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 6.1.5
+- **FIX**(import): Fixed an issue where imported layers didn't scale correctly on different screen sizes. This resolves issue [#272](https://github.com/hm21/pro_image_editor/issues/272)
+
 ## 6.1.4
-- **FIX**(zoom): Fixed an issue where the minimum zoom level setting had no effect, ensuring proper enforcement of zoom boundaries in the viewer. This resolves issue [#260](https://github.com/hm21/pro_image_editor/issues/266)
+- **FIX**(zoom): Fixed an issue where the minimum zoom level setting had no effect, ensuring proper enforcement of zoom boundaries in the viewer. This resolves issue [#266](https://github.com/hm21/pro_image_editor/issues/266)
 
 ## 6.1.3
 - **FIX**(keyboard): resolve issue that escape key throw an error when the context menu is open. This resolves issue [#260](https://github.com/hm21/pro_image_editor/issues/260)

--- a/example/lib/utils/import_history_demo_data.dart
+++ b/example/lib/utils/import_history_demo_data.dart
@@ -583,5 +583,6 @@ Map<String, dynamic> importHistoryDemoData = {
       'blur': 0.0
     }
   ],
-  'imgSize': {'width': 1024.0, 'height': 1792.0}
+  'imgSize': {'width': 1024.0, 'height': 1792.0},
+  'lastRenderedImgSize': {'width': 1024.0, 'height': 1792.0}
 };

--- a/example/lib/utils/import_history_demo_data.dart
+++ b/example/lib/utils/import_history_demo_data.dart
@@ -1,6 +1,6 @@
 /// A map representing the demo data for file import history.
 Map<String, dynamic> importHistoryDemoData = {
-  'version': '3.0.0',
+  'version': '3.0.1',
   'position': 6,
   'history': [
     {

--- a/lib/models/import_export/export_state_history.dart
+++ b/lib/models/import_export/export_state_history.dart
@@ -148,6 +148,10 @@ class ExportStateHistory {
         'width': imageInfos.rawSize.width,
         'height': imageInfos.rawSize.height,
       },
+      'lastRenderedImgSize': {
+        'width': imageInfos.renderedSize.width,
+        'height': imageInfos.renderedSize.height,
+      },
     };
   }
 

--- a/lib/models/import_export/export_state_history.dart
+++ b/lib/models/import_export/export_state_history.dart
@@ -137,7 +137,7 @@ class ExportStateHistory {
     }
 
     return {
-      'version': ExportImportVersion.version_3_0_0,
+      'version': ExportImportVersion.version_3_0_1,
       'position': _configs.historySpan == ExportHistorySpan.current ||
               _configs.historySpan == ExportHistorySpan.currentAndForward
           ? 0

--- a/lib/models/import_export/import_state_history.dart
+++ b/lib/models/import_export/import_state_history.dart
@@ -12,6 +12,9 @@ import 'package:pro_image_editor/models/crop_rotate_editor/transform_factors.dar
 import 'package:pro_image_editor/models/import_export/import_state_history_configs.dart';
 import 'package:pro_image_editor/models/layer/layer.dart';
 import 'package:pro_image_editor/modules/filter_editor/utils/filter_generator/filter_addons.dart';
+import 'package:pro_image_editor/utils/parser/double_parser.dart';
+import 'package:pro_image_editor/utils/parser/int_parser.dart';
+import 'package:pro_image_editor/utils/parser/size_parser.dart';
 import '../history/state_history.dart';
 import '../tune_editor/tune_adjustment_matrix.dart';
 import 'utils/export_import_version.dart';
@@ -42,85 +45,52 @@ class ImportStateHistory {
     Map<String, dynamic> map, {
     ImportEditorConfigs configs = const ImportEditorConfigs(),
   }) {
-    List<EditorStateHistory> stateHistory = [];
-    List<Uint8List> stickers = [];
+    /// Initialize default values
+    final version =
+        map['version'] as String? ?? ExportImportVersion.version_1_0_0;
+    final stateHistory = <EditorStateHistory>[];
+    final stickers = (map['stickers'] as List<dynamic>? ?? [])
+        .map((sticker) => Uint8List.fromList(List.from(sticker)))
+        .toList();
+    final lastRenderedImgSize = safeParseSize(map['lastRenderedImgSize']);
 
-    String version =
-        (map['version'] as String?) ?? ExportImportVersion.version_1_0_0;
+    /// Parse history
+    for (final historyItem in (map['history'] as List<dynamic>? ?? [])) {
+      /// Layers
+      final layers = (historyItem['layers'] as List<dynamic>? ?? [])
+          .map((layer) => Layer.fromMap(layer, stickers))
+          .toList();
 
-    for (var sticker in List.from(map['stickers'] ?? [])) {
-      stickers.add(Uint8List.fromList(List.from(sticker)));
-    }
+      /// Blur
+      final blur = safeParseDouble(historyItem['blur']);
 
-    for (var el in List.from(map['history'] ?? [])) {
-      double blur = 0;
-      List<Layer> layers = [];
+      /// Filters
+      final filters = _parseFilters(historyItem['filters'], version);
 
-      if (el['blur'] != null) {
-        blur = double.tryParse((el['blur'] ?? '0').toString()) ?? 0;
-      }
-      for (var layer in List.from(el['layers'] ?? [])) {
-        layers.add(Layer.fromMap(layer, stickers));
-      }
+      /// Tune Adjustments
+      final tuneAdjustments = (historyItem['tune'] as List<dynamic>? ?? [])
+          .map((tune) => TuneAdjustmentMatrix.fromMap(tune))
+          .toList();
 
-      List<TuneAdjustmentMatrix> tuneAdjustments = [];
-      List<List<double>> filters = [];
-      if (version == ExportImportVersion.version_1_0_0) {
-        for (var el in List.from(el['filters'] ?? [])) {
-          List<List<double>> filterMatrix = List.from(el['filters'] ?? []);
-          double opacity =
-              double.tryParse((el['opacity'] ?? '1').toString()) ?? 1;
-          if (opacity != 1) {
-            filterMatrix.add(ColorFilterAddons.opacity(opacity));
-          }
+      /// Transformations
+      final transformConfigs = historyItem['transform'] != null &&
+              Map.from(historyItem['transform']).isNotEmpty
+          ? TransformConfigs.fromMap(historyItem['transform'])
+          : TransformConfigs.empty();
 
-          filters.addAll(filterMatrix);
-        }
-      } else {
-        /// convert filters
-        List<List<double>> filterList = [];
-        for (var el in List.from(el['filters'] ?? [])) {
-          List<double> filtersRaw = [];
-
-          for (var raw in List.from(el)) {
-            filtersRaw.add(raw);
-          }
-
-          filterList.add(filtersRaw);
-        }
-
-        filters = filterList;
-
-        /// convert tune adjustments
-        List<TuneAdjustmentMatrix> tuneList = List.from(el['tune'] ?? [])
-            .map((el) => TuneAdjustmentMatrix.fromMap(el))
-            .toList();
-
-        tuneAdjustments = tuneList;
-      }
-
-      stateHistory.add(
-        EditorStateHistory(
-          blur: blur,
-          layers: layers,
-          filters: filters,
-          tuneAdjustments: tuneAdjustments,
-          transformConfigs:
-              el['transform'] != null && Map.from(el['transform']).isNotEmpty
-                  ? TransformConfigs.fromMap(el['transform'])
-                  : TransformConfigs.empty(),
-        ),
-      );
+      stateHistory.add(EditorStateHistory(
+        blur: blur,
+        layers: layers,
+        filters: filters,
+        tuneAdjustments: tuneAdjustments,
+        transformConfigs: transformConfigs,
+      ));
     }
 
     return ImportStateHistory._(
-      editorPosition: map['position'],
-      imgSize:
-          Size(map['imgSize']?['width'] ?? 0, map['imgSize']?['height'] ?? 0),
-      lastRenderedImgSize: map['lastRenderedImgSize'] != null
-          ? Size(map['lastRenderedImgSize']?['width'] ?? 0,
-              map['lastRenderedImgSize']?['height'] ?? 0)
-          : Size.zero,
+      editorPosition: safeParseInt(map['position']),
+      imgSize: safeParseSize(map['imgSize']),
+      lastRenderedImgSize: lastRenderedImgSize,
       stateHistory: stateHistory,
       configs: configs,
       version: version,
@@ -133,6 +103,27 @@ class ImportStateHistory {
     ImportEditorConfigs configs = const ImportEditorConfigs(),
   }) {
     return ImportStateHistory.fromMap(jsonDecode(json), configs: configs);
+  }
+
+  /// Helper to parse filters
+  static List<List<double>> _parseFilters(dynamic filtersData, String version) {
+    if (filtersData == null) return [];
+
+    switch (version) {
+      case ExportImportVersion.version_1_0_0:
+        return (filtersData as List<dynamic>).expand((el) {
+          final filterMatrix = List<List<double>>.from(el['filters'] ?? []);
+          final opacity = safeParseDouble(el['opacity'], fallback: 1);
+          if (opacity != 1) {
+            filterMatrix.add(ColorFilterAddons.opacity(opacity));
+          }
+          return filterMatrix;
+        }).toList();
+      default:
+        return (filtersData as List<dynamic>)
+            .map((el) => List<double>.from(el))
+            .toList();
+    }
   }
 
   /// The position of the editor.

--- a/lib/models/import_export/import_state_history.dart
+++ b/lib/models/import_export/import_state_history.dart
@@ -31,6 +31,7 @@ class ImportStateHistory {
   ImportStateHistory._({
     required this.editorPosition,
     required this.imgSize,
+    required this.lastRenderedImgSize,
     required this.stateHistory,
     required this.configs,
     required this.version,
@@ -116,6 +117,10 @@ class ImportStateHistory {
       editorPosition: map['position'],
       imgSize:
           Size(map['imgSize']?['width'] ?? 0, map['imgSize']?['height'] ?? 0),
+      lastRenderedImgSize: map['lastRenderedImgSize'] != null
+          ? Size(map['lastRenderedImgSize']?['width'] ?? 0,
+              map['lastRenderedImgSize']?['height'] ?? 0)
+          : Size.zero,
       stateHistory: stateHistory,
       configs: configs,
       version: version,
@@ -135,6 +140,9 @@ class ImportStateHistory {
 
   /// The size of the imported image.
   final Size imgSize;
+
+  /// The size of the last used screen.
+  final Size lastRenderedImgSize;
 
   /// The state history of each editor state in the session.
   final List<EditorStateHistory> stateHistory;

--- a/lib/models/import_export/utils/export_import_version.dart
+++ b/lib/models/import_export/utils/export_import_version.dart
@@ -9,6 +9,10 @@ class ExportImportVersion {
   static const version_2_0_0 = '2.0.0';
 
   /// The version string representing version `3.0.0` which is used in the
-  /// editor version >= `6.0.0`.
+  /// editor version >= `6.0.0` && < `6.1.5`.
   static const version_3_0_0 = '3.0.0';
+
+  /// The version string representing version `3.0.1` which is used in the
+  /// editor version >= `6.1.5`.
+  static const version_3_0_1 = '3.0.1';
 }

--- a/lib/modules/main_editor/main_editor.dart
+++ b/lib/modules/main_editor/main_editor.dart
@@ -1816,15 +1816,18 @@ class ProImageEditorState extends State<ProImageEditor>
     /// Recalculate position and size
     if (import.configs.recalculateSizeAndPosition ||
         import.version == ExportImportVersion.version_1_0_0) {
-      Size imgSize = import.imgSize / (_imageInfos?.pixelRatio ?? 1);
       for (EditorStateHistory el in import.stateHistory) {
         for (Layer layer in el.layers) {
           if (import.configs.recalculateSizeAndPosition) {
-            // Calculate scaling factors for width and height
-            double scaleWidth =
-                sizesManager.decodedImageSize.width / imgSize.width;
-            double scaleHeight =
-                sizesManager.decodedImageSize.height / imgSize.height;
+
+            Size currentImageSize = sizesManager.decodedImageSize;
+            Size lastDecodedImageSize = import.lastRenderedImgSize;
+
+            // Calculate scale factors for non-uniform scaling
+            double scaleWidth = currentImageSize.width /
+              lastDecodedImageSize.width;
+            double scaleHeight = currentImageSize.height /
+              lastDecodedImageSize.height;
 
             if (scaleWidth == 0 || scaleWidth.isInfinite) scaleWidth = 1;
             if (scaleHeight == 0 || scaleHeight.isInfinite) scaleHeight = 1;

--- a/lib/utils/parser/size_parser.dart
+++ b/lib/utils/parser/size_parser.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/widgets.dart';
+import 'package:pro_image_editor/utils/parser/double_parser.dart';
+
+/// Safely parses a [Map] representation of a size to a [Size] object.
+///
+/// This function attempts to convert the provided [map] to a [Size] object.
+/// If the [map] is `null`, missing required keys (`width` and `height`), or
+/// contains invalid values, a [fallback] size is returned instead.
+///
+/// - Parameters:
+///   - [map]: A [Map] that is expected to contain `width` and `height` keys,
+///            where their values can be converted to [double].
+///   - [fallback]: A [Size] value to return if parsing fails or if [map] is
+///                  `null`.
+///                  Defaults to [Size.zero] if not provided.
+///
+/// - Returns:
+///   A [Size] object constructed from the [map] if parsing succeeds, or the
+///   [fallback] size if it fails.
+///
+/// - Example:
+/// ```dart
+/// safeParseSize({'width': 200, 'height': 100}); // returns Size(200.0, 100.0)
+/// safeParseSize(null);                          // returns Size.zero (fallback)
+/// safeParseSize({'width': 'abc', 'height': 50}, fallback: Size(10, 10));
+///                                               // returns Size(10.0, 10.0) (fallback)
+/// ```
+Size safeParseSize(Map<String, dynamic>? map, {Size fallback = Size.zero}) {
+  if (map == null) return fallback;
+
+  return Size(
+    safeParseDouble(map['width'], fallback: fallback.width),
+    safeParseDouble(map['height'], fallback: fallback.height),
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 6.1.4
+version: 6.1.5
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 issue_tracker: https://github.com/hm21/pro_image_editor/issues/


### PR DESCRIPTION
Hello,

I am honestly not sure if this is the right approach, as I am a bit new around here. But, this solves a problem where editing image states across different screen size/devices would not properly adjust layer scale and position.

This also alters the data structure of import of export, so checking whether the default values are sane is also appreciated. So far I have used a Size.zero absence of this field in previous JSON files for retro-compatibility. The recalculate function takes care of this case so it works fine (in my testing) with older versions.

**However:** The proper calculation will only work in newly exported images, since we didn't have the `lastRenderedSize` in the image states of the past. However it will not fail, it will be just as it was, retrocompatible.

### Before (problem)
![image](https://github.com/user-attachments/assets/7e4fc15e-100f-4bed-bef9-4e977bcfaba3)
![image](https://github.com/user-attachments/assets/c9083063-ceda-4230-bd64-7a4b4806187f)

### After (solution)
![image](https://github.com/user-attachments/assets/0ac79290-d793-4ced-ab2d-6ad9672971ba)
![image](https://github.com/user-attachments/assets/7838b90f-eef9-479d-8485-f7d3cecbdcab)
