### PR TITLE
Enhance widget-layer export functionality and refactor layer data models

### DIFF
--- a/example/lib/core/constants/import_history_demo_data.dart
+++ b/example/lib/core/constants/import_history_demo_data.dart
@@ -1,7 +1,7 @@
 /// A map representing the demo data for file import history.
 Map<String, dynamic> kImportHistoryDemoData = {
-  'version': '3.0.1',
-  'position': 6,
+  'version': '4.0.0',
+  'position': 7,
   'history': [
     {
       'layers': [
@@ -9,9 +9,10 @@ Map<String, dynamic> kImportHistoryDemoData = {
           'x': 0.0,
           'y': 0.0,
           'rotation': 0.0,
-          'scale': 5.0,
+          'scale': 1.5982142857142856,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'emoji',
           'emoji': '😛'
         }
@@ -21,12 +22,13 @@ Map<String, dynamic> kImportHistoryDemoData = {
     {
       'layers': [
         {
-          'x': -110.80000000000001,
-          'y': -222.4,
+          'x': -35.416428571428575,
+          'y': -71.08857142857143,
           'rotation': -0.6108619999999999,
-          'scale': 6.920000000000002,
+          'scale': 2.211928571428572,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'emoji',
           'emoji': '😛'
         }
@@ -36,12 +38,13 @@ Map<String, dynamic> kImportHistoryDemoData = {
     {
       'layers': [
         {
-          'x': -110.80000000000001,
-          'y': -222.4,
+          'x': -35.416428571428575,
+          'y': -71.08857142857143,
           'rotation': -0.6108619999999999,
-          'scale': 6.920000000000002,
+          'scale': 2.211928571428572,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'emoji',
           'emoji': '😛'
         },
@@ -49,9 +52,10 @@ Map<String, dynamic> kImportHistoryDemoData = {
           'x': 0.0,
           'y': 0.0,
           'rotation': 0.0,
-          'scale': 1.0,
+          'scale': 0.3196428571428571,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'text',
           'text': 'Hello World',
           'colorMode': 'backgroundAndColor',
@@ -67,22 +71,24 @@ Map<String, dynamic> kImportHistoryDemoData = {
     {
       'layers': [
         {
-          'x': -110.80000000000001,
-          'y': -222.4,
+          'x': -35.416428571428575,
+          'y': -71.08857142857143,
           'rotation': -0.6108619999999999,
-          'scale': 6.920000000000002,
+          'scale': 2.211928571428572,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'emoji',
           'emoji': '😛'
         },
         {
-          'x': 64.80000000000001,
-          'y': -15.600000000000023,
+          'x': 20.712857142857146,
+          'y': -4.986428571428578,
           'rotation': 0.43633,
-          'scale': 1.5999999999999996,
+          'scale': 0.5114285714285712,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'text',
           'text': 'Hello World',
           'colorMode': 'backgroundAndColor',
@@ -98,22 +104,24 @@ Map<String, dynamic> kImportHistoryDemoData = {
     {
       'layers': [
         {
-          'x': -110.80000000000001,
-          'y': -222.4,
+          'x': -35.416428571428575,
+          'y': -71.08857142857143,
           'rotation': -0.6108619999999999,
-          'scale': 6.920000000000002,
+          'scale': 2.211928571428572,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'emoji',
           'emoji': '😛'
         },
         {
-          'x': 64.80000000000001,
-          'y': -15.600000000000023,
+          'x': 20.712857142857146,
+          'y': -4.986428571428578,
           'rotation': 0.43633,
-          'scale': 1.5999999999999996,
+          'scale': 0.5114285714285712,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'text',
           'text': 'Hello World',
           'colorMode': 'backgroundAndColor',
@@ -124,12 +132,13 @@ Map<String, dynamic> kImportHistoryDemoData = {
           'fontScale': 1.0
         },
         {
-          'x': -118.8,
-          'y': 151.8,
+          'x': -37.973571428571425,
+          'y': 48.52178571428571,
           'rotation': 0.0,
-          'scale': 1.0,
+          'scale': 0.3196428571428571,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'paint',
           'item': {
             'mode': 'arrow',
@@ -151,22 +160,24 @@ Map<String, dynamic> kImportHistoryDemoData = {
     {
       'layers': [
         {
-          'x': -110.80000000000001,
-          'y': -222.4,
+          'x': -35.416428571428575,
+          'y': -71.08857142857143,
           'rotation': -0.6108619999999999,
-          'scale': 6.920000000000002,
+          'scale': 2.211928571428572,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'emoji',
           'emoji': '😛'
         },
         {
-          'x': 64.80000000000001,
-          'y': -15.600000000000023,
+          'x': 20.712857142857146,
+          'y': -4.986428571428578,
           'rotation': 0.43633,
-          'scale': 1.5999999999999996,
+          'scale': 0.5114285714285712,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'text',
           'text': 'Hello World',
           'colorMode': 'backgroundAndColor',
@@ -177,12 +188,13 @@ Map<String, dynamic> kImportHistoryDemoData = {
           'fontScale': 1.0
         },
         {
-          'x': -118.8,
-          'y': 151.8,
+          'x': -37.973571428571425,
+          'y': 48.52178571428571,
           'rotation': 0.0,
-          'scale': 1.0,
+          'scale': 0.3196428571428571,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'paint',
           'item': {
             'mode': 'arrow',
@@ -250,22 +262,24 @@ Map<String, dynamic> kImportHistoryDemoData = {
     {
       'layers': [
         {
-          'x': -110.80000000000001,
-          'y': -222.4,
+          'x': -35.416428571428575,
+          'y': -71.08857142857143,
           'rotation': -0.6108619999999999,
-          'scale': 6.920000000000002,
+          'scale': 2.211928571428572,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'emoji',
           'emoji': '😛'
         },
         {
-          'x': 64.80000000000001,
-          'y': -15.600000000000023,
+          'x': 20.712857142857146,
+          'y': -4.986428571428578,
           'rotation': 0.43633,
-          'scale': 1.5999999999999996,
+          'scale': 0.5114285714285712,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'text',
           'text': 'Hello World',
           'colorMode': 'backgroundAndColor',
@@ -276,12 +290,13 @@ Map<String, dynamic> kImportHistoryDemoData = {
           'fontScale': 1.0
         },
         {
-          'x': -118.8,
-          'y': 151.8,
+          'x': -37.973571428571425,
+          'y': 48.52178571428571,
           'rotation': 0.0,
-          'scale': 1.0,
+          'scale': 0.3196428571428571,
           'flipX': false,
           'flipY': false,
+          'enableInteraction': true,
           'type': 'paint',
           'item': {
             'mode': 'arrow',
@@ -581,8 +596,368 @@ Map<String, dynamic> kImportHistoryDemoData = {
         }
       ],
       'blur': 0.0
+    },
+    {
+      'layers': [
+        {
+          'x': -35.416428571428575,
+          'y': -71.08857142857143,
+          'rotation': -0.6108619999999999,
+          'scale': 2.211928571428572,
+          'flipX': false,
+          'flipY': false,
+          'enableInteraction': true,
+          'type': 'emoji',
+          'emoji': '😛'
+        },
+        {
+          'x': 20.712857142857146,
+          'y': -4.986428571428578,
+          'rotation': 0.43633,
+          'scale': 0.5114285714285712,
+          'flipX': false,
+          'flipY': false,
+          'enableInteraction': true,
+          'type': 'text',
+          'text': 'Hello World',
+          'colorMode': 'backgroundAndColor',
+          'color': 4288216832,
+          'background': 4278190080,
+          'colorPickerPosition': 0.42514285714285716,
+          'align': 'center',
+          'fontScale': 1.0
+        },
+        {
+          'x': -37.973571428571425,
+          'y': 48.52178571428571,
+          'rotation': 0.0,
+          'scale': 0.3196428571428571,
+          'flipX': false,
+          'flipY': false,
+          'enableInteraction': true,
+          'type': 'paint',
+          'item': {
+            'mode': 'arrow',
+            'offsets': [
+              {'x': 9.0, 'y': 189.80000000000007},
+              {'x': 5.0, 'y': 5.0}
+            ],
+            'color': 4294901760,
+            'strokeWidth': 10.0,
+            'opacity': 1.0,
+            'fill': false
+          },
+          'rawSize': {'w': 14.0, 'h': 194.80000000000007},
+          'opacity': 1.0
+        },
+        {
+          'x': -101.19999999999993,
+          'y': -225.19999999999993,
+          'rotation': -0.261798,
+          'scale': 0.6,
+          'flipX': false,
+          'flipY': false,
+          'enableInteraction': true,
+          'type': 'widget',
+          'exportConfigs': {'id': 'my-special-container'}
+        },
+        {
+          'x': 101.19999999999993,
+          'y': 225.19999999999993,
+          'rotation': 0.261798,
+          'scale': 0.6,
+          'flipX': false,
+          'flipY': false,
+          'enableInteraction': true,
+          'type': 'widget',
+          'exportConfigs': {'networkUrl': 'https://picsum.photos/id/17/400'}
+        }
+      ],
+      'filters': [
+        [
+          1.0,
+          0.0,
+          0.0,
+          0.0,
+          50.0,
+          0.0,
+          1.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          1.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          1.0,
+          0.0
+        ],
+        [
+          1.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          1.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          1.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.37,
+          0.0
+        ]
+      ],
+      'tune': [
+        {
+          'id': 'brightness',
+          'value': 0.0,
+          'matrix': [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0
+          ]
+        },
+        {
+          'id': 'contrast',
+          'value': 0.0,
+          'matrix': [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0
+          ]
+        },
+        {
+          'id': 'saturation',
+          'value': 0.0,
+          'matrix': [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0
+          ]
+        },
+        {
+          'id': 'exposure',
+          'value': 0.0,
+          'matrix': [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0
+          ]
+        },
+        {
+          'id': 'hue',
+          'value': 0.0,
+          'matrix': [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0
+          ]
+        },
+        {
+          'id': 'temperature',
+          'value': 0.0,
+          'matrix': [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0
+          ]
+        },
+        {
+          'id': 'sharpness',
+          'value': 0.65,
+          'matrix': [
+            2.3,
+            0.0,
+            0.0,
+            0.0,
+            -166.39999999999998,
+            0.0,
+            2.3,
+            0.0,
+            0.0,
+            -166.39999999999998,
+            0.0,
+            0.0,
+            2.3,
+            0.0,
+            -166.39999999999998,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0
+          ]
+        },
+        {
+          'id': 'luminance',
+          'value': 0.0,
+          'matrix': [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0
+          ]
+        },
+        {
+          'id': 'fade',
+          'value': 0.0,
+          'matrix': [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0
+          ]
+        }
+      ],
+      'blur': 0.0
     }
   ],
   'imgSize': {'width': 1024.0, 'height': 1792.0},
-  'lastRenderedImgSize': {'width': 1024.0, 'height': 1792.0}
+  'lastRenderedImgSize': {'width': 327.3142857142857, 'height': 572.8}
 };

--- a/example/lib/features/design_examples/frosted_glass_example.dart
+++ b/example/lib/features/design_examples/frosted_glass_example.dart
@@ -39,7 +39,7 @@ class _FrostedGlassExampleState extends State<FrostedGlassExample>
 
     if (layer == null || !mounted) return;
 
-    if (layer.runtimeType != StickerLayerData) {
+    if (layer.runtimeType != WidgetLayer) {
       layer.scale = editor.configs.emojiEditor.initScale;
     }
 

--- a/example/lib/features/design_examples/whatsapp_example.dart
+++ b/example/lib/features/design_examples/whatsapp_example.dart
@@ -54,7 +54,7 @@ class _WhatsAppExampleState extends State<WhatsAppExample>
   /// is added back. If no layer is returned or the widget is not mounted,
   /// the method returns early.
   ///
-  /// If the returned layer's runtime type is not StickerLayerData, the layer's
+  /// If the returned layer's runtime type is not WidgetLayer, the layer's
   /// scale is set to the initial scale specified in [emojiEditorConfigs] of
   /// the [configs] parameter. Regardless, the layer's offset is set to the
   /// center of the image.
@@ -100,7 +100,7 @@ class _WhatsAppExampleState extends State<WhatsAppExample>
     editor.initKeyEventListener();
     if (layer == null || !mounted) return;
 
-    if (layer.runtimeType != StickerLayerData) {
+    if (layer.runtimeType != WidgetLayer) {
       layer.scale = editor.configs.emojiEditor.initScale;
     }
 

--- a/example/lib/features/frame_example.dart
+++ b/example/lib/features/frame_example.dart
@@ -80,7 +80,7 @@ class _FrameExampleState extends State<FrameExample>
         /// of the editor.
         offset: Offset.zero,
         scale: _initScale,
-        sticker: Image.memory(
+        widget: Image.memory(
           bytes,
           width: 100,
           height: 100 /

--- a/example/lib/features/frame_example.dart
+++ b/example/lib/features/frame_example.dart
@@ -74,7 +74,7 @@ class _FrameExampleState extends State<FrameExample>
     }
 
     editorKey.currentState!.addLayer(
-      StickerLayerData(
+      WidgetLayer(
         /// Adjust the offset position to place the image at any desired
         /// location. Note that a zero offset places the image at the center
         /// of the editor.

--- a/example/lib/features/import_export_example.dart
+++ b/example/lib/features/import_export_example.dart
@@ -96,8 +96,46 @@ class _ImportExportExampleState extends State<ImportExportExample>
             stateHistory: StateHistoryConfigs(
               initStateHistory: ImportStateHistory.fromMap(
                 kImportHistoryDemoData,
-                configs: const ImportEditorConfigs(
+                configs: ImportEditorConfigs(
                   recalculateSizeAndPosition: true,
+
+                  /// The `widgetLoader` is optional and only required if you
+                  /// add `exportConfigs` with an id to the widget layers.
+                  /// Refer to the [sticker-example] for details on how this
+                  /// works in the sticker editor.
+                  ///
+                  /// If you add widget layers directly to the editor,
+                  /// you can pass the parameters as shown below:
+                  ///
+                  /// ```dart
+                  /// editor.addLayer(
+                  ///   WidgetLayer(
+                  ///     exportConfigs: const WidgetLayerExportConfigs(
+                  ///       id: 'my-special-container',
+                  ///     ),
+                  ///     widget: Container(
+                  ///       width: 100,
+                  ///       height: 100,
+                  ///       color: Colors.amber,
+                  ///     ),
+                  ///   ),
+                  /// );
+                  /// ```
+                  widgetLoader: (id) {
+                    switch (id) {
+                      case 'my-special-container':
+                        return Container(
+                          width: 100,
+                          height: 100,
+                          color: Colors.amber,
+                        );
+
+                      /// ... other widgets
+                    }
+                    throw ArgumentError(
+                      'No widget found for the given id: $id',
+                    );
+                  },
                 ),
               ),
             ),

--- a/example/lib/features/import_export_example.dart
+++ b/example/lib/features/import_export_example.dart
@@ -121,7 +121,10 @@ class _ImportExportExampleState extends State<ImportExportExample>
                   ///   ),
                   /// );
                   /// ```
-                  widgetLoader: (id) {
+                  widgetLoader: (
+                    String id, {
+                    Map<String, dynamic>? meta,
+                  }) {
                     switch (id) {
                       case 'my-special-container':
                         return Container(

--- a/example/lib/features/movable_background_image.dart
+++ b/example/lib/features/movable_background_image.dart
@@ -78,7 +78,7 @@ class _MovableBackgroundImageExampleState
     }
 
     editorKey.currentState!.addLayer(
-      StickerLayerData(
+      WidgetLayer(
         offset: Offset.zero,
         scale: _initScale * 0.5,
         sticker: Image.memory(
@@ -258,7 +258,7 @@ class _MovableBackgroundImageExampleState
             mainEditorCallbacks: MainEditorCallbacks(
               onAfterViewInit: () {
                 editorKey.currentState!.addLayer(
-                  StickerLayerData(
+                  WidgetLayer(
                     offset: Offset.zero,
                     scale: _initScale,
                     sticker: Image.network(

--- a/example/lib/features/movable_background_image.dart
+++ b/example/lib/features/movable_background_image.dart
@@ -81,7 +81,7 @@ class _MovableBackgroundImageExampleState
       WidgetLayer(
         offset: Offset.zero,
         scale: _initScale * 0.5,
-        sticker: Image.memory(
+        widget: Image.memory(
           bytes,
           width: decodedImage.width.toDouble(),
           height: decodedImage.height.toDouble(),
@@ -261,7 +261,7 @@ class _MovableBackgroundImageExampleState
                   WidgetLayer(
                     offset: Offset.zero,
                     scale: _initScale,
-                    sticker: Image.network(
+                    widget: Image.network(
                       _imageUrl,
                       width: _editorSize.width,
                       height: _editorSize.height,

--- a/example/lib/features/reorder_layer_example.dart
+++ b/example/lib/features/reorder_layer_example.dart
@@ -181,23 +181,23 @@ class _ReorderLayerSheetState extends State<ReorderLayerSheet> {
         return ListTile(
           key: ValueKey(layer),
           tileColor: Theme.of(context).cardColor,
-          title: layer.runtimeType == TextLayerData
+          title: layer.runtimeType == TextLayer
               ? Text(
-                  (layer as TextLayerData).text,
+                  (layer as TextLayer).text,
                   style: const TextStyle(fontSize: 20),
                 )
-              : layer.runtimeType == EmojiLayerData
+              : layer.runtimeType == EmojiLayer
                   ? Text(
-                      (layer as EmojiLayerData).emoji,
+                      (layer as EmojiLayer).emoji,
                       style: const TextStyle(fontSize: 24),
                     )
-                  : layer.runtimeType == PaintLayerData
+                  : layer.runtimeType == PaintLayer
                       ? SizedBox(
                           height: 40,
                           child: FittedBox(
                             alignment: Alignment.centerLeft,
                             child: CustomPaint(
-                              size: (layer as PaintLayerData).size,
+                              size: (layer as PaintLayer).size,
                               willChange: true,
                               isComplex: layer.item.mode == PaintMode.freeStyle,
                               painter: DrawPaintItem(
@@ -209,12 +209,12 @@ class _ReorderLayerSheetState extends State<ReorderLayerSheet> {
                             ),
                           ),
                         )
-                      : layer.runtimeType == StickerLayerData
+                      : layer.runtimeType == WidgetLayer
                           ? SizedBox(
                               height: 40,
                               child: FittedBox(
                                 alignment: Alignment.centerLeft,
-                                child: (layer as StickerLayerData).sticker,
+                                child: (layer as WidgetLayer).sticker,
                               ),
                             )
                           : Text(

--- a/example/lib/features/reorder_layer_example.dart
+++ b/example/lib/features/reorder_layer_example.dart
@@ -214,7 +214,7 @@ class _ReorderLayerSheetState extends State<ReorderLayerSheet> {
                               height: 40,
                               child: FittedBox(
                                 alignment: Alignment.centerLeft,
-                                child: (layer as WidgetLayer).sticker,
+                                child: (layer as WidgetLayer).widget,
                               ),
                             )
                           : Text(

--- a/example/lib/features/stickers_example.dart
+++ b/example/lib/features/stickers_example.dart
@@ -85,11 +85,42 @@ class _StickersExampleState extends State<StickersExample>
                         theme: Theme.of(context),
                       );
                       await precacheImage(
-                          NetworkImage(
-                              'https://picsum.photos/id/${(index + 3) * 3}/2000'),
-                          context);
+                        NetworkImage(
+                          'https://picsum.photos/id/${(index + 3) * 3}/2000',
+                        ),
+                        context,
+                      );
                       LoadingDialog.instance.hide();
-                      setLayer(Sticker(index: index));
+                      setLayer(
+                        Sticker(index: index),
+
+                        /// The `exportConfigs` parameter is optional but
+                        /// useful if you want to import or export history and
+                        /// directly load the same sticker.
+                        ///
+                        /// If `exportConfigs` is not added, the editor will
+                        /// convert the exported state history to a `Uint8List`
+                        /// to restore the layer. However, this may reduce
+                        /// quality and cause a delay during export.
+                        ///
+                        /// If you use the ID parameter, it is important to set
+                        /// up a `widgetLoader` inside the `ImportEditorConfigs`
+                        ///  when importing the state history.
+                        /// Refer to the [import-example](https://github.com/hm21/pro_image_editor/blob/stable/example/lib/features/import_export_example.dart)
+                        /// for details on how this works.
+                        exportConfigs: WidgetLayerExportConfigs(
+                          id: 'sticker-$index',
+
+                          /// Alternatively, you can use one of the parameters
+                          /// below instead of the id. However, keep in mind
+                          /// that for complex widgets, this may slightly alter
+                          /// their size.
+                          ///
+                          /// networkUrl: '',
+                          /// assetPath: '',
+                          /// fileUrl: '',
+                        ),
+                      );
                     },
                     child: MouseRegion(
                       cursor: SystemMouseCursors.click,

--- a/example/lib/features/stickers_example.dart
+++ b/example/lib/features/stickers_example.dart
@@ -112,9 +112,10 @@ class _StickersExampleState extends State<StickersExample>
                           id: 'sticker-$index',
 
                           /// Alternatively, you can use one of the parameters
-                          /// below instead of the id. However, keep in mind
-                          /// that for complex widgets, this may slightly alter
-                          /// their size.
+                          /// listed below instead of the id, which does not
+                          /// require setting up the widgetLoader. However,
+                          /// please note that for complex widgets, this
+                          /// approach may slightly alter their size.
                           ///
                           /// networkUrl: '',
                           /// assetPath: '',

--- a/lib/core/models/editor_callbacks/sticker_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/sticker_editor_callbacks.dart
@@ -51,7 +51,7 @@ class StickerEditorCallbacks extends StandaloneEditorCallbacks {
   /// ```
   final Function(
     ProImageEditorState editorState,
-    StickerLayerData sticker,
+    WidgetLayer sticker,
     int index,
   )? onTapEditSticker;
 

--- a/lib/core/models/editor_configs/sticker_editor_configs.dart
+++ b/lib/core/models/editor_configs/sticker_editor_configs.dart
@@ -1,9 +1,9 @@
 // Flutter imports:
 import 'package:flutter/widgets.dart';
 
+import '/core/models/layers/layer.dart';
 import '../icons/sticker_editor_icons.dart';
 import '../styles/sticker_editor_style.dart';
-
 export '../icons/sticker_editor_icons.dart';
 export '../styles/sticker_editor_style.dart';
 
@@ -106,4 +106,9 @@ class StickerEditorConfigs {
 /// editor, allowing customization of how stickers are displayed and
 /// manipulated within the user interface.
 typedef BuildStickers = Widget Function(
-    Function(Widget) setLayer, ScrollController scrollController);
+  Function(
+    Widget widget, {
+    WidgetLayerExportConfigs? exportConfigs,
+  }) setLayer,
+  ScrollController scrollController,
+);

--- a/lib/core/models/editor_image.dart
+++ b/lib/core/models/editor_image.dart
@@ -123,6 +123,29 @@ class EditorImage {
   /// Indicates whether the `assetPath` property is not null.
   bool get hasAssetPath => assetPath != null;
 
+  /// Converts the current `EditorImage` instance to an `ImageProvider`.
+  ///
+  /// The type of `ImageProvider` returned depends on the `EditorImageType`:
+  /// - `EditorImageType.memory`: Returns a `MemoryImage` created from the
+  ///   `byteArray`.
+  /// - `EditorImageType.asset`: Returns an `AssetImage` created from the
+  ///   `assetPath`.
+  /// - `EditorImageType.file`: Returns a `FileImage` created from the `file`.
+  /// - `EditorImageType.network`: Returns a `NetworkImage` created from the
+  ///   `networkUrl`.
+  ImageProvider<Object> toImageProvider() {
+    switch (type) {
+      case EditorImageType.memory:
+        return MemoryImage(byteArray!);
+      case EditorImageType.asset:
+        return AssetImage(assetPath!);
+      case EditorImageType.file:
+        return FileImage(file!);
+      case EditorImageType.network:
+        return NetworkImage(networkUrl!);
+    }
+  }
+
   /// A future that retrieves the image data as a `Uint8List` from the
   /// appropriate source based on the `EditorImageType`.
   Future<Uint8List> safeByteArray(BuildContext context) async {
@@ -166,6 +189,42 @@ class EditorImage {
     } else {
       return EditorImageType.asset;
     }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+
+    return other is EditorImage &&
+        _areUint8ListsEqual(byteArray, other.byteArray) &&
+        file?.path == other.file?.path &&
+        networkUrl == other.networkUrl &&
+        assetPath == other.assetPath;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      _hashUint8List(byteArray),
+      file?.path,
+      networkUrl,
+      assetPath,
+    );
+  }
+
+  bool _areUint8ListsEqual(Uint8List? a, Uint8List? b) {
+    if (a == null || b == null) return a == b;
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+
+  int _hashUint8List(Uint8List? list) {
+    if (list == null) return 0;
+    return list.fold(0, (hash, byte) => hash * 31 + byte);
   }
 }
 

--- a/lib/core/models/layers/emoji_layer.dart
+++ b/lib/core/models/layers/emoji_layer.dart
@@ -2,25 +2,70 @@ import 'layer.dart';
 
 /// A class representing a layer with emoji content.
 ///
-/// EmojiLayerData is a subclass of [Layer] that allows you to display emoji
+/// EmojiLayer is a subclass of [Layer] that allows you to display emoji
 /// on a canvas. You can specify the emoji to display, along with optional
 /// properties like offset, rotation, scale, and more.
 ///
 /// Example usage:
 /// ```dart
-/// EmojiLayerData(
+/// EmojiLayer(
 ///   emoji: '😀',
 ///   offset: Offset(100.0, 100.0),
 ///   rotation: 45.0,
 ///   scale: 2.0,
 /// );
 /// ```
-class EmojiLayerData extends Layer {
-  /// Creates an instance of EmojiLayerData.
+class EmojiLayer extends Layer {
+  /// Creates an instance of EmojiLayer.
   ///
   /// The [emoji] parameter is required, and other properties are optional.
-  EmojiLayerData({
+  EmojiLayer({
     required this.emoji,
+    super.offset,
+    super.rotation,
+    super.scale,
+    super.id,
+    super.flipX,
+    super.flipY,
+    super.enableInteraction,
+  });
+
+  /// Factory constructor for creating an EmojiLayer instance from a Layer
+  /// and a map.
+  factory EmojiLayer.fromMap(Layer layer, Map<String, dynamic> map) {
+    /// Constructs and returns an EmojiLayer instance with properties
+    /// derived from the layer and map.
+    return EmojiLayer(
+      flipX: layer.flipX,
+      flipY: layer.flipY,
+      enableInteraction: layer.enableInteraction,
+      offset: layer.offset,
+      rotation: layer.rotation,
+      scale: layer.scale,
+      emoji: map['emoji'],
+    );
+  }
+
+  /// The emoji to display on the layer.
+  String emoji;
+
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      ...super.toMap(),
+      'emoji': emoji,
+      'type': 'emoji',
+    };
+  }
+}
+
+// TODO: Remove in version 8.0.0
+/// **DEPRECATED:** Use [EmojiLayer] instead.
+@Deprecated('Use EmojiLayer instead')
+class EmojiLayerData extends EmojiLayer {
+  /// Constructor for EmojiLayerData
+  EmojiLayerData({
+    required super.emoji,
     super.offset,
     super.rotation,
     super.scale,
@@ -44,17 +89,5 @@ class EmojiLayerData extends Layer {
       scale: layer.scale,
       emoji: map['emoji'],
     );
-  }
-
-  /// The emoji to display on the layer.
-  String emoji;
-
-  @override
-  Map<String, dynamic> toMap() {
-    return {
-      ...super.toMap(),
-      'emoji': emoji,
-      'type': 'emoji',
-    };
   }
 }

--- a/lib/core/models/layers/layer.dart
+++ b/lib/core/models/layers/layer.dart
@@ -7,13 +7,13 @@ import '../../utils/parser/double_parser.dart';
 import '../../utils/unique_id_generator.dart';
 import 'emoji_layer.dart';
 import 'paint_layer.dart';
-import 'sticker_layer.dart';
 import 'text_layer.dart';
+import 'widget_layer.dart';
 
 export 'emoji_layer.dart';
 export 'paint_layer.dart';
-export 'sticker_layer.dart';
 export 'text_layer.dart';
+export 'widget_layer.dart';
 
 /// Represents a layer with common properties for widgets.
 class Layer {
@@ -69,19 +69,19 @@ class Layer {
     /// LayerData subclass.
     switch (map['type']) {
       case 'text':
-        // Returns a TextLayerData instance when type is 'text'.
-        return TextLayerData.fromMap(layer, map);
+        // Returns a TextLayer instance when type is 'text'.
+        return TextLayer.fromMap(layer, map);
       case 'emoji':
-        // Returns an EmojiLayerData instance when type is 'emoji'.
-        return EmojiLayerData.fromMap(layer, map);
+        // Returns an EmojiLayer instance when type is 'emoji'.
+        return EmojiLayer.fromMap(layer, map);
       case 'paint':
       case 'painting':
-        // Returns a PaintLayerData instance when type is 'paint'.
-        return PaintLayerData.fromMap(layer, map);
+        // Returns a PaintLayer instance when type is 'paint'.
+        return PaintLayer.fromMap(layer, map);
       case 'sticker':
-        // Returns a StickerLayerData instance when type is 'sticker',
+        // Returns a WidgetLayer instance when type is 'sticker',
         // utilizing the stickers list.
-        return StickerLayerData.fromMap(layer, map, stickers);
+        return WidgetLayer.fromMap(layer, map, stickers);
       default:
         // Returns the base Layer instance when type is unrecognized.
         return layer;

--- a/lib/core/models/layers/layer.dart
+++ b/lib/core/models/layers/layer.dart
@@ -2,9 +2,10 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-// Project imports:
+import '/shared/services/import_export/types/widget_loader.dart';
 import '../../utils/parser/double_parser.dart';
 import '../../utils/unique_id_generator.dart';
+import '../editor_image.dart';
 import 'emoji_layer.dart';
 import 'paint_layer.dart';
 import 'text_layer.dart';
@@ -52,9 +53,11 @@ class Layer {
   /// Factory constructor for creating a Layer instance from a map and a list
   /// of stickers.
   factory Layer.fromMap(
-    Map<String, dynamic> map,
-    List<Uint8List> stickers,
-  ) {
+    Map<String, dynamic> map, {
+    List<Uint8List>? widgetRecords,
+    WidgetLoader? widgetLoader,
+    Function(EditorImage editorImage)? requirePrecache,
+  }) {
     /// Creates a base Layer instance with default or map-provided properties.
     Layer layer = Layer(
       flipX: map['flipX'] ?? false,
@@ -79,9 +82,16 @@ class Layer {
         // Returns a PaintLayer instance when type is 'paint'.
         return PaintLayer.fromMap(layer, map);
       case 'sticker':
-        // Returns a WidgetLayer instance when type is 'sticker',
-        // utilizing the stickers list.
-        return WidgetLayer.fromMap(layer, map, stickers);
+      case 'widget':
+        // Returns a WidgetLayer instance when type is 'widget' or 'sticker',
+        // utilizing the widgets layer list.
+        return WidgetLayer.fromMap(
+          layer: layer,
+          map: map,
+          widgetRecords: widgetRecords ?? [],
+          widgetLoader: widgetLoader,
+          requirePrecache: requirePrecache,
+        );
       default:
         // Returns the base Layer instance when type is unrecognized.
         return layer;

--- a/lib/core/models/layers/paint_layer.dart
+++ b/lib/core/models/layers/paint_layer.dart
@@ -6,14 +6,14 @@ import 'layer.dart';
 
 /// A class representing a layer with custom paint content.
 ///
-/// PaintLayerData is a subclass of [Layer] that allows you to display
+/// PaintLayer is a subclass of [Layer] that allows you to display
 /// custom-painted content on a canvas. You can specify the painted item and
 /// its raw size, along with optional properties like offset, rotation,
 /// scale, and more.
 ///
 /// Example usage:
 /// ```dart
-/// PaintLayerData(
+/// PaintLayer(
 ///   item: CustomPaintedItem(),
 ///   rawSize: Size(200.0, 150.0),
 ///   offset: Offset(50.0, 50.0),
@@ -21,12 +21,12 @@ import 'layer.dart';
 ///   scale: 1.5,
 /// );
 /// ```
-class PaintLayerData extends Layer {
-  /// Creates an instance of PaintLayerData.
+class PaintLayer extends Layer {
+  /// Creates an instance of PaintLayer.
   ///
   /// The [item] and [rawSize] parameters are required, and other properties
   /// are optional.
-  PaintLayerData({
+  PaintLayer({
     required this.item,
     required this.rawSize,
     required this.opacity,
@@ -39,12 +39,12 @@ class PaintLayerData extends Layer {
     super.enableInteraction,
   });
 
-  /// Factory constructor for creating a PaintLayerData instance from a
+  /// Factory constructor for creating a PaintLayer instance from a
   /// Layer and a map.
-  factory PaintLayerData.fromMap(Layer layer, Map<String, dynamic> map) {
-    /// Constructs and returns a PaintLayerData instance with properties
+  factory PaintLayer.fromMap(Layer layer, Map<String, dynamic> map) {
+    /// Constructs and returns a PaintLayer instance with properties
     /// derived from the layer and map.
-    return PaintLayerData(
+    return PaintLayer(
       flipX: layer.flipX,
       flipY: layer.flipY,
       enableInteraction: layer.enableInteraction,
@@ -84,5 +84,43 @@ class PaintLayerData extends Layer {
       'opacity': opacity,
       'type': 'paint',
     };
+  }
+}
+
+// TODO: Remove in version 8.0.0
+/// **DEPRECATED:** Use [PaintLayer] instead.
+@Deprecated('Use PaintLayer instead')
+class PaintLayerData extends PaintLayer {
+  /// Creates an instance of PaintLayerData.
+  PaintLayerData({
+    required super.item,
+    required super.rawSize,
+    required super.opacity,
+    super.offset,
+    super.rotation,
+    super.scale,
+    super.id,
+    super.flipX,
+    super.flipY,
+    super.enableInteraction,
+  });
+
+  /// Factory constructor for creating a PaintLayerData instance from a
+  /// Layer and a map.
+  factory PaintLayerData.fromMap(Layer layer, Map<String, dynamic> map) {
+    return PaintLayerData(
+      flipX: layer.flipX,
+      flipY: layer.flipY,
+      enableInteraction: layer.enableInteraction,
+      offset: layer.offset,
+      rotation: layer.rotation,
+      scale: layer.scale,
+      opacity: safeParseDouble(map['opacity'], fallback: 1.0),
+      rawSize: Size(
+        safeParseDouble(map['rawSize']?['w'], fallback: 0),
+        safeParseDouble(map['rawSize']?['h'], fallback: 0),
+      ),
+      item: PaintedModel.fromMap(map['item'] ?? {}),
+    );
   }
 }

--- a/lib/core/models/layers/text_layer.dart
+++ b/lib/core/models/layers/text_layer.dart
@@ -7,7 +7,7 @@ import 'enums/layer_background_mode.dart';
 import 'layer.dart';
 
 /// Represents a text layer with customizable properties.
-class TextLayerData extends Layer {
+class TextLayer extends Layer {
   /// Creates a new text layer with customizable properties.
   ///
   /// The [text] parameter specifies the text content of the layer.
@@ -23,7 +23,7 @@ class TextLayerData extends Layer {
   /// [scale], [id], [flipX], and [flipY]
   /// can be used to customize the position, appearance, and behavior of the
   /// text layer.
-  TextLayerData({
+  TextLayer({
     required this.text,
     this.customSecondaryColor = false,
     this.textStyle,
@@ -33,6 +33,180 @@ class TextLayerData extends Layer {
     this.background = const Color(0x00000000),
     this.align = TextAlign.left,
     this.fontScale = 1.0,
+    super.offset,
+    super.rotation,
+    super.scale,
+    super.id,
+    super.flipX,
+    super.flipY,
+    super.enableInteraction,
+  });
+
+  /// Factory constructor for creating a TextLayer instance from a Layer
+  /// instance and a map.
+  factory TextLayer.fromMap(Layer layer, Map<String, dynamic> map) {
+    /// Helper function to determine the text decoration style from a string.
+    TextDecoration getDecoration(String decoration) {
+      if (decoration.contains('combine')) {
+        /// List to hold multiple text decoration styles if combined.
+        List<TextDecoration> decorations = [];
+
+        /// Adds line-through decoration if specified.
+        if (decoration.contains('lineThrough')) {
+          decorations.add(TextDecoration.lineThrough);
+        }
+
+        /// Adds overline decoration if specified.
+        if (decoration.contains('overline')) {
+          decorations.add(TextDecoration.overline);
+        }
+
+        /// Adds underline decoration if specified.
+        if (decoration.contains('underline')) {
+          decorations.add(TextDecoration.underline);
+        }
+
+        /// Combines multiple decorations into a single TextDecoration.
+        return TextDecoration.combine(decorations);
+      } else {
+        /// Checks and returns line-through decoration.
+        if (decoration.contains('lineThrough')) {
+          return TextDecoration.lineThrough;
+        }
+
+        /// Checks and returns overline decoration.
+        else if (decoration.contains('overline')) {
+          return TextDecoration.overline;
+        }
+
+        /// Checks and returns underline decoration.
+        else if (decoration.contains('underline')) {
+          return TextDecoration.underline;
+        }
+      }
+
+      /// Returns no decoration if none is specified.
+      return TextDecoration.none;
+    }
+
+    /// Optional properties for text styling from the map.
+    String? fontFamily = map['fontFamily'] as String?;
+    double? wordSpacing = tryParseDouble(map['wordSpacing']);
+    double? height = tryParseDouble(map['height']);
+    double? letterSpacing = tryParseDouble(map['letterSpacing']);
+    int? fontWeight = tryParseInt(map['fontWeight']);
+    String? fontStyle = map['fontStyle'] as String?;
+    String? decoration = map['decoration'] as String?;
+
+    /// Constructs and returns a TextLayer instance with properties derived
+    /// from the map.
+    return TextLayer(
+      flipX: layer.flipX,
+      flipY: layer.flipY,
+      enableInteraction: layer.enableInteraction,
+      offset: layer.offset,
+      rotation: layer.rotation,
+      scale: layer.scale,
+      text: map['text'] ?? '-',
+      fontScale: map['fontScale'] ?? 1.0,
+      textStyle: map['fontFamily'] != null
+          ? TextStyle(
+              fontFamily: fontFamily,
+              height: height,
+              wordSpacing: wordSpacing,
+              letterSpacing: letterSpacing,
+              decoration: decoration != null ? getDecoration(decoration) : null,
+              fontStyle: fontStyle != null
+                  ? FontStyle.values
+                      .firstWhere((element) => element.name == fontStyle)
+                  : null,
+              fontWeight: fontWeight != null
+                  ? FontWeight.values
+                      .firstWhere((element) => element.value == fontWeight)
+                  : null,
+            )
+          : null,
+      colorMode: LayerBackgroundMode.values
+          .firstWhere((element) => element.name == map['colorMode']),
+      color: Color(map['color']),
+      background: Color(map['background']),
+      colorPickerPosition: map['colorPickerPosition'] ?? 0,
+      align: TextAlign.values
+          .firstWhere((element) => element.name == map['align']),
+      customSecondaryColor: map['customSecondaryColor'] ?? false,
+    );
+  }
+
+  /// The text content of the layer.
+  String text;
+
+  /// The color mode for the text.
+  LayerBackgroundMode? colorMode;
+
+  /// The text color.
+  Color color;
+
+  /// The background color for the text.
+  Color background;
+
+  /// This flag define if the secondary color is manually set.
+  bool customSecondaryColor;
+
+  /// The position of the color picker (if applicable).
+  double? colorPickerPosition;
+
+  /// The text alignment within the layer.
+  TextAlign align;
+
+  /// The font scale for text, to make text bigger or smaller.
+  double fontScale;
+
+  /// A custom text style for the text. Be careful the editor allow not to
+  /// import and export this style.
+  TextStyle? textStyle;
+
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      ...super.toMap(),
+      'text': text,
+      'colorMode': LayerBackgroundMode.values[colorMode?.index ?? 0].name,
+      'color': color.toHex(),
+      'background': background.toHex(),
+      'colorPickerPosition': colorPickerPosition ?? 0,
+      'align': align.name,
+      'fontScale': fontScale,
+      'type': 'text',
+      if (customSecondaryColor) 'customSecondaryColor': customSecondaryColor,
+      if (textStyle?.fontFamily != null) 'fontFamily': textStyle?.fontFamily,
+      if (textStyle?.fontStyle != null) 'fontStyle': textStyle?.fontStyle!.name,
+      if (textStyle?.fontWeight != null)
+        'fontWeight': textStyle?.fontWeight!.value,
+      if (textStyle?.letterSpacing != null)
+        'letterSpacing': textStyle?.letterSpacing,
+      if (textStyle?.height != null) 'height': textStyle?.height,
+      if (textStyle?.wordSpacing != null) 'wordSpacing': textStyle?.wordSpacing,
+      if (textStyle?.decoration != null)
+        'decoration': textStyle?.decoration.toString(),
+    };
+  }
+}
+
+// TODO: Remove in version 8.0.0
+/// **DEPRECATED:** Use [TextLayer] instead.
+@Deprecated('Use TextLayer instead')
+class TextLayerData extends TextLayer {
+  /// Constructor for TextLayerData
+  TextLayerData({
+    required super.text,
+    super.customSecondaryColor,
+    super.textStyle,
+    super.colorMode,
+    super.colorPickerPosition,
+    super.color,
+    super.background,
+    super.align,
+    super.fontScale,
     super.offset,
     super.rotation,
     super.scale,
@@ -135,59 +309,5 @@ class TextLayerData extends Layer {
           .firstWhere((element) => element.name == map['align']),
       customSecondaryColor: map['customSecondaryColor'] ?? false,
     );
-  }
-
-  /// The text content of the layer.
-  String text;
-
-  /// The color mode for the text.
-  LayerBackgroundMode? colorMode;
-
-  /// The text color.
-  Color color;
-
-  /// The background color for the text.
-  Color background;
-
-  /// This flag define if the secondary color is manually set.
-  bool customSecondaryColor;
-
-  /// The position of the color picker (if applicable).
-  double? colorPickerPosition;
-
-  /// The text alignment within the layer.
-  TextAlign align;
-
-  /// The font scale for text, to make text bigger or smaller.
-  double fontScale;
-
-  /// A custom text style for the text. Be careful the editor allow not to
-  /// import and export this style.
-  TextStyle? textStyle;
-
-  @override
-  Map<String, dynamic> toMap() {
-    return {
-      ...super.toMap(),
-      'text': text,
-      'colorMode': LayerBackgroundMode.values[colorMode?.index ?? 0].name,
-      'color': color.toHex(),
-      'background': background.toHex(),
-      'colorPickerPosition': colorPickerPosition ?? 0,
-      'align': align.name,
-      'fontScale': fontScale,
-      'type': 'text',
-      if (customSecondaryColor) 'customSecondaryColor': customSecondaryColor,
-      if (textStyle?.fontFamily != null) 'fontFamily': textStyle?.fontFamily,
-      if (textStyle?.fontStyle != null) 'fontStyle': textStyle?.fontStyle!.name,
-      if (textStyle?.fontWeight != null)
-        'fontWeight': textStyle?.fontWeight!.value,
-      if (textStyle?.letterSpacing != null)
-        'letterSpacing': textStyle?.letterSpacing,
-      if (textStyle?.height != null) 'height': textStyle?.height,
-      if (textStyle?.wordSpacing != null) 'wordSpacing': textStyle?.wordSpacing,
-      if (textStyle?.decoration != null)
-        'decoration': textStyle?.decoration.toString(),
-    };
   }
 }

--- a/lib/core/models/layers/widget_layer.dart
+++ b/lib/core/models/layers/widget_layer.dart
@@ -73,7 +73,7 @@ class WidgetLayer extends Layer {
         'The `widgetLoader` must be defined when '
         'importing the widget layer by id',
       );
-      widget = widgetLoader!(exportConfigs.id!);
+      widget = widgetLoader!(exportConfigs.id!, meta: exportConfigs.meta);
     } else if (exportConfigs.networkUrl != null) {
       widget = ConstrainedBox(
         constraints: defaultConstraints,

--- a/lib/core/models/layers/widget_layer.dart
+++ b/lib/core/models/layers/widget_layer.dart
@@ -6,24 +6,127 @@ import 'layer.dart';
 
 /// A class representing a layer with custom sticker content.
 ///
-/// StickerLayerData is a subclass of [Layer] that allows you to display
+/// WidgetLayer is a subclass of [Layer] that allows you to display
 /// custom sticker content. You can specify properties like offset, rotation,
 /// scale, and more.
 ///
 /// Example usage:
 /// ```dart
-/// StickerLayerData(
+/// WidgetLayer(
 ///   offset: Offset(50.0, 50.0),
 ///   rotation: -30.0,
 ///   scale: 1.5,
 /// );
 /// ```
-class StickerLayerData extends Layer {
-  /// Creates an instance of StickerLayerData.
+class WidgetLayer extends Layer {
+  /// Creates an instance of WidgetLayer.
   ///
   /// The [sticker] parameter is required, and other properties are optional.
-  StickerLayerData({
+  WidgetLayer({
     required this.sticker,
+    super.offset,
+    super.rotation,
+    super.scale,
+    super.id,
+    super.flipX,
+    super.flipY,
+    super.enableInteraction,
+  });
+
+  /// Factory constructor for creating a WidgetLayer instance from a
+  /// Layer, a map, and a list of stickers.
+  factory WidgetLayer.fromMap(
+    Layer layer,
+    Map<String, dynamic> map,
+    List<Uint8List> stickers,
+  ) {
+    /// Determines the position of the sticker in the list.
+    int stickerPosition = safeParseInt(map['listPosition'], fallback: -1);
+
+    /// Widget to display a sticker or a placeholder if not found.
+    Widget sticker = kDebugMode
+        ? Text(
+            'Sticker $stickerPosition not found',
+            style: const TextStyle(color: Color(0xFFF44336), fontSize: 24),
+          )
+        : const SizedBox.shrink();
+
+    /// Updates the sticker widget if the position is valid.
+    if (stickers.isNotEmpty && stickers.length > stickerPosition) {
+      sticker = ConstrainedBox(
+        constraints: const BoxConstraints(minWidth: 1, minHeight: 1),
+        child: Image.memory(
+          stickers[stickerPosition],
+        ),
+      );
+    }
+
+    /// Constructs and returns a WidgetLayer instance with properties
+    /// derived from the layer and map.
+    return WidgetLayer(
+      flipX: layer.flipX,
+      flipY: layer.flipY,
+      enableInteraction: layer.enableInteraction,
+      offset: layer.offset,
+      rotation: layer.rotation,
+      scale: layer.scale,
+      sticker: sticker,
+    );
+  }
+
+  /// The sticker to display on the layer.
+  Widget sticker;
+
+  /// Converts this transform object to a Map suitable for representing a
+  /// sticker.
+  ///
+  /// Returns a Map representing the properties of this transform object,
+  /// augmented with the specified [listPosition] indicating the position of
+  /// the sticker in a list.
+  Map<String, dynamic> toStickerMap(int listPosition) {
+    return {
+      ...toMap(),
+      'listPosition': listPosition,
+      'type': 'sticker',
+    };
+  }
+
+  /// Creates a new instance of [WidgetLayer] with modified properties.
+  ///
+  /// Each property of the new instance can be replaced by providing a value
+  /// to the corresponding parameter of this method. Unprovided parameters
+  /// will default to the current instance's values.
+  WidgetLayer copyWith({
+    Widget? sticker,
+    Offset? offset,
+    double? rotation,
+    double? scale,
+    String? id,
+    bool? flipX,
+    bool? flipY,
+    bool? enableInteraction,
+  }) {
+    return WidgetLayer(
+      sticker: sticker ?? this.sticker,
+      offset: offset ?? this.offset,
+      rotation: rotation ?? this.rotation,
+      scale: scale ?? this.scale,
+      id: id ?? this.id,
+      flipX: flipX ?? this.flipX,
+      flipY: flipY ?? this.flipY,
+      enableInteraction: enableInteraction ?? this.enableInteraction,
+    );
+  }
+}
+
+/// **DEPRECATED:** Use [WidgetLayer] instead.
+///
+/// A class representing a layer with custom sticker content.
+@Deprecated('Use WidgetLayer instead')
+class StickerLayerData extends WidgetLayer {
+  /// Constructor for StickerLayerData
+  StickerLayerData({
+    required super.sticker,
     super.offset,
     super.rotation,
     super.scale,
@@ -71,50 +174,6 @@ class StickerLayerData extends Layer {
       rotation: layer.rotation,
       scale: layer.scale,
       sticker: sticker,
-    );
-  }
-
-  /// The sticker to display on the layer.
-  Widget sticker;
-
-  /// Converts this transform object to a Map suitable for representing a
-  /// sticker.
-  ///
-  /// Returns a Map representing the properties of this transform object,
-  /// augmented with the specified [listPosition] indicating the position of
-  /// the sticker in a list.
-  Map<String, dynamic> toStickerMap(int listPosition) {
-    return {
-      ...toMap(),
-      'listPosition': listPosition,
-      'type': 'sticker',
-    };
-  }
-
-  /// Creates a new instance of [StickerLayerData] with modified properties.
-  ///
-  /// Each property of the new instance can be replaced by providing a value
-  /// to the corresponding parameter of this method. Unprovided parameters
-  /// will default to the current instance's values.
-  StickerLayerData copyWith({
-    Widget? sticker,
-    Offset? offset,
-    double? rotation,
-    double? scale,
-    String? id,
-    bool? flipX,
-    bool? flipY,
-    bool? enableInteraction,
-  }) {
-    return StickerLayerData(
-      sticker: sticker ?? this.sticker,
-      offset: offset ?? this.offset,
-      rotation: rotation ?? this.rotation,
-      scale: scale ?? this.scale,
-      id: id ?? this.id,
-      flipX: flipX ?? this.flipX,
-      flipY: flipY ?? this.flipY,
-      enableInteraction: enableInteraction ?? this.enableInteraction,
     );
   }
 }

--- a/lib/features/emoji_editor/emoji_editor.dart
+++ b/lib/features/emoji_editor/emoji_editor.dart
@@ -197,7 +197,7 @@ class EmojiEditorState extends State<EmojiEditor>
             (category, emoji) {
               Navigator.pop(
                 context,
-                EmojiLayerData(emoji: emoji.emoji),
+                EmojiLayer(emoji: emoji.emoji),
               );
             },
             () {},
@@ -212,7 +212,7 @@ class EmojiEditorState extends State<EmojiEditor>
         child: EmojiPicker(
           key: _emojiPickerKey,
           onEmojiSelected: (category, emoji) => {
-            Navigator.pop(context, EmojiLayerData(emoji: emoji.emoji)),
+            Navigator.pop(context, EmojiLayer(emoji: emoji.emoji)),
           },
           textEditingController: _controller,
           config: _getEditorConfig(constraints),

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -982,8 +982,8 @@ class ProImageEditorState extends State<ProImageEditor>
   /// based on the user's input.
   ///
   /// [layerData] - The text layer data to be edited.
-  void _onTextLayerTap(TextLayerData layerData) async {
-    TextLayerData? layer = await openPage(
+  void _onTextLayerTap(TextLayer layerData) async {
+    TextLayer? layer = await openPage(
       TextEditor(
         key: textEditor,
         layer: layerData,
@@ -1002,7 +1002,7 @@ class ProImageEditorState extends State<ProImageEditor>
     int i = activeLayers.indexWhere((element) => element.id == layerData.id);
     if (i >= 0) {
       _setTempLayer(layerData);
-      (activeLayers[i] as TextLayerData)
+      (activeLayers[i] as TextLayer)
         ..text = layer.text
         ..background = layer.background
         ..color = layer.color
@@ -1191,8 +1191,7 @@ class ProImageEditorState extends State<ProImageEditor>
   /// After closing the paint editor, any changes made are applied to the
   /// image's layers.
   void openPaintEditor() async {
-    List<PaintLayerData>? paintItemLayers =
-        await openPage<List<PaintLayerData>>(
+    List<PaintLayer>? paintItemLayers = await openPage<List<PaintLayer>>(
       PaintEditor.autoSource(
         key: paintEditor,
         file: editorImage.file,
@@ -1238,7 +1237,7 @@ class ProImageEditorState extends State<ProImageEditor>
     /// Small Duration is important for a smooth hero animation
     Duration duration = const Duration(milliseconds: 150),
   }) async {
-    TextLayerData? layer = await openPage(
+    TextLayer? layer = await openPage(
       TextEditor(
         key: textEditor,
         configs: configs,
@@ -1475,7 +1474,7 @@ class ProImageEditorState extends State<ProImageEditor>
     DraggableSheetStyle sheetTheme =
         emojiEditorConfigs.style.themeDraggableSheet;
     bool useDraggableSheet = sheetTheme.maxChildSize != sheetTheme.minChildSize;
-    EmojiLayerData? layer = await showModalBottomSheet(
+    EmojiLayer? layer = await showModalBottomSheet(
         context: context,
         backgroundColor: emojiEditorConfigs.style.backgroundColor,
         constraints: effectiveBoxConstraints,
@@ -1528,7 +1527,7 @@ class ProImageEditorState extends State<ProImageEditor>
         .style.editorBoxConstraintsBuilder
         ?.call(context, configs);
     var sheetTheme = stickerEditorConfigs.style.draggableSheetStyle;
-    StickerLayerData? layer = await showModalBottomSheet(
+    WidgetLayer? layer = await showModalBottomSheet(
         context: context,
         backgroundColor: stickerEditorConfigs.style.bottomSheetBackgroundColor,
         constraints: effectiveBoxConstraints,
@@ -2453,8 +2452,7 @@ class ProImageEditorState extends State<ProImageEditor>
                 onHover: isDesktop
                     ? (event) {
                         bool hasHit = activeLayers.indexWhere((element) =>
-                                element is PaintLayerData &&
-                                element.item.hit) >=
+                                element is PaintLayer && element.item.hit) >=
                             0;
 
                         MouseCursor activeCursor =
@@ -2497,9 +2495,9 @@ class ProImageEditorState extends State<ProImageEditor>
                               highPerformanceMode: layerInteractionManager
                                   .freeStyleHighPerformance,
                               onEditTap: () {
-                                if (layerItem is TextLayerData) {
+                                if (layerItem is TextLayer) {
                                   _onTextLayerTap(layerItem);
-                                } else if (layerItem is StickerLayerData) {
+                                } else if (layerItem is WidgetLayer) {
                                   callbacks
                                       .stickerEditorCallbacks!.onTapEditSticker
                                       ?.call(this, layerItem, i);
@@ -2515,7 +2513,7 @@ class ProImageEditorState extends State<ProImageEditor>
                                           ? ''
                                           : layer.id;
                                   _checkInteractiveViewer();
-                                } else if (layer is TextLayerData) {
+                                } else if (layer is TextLayer) {
                                   _onTextLayerTap(layer);
                                 }
                               },

--- a/lib/features/main_editor/services/desktop_interaction_manager.dart
+++ b/lib/features/main_editor/services/desktop_interaction_manager.dart
@@ -156,9 +156,9 @@ class DesktopInteractionManager {
     required Layer? activeLayer,
   }) {
     if (activeLayer == null) return;
-    double factor = activeLayer is PaintLayerData
+    double factor = activeLayer is PaintLayer
         ? 0.1
-        : activeLayer is TextLayerData
+        : activeLayer is TextLayer
             ? 0.15
             : configs.textEditor.initFontSize / 50;
     if (zoomIn) {
@@ -191,9 +191,9 @@ class DesktopInteractionManager {
           activeLayer.rotation += 0.087266;
         }
       } else {
-        double factor = activeLayer is PaintLayerData
+        double factor = activeLayer is PaintLayer
             ? 0.1
-            : activeLayer is TextLayerData
+            : activeLayer is TextLayer
                 ? 0.15
                 : configs.textEditor.initFontSize / 50;
         if (event.scrollDelta.dy > 0) {

--- a/lib/features/main_editor/services/layer_copy_manager.dart
+++ b/lib/features/main_editor/services/layer_copy_manager.dart
@@ -17,13 +17,13 @@ class LayerCopyManager {
   /// If the layer type is not recognized, it returns the original layer
   /// unchanged.
   Layer copyLayer(Layer layer) {
-    if (layer is TextLayerData) {
+    if (layer is TextLayer) {
       return createCopyTextLayer(layer);
-    } else if (layer is EmojiLayerData) {
+    } else if (layer is EmojiLayer) {
       return createCopyEmojiLayer(layer);
-    } else if (layer is PaintLayerData) {
+    } else if (layer is PaintLayer) {
       return createCopyPaintLayer(layer);
-    } else if (layer is StickerLayerData) {
+    } else if (layer is WidgetLayer) {
       return createCopyStickerLayer(layer);
     } else {
       return layer;
@@ -35,9 +35,9 @@ class LayerCopyManager {
     return layers.map(copyLayer).toList();
   }
 
-  /// Create a copy of a TextLayerData instance.
-  TextLayerData createCopyTextLayer(TextLayerData layer) {
-    return TextLayerData(
+  /// Create a copy of a TextLayer instance.
+  TextLayer createCopyTextLayer(TextLayer layer) {
+    return TextLayer(
       id: layer.id,
       text: layer.text,
       align: layer.align,
@@ -67,9 +67,9 @@ class LayerCopyManager {
     );
   }
 
-  /// Create a copy of an EmojiLayerData instance.
-  EmojiLayerData createCopyEmojiLayer(EmojiLayerData layer) {
-    return EmojiLayerData(
+  /// Create a copy of an EmojiLayer instance.
+  EmojiLayer createCopyEmojiLayer(EmojiLayer layer) {
+    return EmojiLayer(
       id: layer.id,
       emoji: layer.emoji,
       offset: Offset(layer.offset.dx, layer.offset.dy),
@@ -81,9 +81,9 @@ class LayerCopyManager {
     );
   }
 
-  /// Create a copy of an EmojiLayerData instance.
-  StickerLayerData createCopyStickerLayer(StickerLayerData layer) {
-    return StickerLayerData(
+  /// Create a copy of an WidgetLayer instance.
+  WidgetLayer createCopyStickerLayer(WidgetLayer layer) {
+    return WidgetLayer(
       id: layer.id,
       sticker: layer.sticker,
       offset: Offset(layer.offset.dx, layer.offset.dy),
@@ -95,9 +95,9 @@ class LayerCopyManager {
     );
   }
 
-  /// Create a copy of a PaintLayerData instance.
-  PaintLayerData createCopyPaintLayer(PaintLayerData layer) {
-    return PaintLayerData(
+  /// Create a copy of a PaintLayer instance.
+  PaintLayer createCopyPaintLayer(PaintLayer layer) {
+    return PaintLayer(
       id: layer.id,
       offset: Offset(layer.offset.dx, layer.offset.dy),
       rotation: layer.rotation,

--- a/lib/features/main_editor/services/layer_copy_manager.dart
+++ b/lib/features/main_editor/services/layer_copy_manager.dart
@@ -24,7 +24,7 @@ class LayerCopyManager {
     } else if (layer is PaintLayer) {
       return createCopyPaintLayer(layer);
     } else if (layer is WidgetLayer) {
-      return createCopyStickerLayer(layer);
+      return createCopyWidgetLayer(layer);
     } else {
       return layer;
     }
@@ -82,16 +82,17 @@ class LayerCopyManager {
   }
 
   /// Create a copy of an WidgetLayer instance.
-  WidgetLayer createCopyStickerLayer(WidgetLayer layer) {
+  WidgetLayer createCopyWidgetLayer(WidgetLayer layer) {
     return WidgetLayer(
       id: layer.id,
-      sticker: layer.sticker,
+      widget: layer.widget,
       offset: Offset(layer.offset.dx, layer.offset.dy),
       rotation: layer.rotation,
       scale: layer.scale,
       flipX: layer.flipX,
       flipY: layer.flipY,
       enableInteraction: layer.enableInteraction,
+      exportConfigs: layer.exportConfigs,
     );
   }
 

--- a/lib/features/main_editor/services/layer_interaction_manager.dart
+++ b/lib/features/main_editor/services/layer_interaction_manager.dart
@@ -521,22 +521,22 @@ class LayerInteractionManager {
   }
 
   void _setMinMaxScaleFactor(ProImageEditorConfigs configs, Layer layer) {
-    if (layer is PaintLayerData) {
+    if (layer is PaintLayer) {
       layer.scale = layer.scale.clamp(
         configs.paintEditor.minScale,
         configs.paintEditor.maxScale,
       );
-    } else if (layer is TextLayerData) {
+    } else if (layer is TextLayer) {
       layer.scale = layer.scale.clamp(
         configs.textEditor.minScale,
         configs.textEditor.maxScale,
       );
-    } else if (layer is EmojiLayerData) {
+    } else if (layer is EmojiLayer) {
       layer.scale = layer.scale.clamp(
         configs.emojiEditor.minScale,
         configs.emojiEditor.maxScale,
       );
-    } else if (layer is StickerLayerData) {
+    } else if (layer is WidgetLayer) {
       layer.scale = layer.scale.clamp(
         configs.stickerEditor.minScale,
         configs.stickerEditor.maxScale,

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -564,16 +564,16 @@ class PaintEditorState extends State<PaintEditor>
     paintEditorCallbacks?.handleDone();
   }
 
-  /// Exports the painted items as a list of [PaintLayerData].
+  /// Exports the painted items as a list of [PaintLayer].
   ///
   /// This method converts the paint history into a list of
-  /// [PaintLayerData] representing the painted items.
+  /// [PaintLayer] representing the painted items.
   ///
   /// Example:
   /// ```dart
-  /// List<PaintLayerData> layers = exportPaintedItems();
+  /// List<PaintLayer> layers = exportPaintedItems();
   /// ```
-  List<PaintLayerData> _exportPaintedItems(Size editorSize) {
+  List<PaintLayer> _exportPaintedItems(Size editorSize) {
     Rect findRenderedLayerRect(List<Offset?> points) {
       if (points.isEmpty) return Rect.zero;
 
@@ -653,8 +653,8 @@ class PaintEditorState extends State<PaintEditor>
         );
       }
 
-      // Create and return a PaintLayerData instance for the exported layer
-      return PaintLayerData(
+      // Create and return a PaintLayer instance for the exported layer
+      return PaintLayer(
         item: layer.copy(),
         rawSize: Size(
           max(size.width, layer.strokeWidth),

--- a/lib/features/sticker_editor/sticker_editor.dart
+++ b/lib/features/sticker_editor/sticker_editor.dart
@@ -57,16 +57,24 @@ class StickerEditorState extends State<StickerEditor>
 
     return ExtendedPopScope(
       child: widget.configs.stickerEditor.buildStickers!(
-          setLayer, widget.scrollController),
+        setLayer,
+        widget.scrollController,
+      ),
     );
   }
 
   /// Sets the current layer with a sticker and closes the navigation.
   ///
-  /// [sticker] is the widget to be set as the layer.
-  void setLayer(Widget sticker) {
+  /// [widget] is the widget to be set as the layer.
+  void setLayer(
+    Widget widget, {
+    WidgetLayerExportConfigs? exportConfigs,
+  }) {
     Navigator.of(context).pop(
-      WidgetLayer(sticker: sticker),
+      WidgetLayer(
+        widget: widget,
+        exportConfigs: exportConfigs ?? const WidgetLayerExportConfigs(),
+      ),
     );
   }
 }

--- a/lib/features/sticker_editor/sticker_editor.dart
+++ b/lib/features/sticker_editor/sticker_editor.dart
@@ -9,11 +9,7 @@ import '/shared/widgets/extended/extended_pop_scope.dart';
 import '../../core/models/layers/layer.dart';
 
 /// The `StickerEditor` class is responsible for creating a widget that allows
-/// users to select emojis.
-///
-/// This widget provides an EmojiPicker that allows users to choose emojis,
-/// which are then returned
-/// as `EmojiLayerData` containing the selected emoji text.
+/// users to select stickers
 class StickerEditor extends StatefulWidget with SimpleConfigsAccess {
   /// Creates an `StickerEditor` widget.
   const StickerEditor({
@@ -70,7 +66,7 @@ class StickerEditorState extends State<StickerEditor>
   /// [sticker] is the widget to be set as the layer.
   void setLayer(Widget sticker) {
     Navigator.of(context).pop(
-      StickerLayerData(sticker: sticker),
+      WidgetLayer(sticker: sticker),
     );
   }
 }

--- a/lib/features/text_editor/text_editor.dart
+++ b/lib/features/text_editor/text_editor.dart
@@ -43,7 +43,7 @@ class TextEditor extends StatefulWidget with SimpleConfigsAccess {
   final ThemeData theme;
 
   /// The text layer data to be edited, if any.
-  final TextLayerData? layer;
+  final TextLayer? layer;
 
   @override
   createState() => TextEditorState();
@@ -365,7 +365,7 @@ class TextEditorState extends State<TextEditor>
   void done() {
     if (textCtrl.text.trim().isNotEmpty) {
       Navigator.of(context).pop(
-        TextLayerData(
+        TextLayer(
           text: textCtrl.text.trim(),
           background: _backgroundColor,
           color: _textColor,

--- a/lib/shared/services/import_export/constants/export_import_version.dart
+++ b/lib/shared/services/import_export/constants/export_import_version.dart
@@ -13,6 +13,10 @@ class ExportImportVersion {
   static const version_3_0_0 = '3.0.0';
 
   /// The version string representing version `3.0.1` which is used in the
-  /// editor version >= `6.1.5`.
+  /// editor version >= `6.1.5` && < `7.5.0`.
   static const version_3_0_1 = '3.0.1';
+
+  /// The version string representing version `4.0.0` which is used in the
+  /// editor version >= `7.5.0`.
+  static const version_4_0_0 = '4.0.0';
 }

--- a/lib/shared/services/import_export/export_state_history.dart
+++ b/lib/shared/services/import_export/export_state_history.dart
@@ -199,13 +199,12 @@ class ExportStateHistory {
     required ImageInfos imageInfos,
   }) async {
     for (var layer in element.layers) {
-      if ((_configs.exportPaint && layer.runtimeType == PaintLayerData) ||
-          (_configs.exportText && layer.runtimeType == TextLayerData) ||
-          (_configs.exportEmoji && layer.runtimeType == EmojiLayerData)) {
+      if ((_configs.exportPaint && layer.runtimeType == PaintLayer) ||
+          (_configs.exportText && layer.runtimeType == TextLayer) ||
+          (_configs.exportEmoji && layer.runtimeType == EmojiLayer)) {
         layers.add(layer.toMap());
-      } else if (_configs.exportSticker &&
-          layer.runtimeType == StickerLayerData) {
-        layers.add((layer as StickerLayerData).toStickerMap(stickers.length));
+      } else if (_configs.exportSticker && layer.runtimeType == WidgetLayer) {
+        layers.add((layer as WidgetLayer).toStickerMap(stickers.length));
 
         Uint8List? result;
         if (_configs.serializeSticker) {

--- a/lib/shared/services/import_export/models/export_state_history_configs.dart
+++ b/lib/shared/services/import_export/models/export_state_history_configs.dart
@@ -15,7 +15,8 @@ class ExportEditorConfigs {
     this.exportFilter = true,
     this.exportTuneAdjustments = true,
     this.exportEmoji = true,
-    this.exportSticker = true,
+    this.exportSticker,
+    this.exportWidgets = true,
     this.serializeSticker = true,
   });
 
@@ -54,13 +55,25 @@ class ExportEditorConfigs {
   /// Defaults to `true`.
   final bool exportEmoji;
 
+  // TODO: Remove in version 8.0.0
   /// Whether to export the stickers.
   ///
   /// Defaults to `true`.
   ///
   /// Warning: Exporting stickers may result in increased file size.
-  final bool exportSticker;
+  @Deprecated('Use exportWidgets instead')
+  final bool? exportSticker;
 
+  /// Whether to export the widget layers.
+  ///
+  /// Defaults to `true`.
+  ///
+  /// Warning: Exporting widgets may result in a significantly increased file
+  /// size if no `exportConfigs` are added to the `WidgetLayer`.
+  final bool exportWidgets;
+
+  // TODO: Remove in version 8.0.0
+  /// **DEPRECATED:**
   /// Controls whether stickers should be serialized.
   ///
   /// When enabled, each sticker widget is converted to a `Uint8List` and
@@ -72,5 +85,9 @@ class ExportEditorConfigs {
   ///
   /// **Warning:** Disabling sticker serialization may result in the loss of
   /// stickers during export.
+  @Deprecated(
+    'The parameter is no longer used. Instead, add `exportConfigs` to the '
+    '`WidgetLayer`',
+  )
   final bool serializeSticker;
 }

--- a/lib/shared/services/import_export/models/import_state_history_configs.dart
+++ b/lib/shared/services/import_export/models/import_state_history_configs.dart
@@ -1,5 +1,6 @@
 // Project imports:
 import '../enums/export_import_enum.dart';
+import '../types/widget_loader.dart';
 
 /// This class represents configurations for importing editor data.
 class ImportEditorConfigs {
@@ -10,6 +11,7 @@ class ImportEditorConfigs {
   const ImportEditorConfigs({
     this.recalculateSizeAndPosition = true,
     this.mergeMode = ImportEditorMergeMode.replace,
+    this.widgetLoader,
   });
 
   /// The merge mode for importing editor data.
@@ -18,4 +20,7 @@ class ImportEditorConfigs {
   /// A flag indicating whether to recalculate size and position during import
   /// based on the new image size and device size.
   final bool recalculateSizeAndPosition;
+
+  /// {@macro widgetLoader}
+  final WidgetLoader? widgetLoader;
 }

--- a/lib/shared/services/import_export/models/widget_layer_export_configs.dart
+++ b/lib/shared/services/import_export/models/widget_layer_export_configs.dart
@@ -1,0 +1,108 @@
+/// A class that represents the export configurations for a widget layer.
+class WidgetLayerExportConfigs {
+  /// Creates a [WidgetLayerExportConfigs] instance with the provided
+  /// configuration values.
+  ///
+  /// Only one parameter except `meta` can be non-null.
+  /// If more than one parameter is provided, an assertion error will be thrown.
+  ///
+  /// {@template widgetLoaderIdWarning}
+  /// If you use the ID parameter, it is important to set up a `widgetLoader`
+  /// inside the `ImportEditorConfigs`when importing the state history.
+  /// Refer to the [import-example](https://github.com/hm21/pro_image_editor/blob/stable/example/lib/features/import_export_example.dart)
+  /// for details on how this works.
+  /// {@endtemplate}
+  const WidgetLayerExportConfigs({
+    this.id,
+    this.networkUrl,
+    this.assetPath,
+    this.fileUrl,
+    this.meta,
+  }) : assert(
+          (id != null ? 1 : 0) +
+                  (networkUrl != null ? 1 : 0) +
+                  (assetPath != null ? 1 : 0) +
+                  (fileUrl != null ? 1 : 0) <=
+              1,
+          'Only one parameter can be non-null',
+        );
+
+  /// Creates a [WidgetLayerExportConfigs] instance from a [Map].
+  ///
+  /// If the [map] is `null`, an empty map is used.
+  factory WidgetLayerExportConfigs.fromMap(Map<String, dynamic>? map) {
+    map ??= {};
+    return WidgetLayerExportConfigs(
+      id: map['id'],
+      networkUrl: map['networkUrl'],
+      assetPath: map['assetPath'],
+      fileUrl: map['fileUrl'],
+    );
+  }
+
+  /// The id from the widget to restore it.
+  ///
+  /// {@macro widgetLoaderIdWarning}
+  final String? id;
+
+  /// The network url to the widget to restore it. That can only restore images.
+  final String? networkUrl;
+
+  /// The asset path to the widget to restore it. That can only restore images.
+  final String? assetPath;
+
+  /// The file url to the widget to restore it. That can only restore images.
+  final String? fileUrl;
+
+  /// A map containing metadata associated with the widget layer.
+  /// The keys are strings representing the metadata field names, and the values
+  /// are dynamic, allowing for various types of metadata values.
+  ///
+  /// This can be used to store additional information about the widget layer
+  /// that may be needed for import/export operations.
+  final Map<String, dynamic>? meta;
+
+  /// Checks if the widget layer has any of the parameters set.
+  ///
+  /// Returns `true` if any of the following parameters are not null:
+  /// - [id]
+  /// - [networkUrl]
+  /// - [assetPath]
+  /// - [fileUrl]
+  /// Otherwise, returns `false`.
+  bool get hasParameter =>
+      id != null || networkUrl != null || assetPath != null || fileUrl != null;
+
+  /// Converts the [WidgetLayerExportConfigs] instance into a [Map].
+  ///
+  /// Only non-null fields are included in the map.
+  Map<String, dynamic> toMap() {
+    return {
+      if (id != null) 'id': id,
+      if (networkUrl != null) 'networkUrl': networkUrl,
+      if (assetPath != null) 'assetPath': assetPath,
+      if (fileUrl != null) 'fileUrl': fileUrl,
+      if (meta != null) 'meta': meta,
+    };
+  }
+
+  /// Creates a copy of the current [WidgetLayerExportConfigs] with optional
+  /// updated fields.
+  ///
+  /// If a field is not provided, the value from the current instance is used.
+  WidgetLayerExportConfigs copyWith({
+    String? id,
+    String? networkUrl,
+    String? assetPath,
+    String? fileUrl,
+    Map<String, dynamic>? meta,
+  }) {
+    return WidgetLayerExportConfigs(
+      id: id ?? this.id,
+      networkUrl: networkUrl ?? this.networkUrl,
+      assetPath: assetPath ?? this.assetPath,
+      fileUrl: fileUrl ?? this.fileUrl,
+      meta: meta ?? this.meta,
+    );
+  }
+}

--- a/lib/shared/services/import_export/types/widget_loader.dart
+++ b/lib/shared/services/import_export/types/widget_loader.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/widgets.dart';
+
+/// {@template widgetLoader}
+/// This function allows you to import widget layers using your own logic.
+/// Add an `exportConfig` with an ID to your `WidgetLayer`. After that,
+/// this function will be triggered to import the layer using the specified ID.
+///
+/// Parameters:
+/// - `id` (String): The export ID of the widget to be loaded.
+///
+/// Returns:
+/// - `Widget`: The widget corresponding to the given export ID.
+///
+/// **Example:**
+///
+/// Add to the editor:
+/// ```dart
+/// editor.addLayer(
+///   WidgetLayer(
+///     exportConfigs: const WidgetLayerExportConfigs(
+///       id: 'my-special-container',
+///     ),
+///     widget: Container(
+///       width: 100,
+///       height: 100,
+///       color: Colors.amber,
+///     ),
+///   ),
+/// );
+/// ```
+///
+/// Import:
+/// ```dart
+/// editor.importStateHistory(
+///   ImportStateHistory.fromJson(
+///     savedHistory,
+///     configs: ImportEditorConfigs(
+///       widgetLoader: (id) {
+///         switch (id) {
+///           case 'my-special-container':
+///             return Container(
+///               width: 100,
+///               height: 100,
+///               color: Colors.amber,
+///             );
+///
+///           /// ... other widgets
+///         }
+///         throw ArgumentError(
+///           'No widget found for the given id: $id',
+///         );
+///       },
+///     ),
+///   ),
+/// );
+/// ```
+///
+/// {@endtemplate}
+typedef WidgetLoader = Widget Function(String id);

--- a/lib/shared/services/import_export/types/widget_loader.dart
+++ b/lib/shared/services/import_export/types/widget_loader.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unintended_html_in_doc_comment
+
 import 'package:flutter/widgets.dart';
 
 /// {@template widgetLoader}
@@ -7,6 +9,7 @@ import 'package:flutter/widgets.dart';
 ///
 /// Parameters:
 /// - `id` (String): The export ID of the widget to be loaded.
+/// - `meta` (Map<String, dynamic>?): Additional information about the widget.
 ///
 /// Returns:
 /// - `Widget`: The widget corresponding to the given export ID.
@@ -35,7 +38,10 @@ import 'package:flutter/widgets.dart';
 ///   ImportStateHistory.fromJson(
 ///     savedHistory,
 ///     configs: ImportEditorConfigs(
-///       widgetLoader: (id) {
+///         widgetLoader: (
+///           String id, {
+///           Map<String, dynamic>? meta,
+///         }) {
 ///         switch (id) {
 ///           case 'my-special-container':
 ///             return Container(
@@ -56,4 +62,7 @@ import 'package:flutter/widgets.dart';
 /// ```
 ///
 /// {@endtemplate}
-typedef WidgetLoader = Widget Function(String id);
+typedef WidgetLoader = Widget Function(
+  String id, {
+  Map<String, dynamic>? meta,
+});

--- a/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
+++ b/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
@@ -184,8 +184,8 @@ class _LayerInteractionHelperWidgetState
               ),
             ),
             _buildRemoveIcon(),
-            if (widget.layerData.runtimeType == TextLayerData ||
-                (widget.layerData.runtimeType == StickerLayerData &&
+            if (widget.layerData.runtimeType == TextLayer ||
+                (widget.layerData.runtimeType == WidgetLayer &&
                     widget.callbacks.stickerEditorCallbacks?.onTapEditSticker !=
                         null))
               _buildEditIcon(),

--- a/lib/shared/widgets/layer/layer_widget.dart
+++ b/lib/shared/widgets/layer/layer_widget.dart
@@ -139,16 +139,16 @@ class _LayerWidgetState extends State<LayerWidget>
   @override
   void initState() {
     switch (widget.layerData.runtimeType) {
-      case const (TextLayerData):
+      case const (TextLayer):
         _layerType = _LayerType.text;
         break;
-      case const (EmojiLayerData):
+      case const (EmojiLayer):
         _layerType = _LayerType.emoji;
         break;
-      case const (StickerLayerData):
+      case const (WidgetLayer):
         _layerType = _LayerType.sticker;
         break;
-      case const (PaintLayerData):
+      case const (PaintLayer):
         _layerType = _LayerType.canvas;
         break;
       default:
@@ -216,8 +216,7 @@ class _LayerWidgetState extends State<LayerWidget>
 
   /// Checks if the hit is outside the canvas for certain types of layers.
   bool _checkHitIsOutsideInCanvas() {
-    return _layerType == _LayerType.canvas &&
-        !(_layer as PaintLayerData).item.hit;
+    return _layerType == _LayerType.canvas && !(_layer as PaintLayer).item.hit;
   }
 
   /// Calculates the transformation matrix for the layer's position and
@@ -293,7 +292,7 @@ class _LayerWidgetState extends State<LayerWidget>
               },
               onExit: (event) {
                 if (_layerType == _LayerType.canvas) {
-                  (widget.layerData as PaintLayerData).item.hit = false;
+                  (widget.layerData as PaintLayer).item.hit = false;
                 } else {
                   setState(() {
                     _showMoveCursor = false;
@@ -352,7 +351,7 @@ class _LayerWidgetState extends State<LayerWidget>
   /// Build the text widget
   Widget _buildText() {
     var fontSize = textEditorConfigs.initFontSize * _layer.scale;
-    var layer = _layer as TextLayerData;
+    var layer = _layer as TextLayer;
     var style = TextStyle(
       fontSize: fontSize * layer.fontScale,
       color: layer.color,
@@ -389,7 +388,7 @@ class _LayerWidgetState extends State<LayerWidget>
 
   /// Build the emoji widget
   Widget _buildEmoji() {
-    var layer = _layer as EmojiLayerData;
+    var layer = _layer as EmojiLayer;
     return Material(
       // Prevent hero animation bug
       type: MaterialType.transparency,
@@ -406,7 +405,7 @@ class _LayerWidgetState extends State<LayerWidget>
 
   /// Build the sticker widget
   Widget _buildSticker() {
-    var layer = _layer as StickerLayerData;
+    var layer = _layer as WidgetLayer;
     return SizedBox(
       width: stickerEditorConfigs.initWidth * layer.scale,
       child: FittedBox(
@@ -418,7 +417,7 @@ class _LayerWidgetState extends State<LayerWidget>
 
   /// Build the canvas widget
   Widget _buildCanvas() {
-    var layer = _layer as PaintLayerData;
+    var layer = _layer as PaintLayer;
     return Padding(
       // Better hit detection for mobile devices
       padding: EdgeInsets.all(isDesktop ? 0 : 15),

--- a/lib/shared/widgets/layer/layer_widget.dart
+++ b/lib/shared/widgets/layer/layer_widget.dart
@@ -146,7 +146,7 @@ class _LayerWidgetState extends State<LayerWidget>
         _layerType = _LayerType.emoji;
         break;
       case const (WidgetLayer):
-        _layerType = _LayerType.sticker;
+        _layerType = _LayerType.widget;
         break;
       case const (PaintLayer):
         _layerType = _LayerType.canvas;
@@ -329,8 +329,8 @@ class _LayerWidgetState extends State<LayerWidget>
         return _buildEmoji();
       case _LayerType.text:
         return _buildText();
-      case _LayerType.sticker:
-        return _buildSticker();
+      case _LayerType.widget:
+        return _buildWidgetLayer();
       case _LayerType.canvas:
         return _buildCanvas();
       default:
@@ -403,14 +403,14 @@ class _LayerWidgetState extends State<LayerWidget>
     );
   }
 
-  /// Build the sticker widget
-  Widget _buildSticker() {
+  /// Build the layer widget
+  Widget _buildWidgetLayer() {
     var layer = _layer as WidgetLayer;
     return SizedBox(
       width: stickerEditorConfigs.initWidth * layer.scale,
       child: FittedBox(
         fit: BoxFit.contain,
-        child: layer.sticker,
+        child: layer.widget,
       ),
     );
   }
@@ -443,4 +443,4 @@ class _LayerWidgetState extends State<LayerWidget>
 }
 
 // ignore: camel_case_types
-enum _LayerType { emoji, text, sticker, canvas, unknown }
+enum _LayerType { emoji, text, widget, canvas, unknown }

--- a/test/widgets/layer_widget_test.dart
+++ b/test/widgets/layer_widget_test.dart
@@ -11,7 +11,7 @@ import 'package:pro_image_editor/shared/widgets/layer/layer_widget.dart';
 void main() {
   testWidgets('LayerWidget test', (WidgetTester tester) async {
     // Create a mock layer for testing.
-    final layer = TextLayerData(
+    final layer = TextLayer(
       text: 'Test Text',
       color: Colors.white,
       background: Colors.blue,


### PR DESCRIPTION
## **PR Description:**  
This pull request focuses on improving code consistency and enhancing the export functionality for widget layers by introducing configurable export support. The key changes include renaming the `StickerLayerData` to `WidgetLayer` for clarity and adding the `exportConfigs` parameter to support customizable import/export workflows.

---

## **Key Changes:**  

### 1. **Renaming for Consistency:**  
- `StickerLayerData` is renamed to `WidgetLayer`.
- `PaintLayerData` is renamed to `PaintLayer`.
- `TextLayerData` is renamed to `TextLayer`.
- `EmojiLayerData` is renamed to `EmojiLayer`.

### 2. **Introduction of `exportConfigs`:**  
The `WidgetLayer` now includes an `exportConfigs` parameter to enhance flexibility for widget exports.  
Only one parameter except `meta` can be non-null.
- **`id`**: The id from the widget to restore it.
- **`networkUrl`**: The network url to the widget to restore it. That can only restore images.
- **`assetPath`**: The asset path to the widget to restore it. That can only restore images.
- **`fileUrl`**: The file url to the widget to restore it. That can only restore images.
- **`meta`**: This can be used to store additional information about the widget layer that may be needed for import/export operations.

### 3. **Export Process Optimization:**  
The introduction of `exportConfigs` eliminates the need to convert widgets to `Uint8List`, improving both export quality and speed.

---

### Example:
Add to the editor:
```dart
editor.addLayer(
  WidgetLayer(
    exportConfigs: const WidgetLayerExportConfigs(
      id: 'my-special-container',

      /// Alternatively, you can use one of the parameters 
      /// listed below instead of the id, which does not 
      /// require setting up the widgetLoader. However, 
      /// please note that for complex widgets, this 
      /// approach may slightly alter their size.
      ///
      /// networkUrl: '',
      /// assetPath: '',
      /// fileUrl: '',
      ///
      /// The parameter `meta` can be used to store additional information 
      /// about the widget layer that may be needed for import/export operations.
    ),
    widget: Container(
      width: 100,
      height: 100,
      color: Colors.amber,
    ),
  ),
);
```
Import:
```dart
editor.importStateHistory(
  ImportStateHistory.fromJson(
    savedHistory,
    configs: ImportEditorConfigs(
      widgetLoader: (
         String id, {
         Map<String, dynamic>? meta,
      }) {
        switch (id) {
          /// If the sticker has an id in the exportConfigs, the editor will attempt to load it using that id.
          case 'my-special-container':
            return Container(
              width: 100,
              height: 100,
              color: Colors.amber,
            );
          /// ... other widgets
        }
        throw ArgumentError(
          'No widget found for the given id: $id',
        );
      },
    ),
  ),
);
```

---

### Documentation Updates

Updated documentation for the [import example](https://github.com/hm21/pro_image_editor/blob/stable/example/lib/features/import_export_example.dart) and the [stickers example](https://github.com/hm21/pro_image_editor/blob/stable/example/lib/features/stickers_example.dart) showcases the new export/import workflow in detail.

---

### Why this Change Matters
- Improved Code Readability
The renaming of key components aligns with their purpose, making the code easier to understand.

- Maintainability
The separation of concerns for configuration data allows for cleaner imports/exports.

- Enhanced User Control
Developers can specify exactly how widgets should be imported/exported using exportConfigs without unnecessary conversions, preserving fidelity and improving performance.