### PR TITLE
fix: Widgets calculation is correct upon screen rotation

### DIFF
--- a/lib/widgets/screen_resize_detector.dart
+++ b/lib/widgets/screen_resize_detector.dart
@@ -76,8 +76,8 @@ class _ScreenResizeDetectorState extends State<ScreenResizeDetector> {
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
       Size newSize = Size(
-        constraints.biggest.width - _safeArea.horizontal,
-        constraints.biggest.height - _safeArea.vertical,
+        constraints.biggest.width,
+        constraints.biggest.height,
       );
 
       if (newSize != _lastContentSize) {


### PR DESCRIPTION
Fixes #283  - 

Upon screen rotation (mobile platforms), widgets are now correctly scaled and positioned.

Credits go to @hm21 - this PR is mostly a convenience offer.

Commit may not be safe, side effects of removing SafeArea in the constraints space could exist.

![Simulator Screenshot - iPhone 16 Plus - 2024-12-17 at 10 59 21](https://github.com/user-attachments/assets/1a7d6a7f-5b18-4bfe-ae7e-29c7987d7bb2)
![Simulator Screenshot - iPhone 16 Plus - 2024-12-17 at 10 59 15](https://github.com/user-attachments/assets/94621d0b-eb5d-4d24-8bb1-d3e08593b915)

Best regards