### PR TITLE
fix: enforceSizeFromMainEditor should be true

### DIFF
--- a/lib/models/theme/theme_sub_editor_page.dart
+++ b/lib/models/theme/theme_sub_editor_page.dart
@@ -5,10 +5,10 @@ import 'package:flutter/widgets.dart';
 class SubEditorPageTheme {
   /// Creates a [SubEditorPageTheme].
   ///
-  /// The [enforceSizeFromMainEditor] defaults to `false`.
+  /// The [enforceSizeFromMainEditor] defaults to `true`.
   /// The [barrierDismissible] defaults to `false`.
   const SubEditorPageTheme({
-    this.enforceSizeFromMainEditor = false,
+    this.enforceSizeFromMainEditor = true,
     this.barrierDismissible = false,
     this.borderRadius,
     this.positionTop,


### PR DESCRIPTION
Hello!

I can't see any reason for the enforceSizeFromMainEditor parameter to be `false`, spent some time figuring out why my image editor would popup to full screen out of nowhere.

Unless I am overlooking something, I would like to suggest to switch this to `true` to avoid future victims :) It might be rather the norm than the exception that developers allocate the image editor in some container in their apps, no?

Cheers!