### PR TITLE
feat(stickers): flag to not serialize stickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.2.0
+- **FEAT**(export-history): Introduce the `serializeSticker` parameter to `ExportEditorConfigs` to enable exporting only `StickerLayerData` without converting the sticker to a `Uint8List`. This change incorporates the updates from pull request [#306](https://github.com/hm21/pro_image_editor/pull/306).
+
 ## 7.1.1
 - **FIX**(android): Resolve crop-drag conflicts with navigation gestures on android. This resolves issue [#303](https://github.com/hm21/pro_image_editor/issues/303)
 

--- a/README.md
+++ b/README.md
@@ -968,6 +968,7 @@ The state history from the image editor can be exported and imported. However, i
       exportFilter: true,
       exportEmoji: true,
       exportSticker: true,
+      serializeSticker: true,
       historySpan: ExportHistorySpan.all,
     ),
   ).toJson(); // or => toMap(), toFile()

--- a/lib/models/import_export/export_state_history.dart
+++ b/lib/models/import_export/export_state_history.dart
@@ -203,21 +203,26 @@ class ExportStateHistory {
           layer.runtimeType == StickerLayerData) {
         layers.add((layer as StickerLayerData).toStickerMap(stickers.length));
 
-        double imageWidth = editorConfigs.stickerEditor.initWidth * layer.scale;
-        Size targetSize = Size(
-            imageWidth,
-            MediaQuery.of(context).size.height /
-                MediaQuery.of(context).size.width *
-                imageWidth);
+        Uint8List? result;
+        if (_configs.serializeSticker) {
+          double imageWidth = editorConfigs.stickerEditor.initWidth * layer.scale;
+          Size targetSize = Size(
+              imageWidth,
+              MediaQuery.of(context).size.height /
+                  MediaQuery.of(context).size.width *
+                  imageWidth);
 
-        Uint8List? result = await contentRecorderCtrl.captureFromWidget(
-          layer.sticker,
-          format: OutputFormat.png,
-          imageInfos: imageInfos,
-          targetSize: targetSize,
-        );
-        if (result == null) return;
-
+          result = await contentRecorderCtrl.captureFromWidget(
+            layer.sticker,
+            format: OutputFormat.png,
+            imageInfos: imageInfos,
+            targetSize: targetSize,
+          );
+          if (result == null) return;
+        } else {
+          result = Uint8List.fromList([]);
+        }
+          
         stickers.add(result);
       }
     }

--- a/lib/models/import_export/export_state_history.dart
+++ b/lib/models/import_export/export_state_history.dart
@@ -205,7 +205,8 @@ class ExportStateHistory {
 
         Uint8List? result;
         if (_configs.serializeSticker) {
-          double imageWidth = editorConfigs.stickerEditor.initWidth * layer.scale;
+          double imageWidth =
+              editorConfigs.stickerEditor.initWidth * layer.scale;
           Size targetSize = Size(
               imageWidth,
               MediaQuery.of(context).size.height /
@@ -222,7 +223,7 @@ class ExportStateHistory {
         } else {
           result = Uint8List.fromList([]);
         }
-          
+
         stickers.add(result);
       }
     }

--- a/lib/models/import_export/export_state_history_configs.dart
+++ b/lib/models/import_export/export_state_history_configs.dart
@@ -16,6 +16,7 @@ class ExportEditorConfigs {
     this.exportTuneAdjustments = true,
     this.exportEmoji = true,
     this.exportSticker = true,
+    this.serializeSticker = true,
   });
 
   /// The span of the export history to include in the export.
@@ -59,4 +60,11 @@ class ExportEditorConfigs {
   ///
   /// Warning: Exporting stickers may result in increased file size.
   final bool exportSticker;
+
+  /// Whether to serialize the stickers.
+  ///
+  /// Defaults to `true`.
+  ///
+  /// Warning: Not serializing stickers may result in loss of stickers.
+  final bool serializeSticker;
 }

--- a/lib/models/import_export/export_state_history_configs.dart
+++ b/lib/models/import_export/export_state_history_configs.dart
@@ -61,10 +61,16 @@ class ExportEditorConfigs {
   /// Warning: Exporting stickers may result in increased file size.
   final bool exportSticker;
 
-  /// Whether to serialize the stickers.
+  /// Controls whether stickers should be serialized.
+  ///
+  /// When enabled, each sticker widget is converted to a `Uint8List` and
+  /// included in the export history.
+  /// **Note:** Enabling this flag with a large number of stickers can
+  /// significantly increase the size of the JSON file.
   ///
   /// Defaults to `true`.
   ///
-  /// Warning: Not serializing stickers may result in loss of stickers.
+  /// **Warning:** Disabling sticker serialization may result in the loss of
+  /// stickers during export.
   final bool serializeSticker;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 7.1.1
+version: 7.2.0
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 issue_tracker: https://github.com/hm21/pro_image_editor/issues/


### PR DESCRIPTION
### Excuse the duplicate PR, this follows the discussion at: https://github.com/hm21/pro_image_editor/pull/291 - PR is however independent and is sourced at version 7.0.0

---

Hello,

This is rather a prompt to discuss a feature, more than a full blown feature PR on itself.

I am currently storing Stickers in my app, and loading the `StickerLayerData` from source files. The current serialization is hardcoded to png and the history json files increase their size exponentially if storing the state.

This PR adds a flag that allows skipping serialization of Widget if the developer takes care of their own Sticker layers. A better feature would be to allow storing other than serialized widget, for example file paths to load from instead.

Currently, upon restoring the state, I am overriding the stickers with an Image of my own, i.e.

```dart
    if (image.historyImgLayers != null) {
      image.historyImgLayers!.forEach((layerIndex, imageName) {
        ImageMetadata loadedImage = galleryImages.firstWhere(
          (image) => image.filename == imageName,
          orElse: () {
            return ImageMetadata.fromFileNameInGame(imageName);
          }
        );
        // replace all sticker layers with the original image using the active layer index
        var baseLayers = history?.stateHistory.first.layers;
        if (baseLayers != null && baseLayers.length > layerIndex) {
          var baseLayer = baseLayers[layerIndex];
          if (baseLayer is StickerLayerData) {
            baseLayers[layerIndex] = baseLayer.copyWith(
              sticker: Image.memory(
                loadedImage.image,
                fit: BoxFit.cover,
                width: loadedImage.size.width.toDouble(),
                height: loadedImage.size.height.toDouble(),
              ),
            );
          }
        }
      });
    }
```

Definitely not fancy, but work blazing well, history state files are very lightweight this way, and I don't have to care about layer compression and quality.

![image](https://github.com/user-attachments/assets/93bd6415-d889-466e-838a-b54c69088955)


Open to discuss!
Cheers and thanks again for the awesome library