### PR TITLE
fix: dehardcore paint editor icon colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.0.2
+- **FIX**(paint-editor): Resolve the issue where the paint editor did not use `appBarColor` from the style configuration. More details in PR [#333](https://github.com/hm21/pro_image_editor/issues/333)
+
 ## 8.0.1
 - **FIX**(layer-interaction): Fix issue where layers remove-area still appear when attempting to move a layer, even when `enableMove` is set to `false`. Resolves issue [#332](https://github.com/hm21/pro_image_editor/issues/332)
 - **FEAT**(layer-interaction): Introduce `enableEdit` to the layer interaction options, allowing users to disable direct editing of text layers.

--- a/lib/features/paint_editor/widgets/paint_editor_appbar.dart
+++ b/lib/features/paint_editor/widgets/paint_editor_appbar.dart
@@ -218,7 +218,7 @@ class PaintEditorAppBar extends StatelessWidget implements PreferredSizeWidget {
             padding: const EdgeInsets.symmetric(horizontal: 8),
             icon: Icon(
               paintEditorConfigs.icons.lineWeight,
-              color: Colors.white,
+              color: paintEditorConfigs.style.appBarColor,
             ),
             onPressed: onOpenLineWeightBottomSheet,
           ),
@@ -230,7 +230,7 @@ class PaintEditorAppBar extends StatelessWidget implements PreferredSizeWidget {
               !isFillMode
                   ? paintEditorConfigs.icons.noFill
                   : paintEditorConfigs.icons.fill,
-              color: Colors.white,
+              color: paintEditorConfigs.style.appBarColor,
             ),
             onPressed: onToggleFill,
           ),
@@ -240,7 +240,7 @@ class PaintEditorAppBar extends StatelessWidget implements PreferredSizeWidget {
             padding: const EdgeInsets.symmetric(horizontal: 8),
             icon: Icon(
               paintEditorConfigs.icons.changeOpacity,
-              color: Colors.white,
+              color: paintEditorConfigs.style.appBarColor,
             ),
             onPressed: onOpenOpacityBottomSheet,
           ),
@@ -253,7 +253,7 @@ class PaintEditorAppBar extends StatelessWidget implements PreferredSizeWidget {
           padding: const EdgeInsets.symmetric(horizontal: 8),
           icon: Icon(
             paintEditorConfigs.icons.undoAction,
-            color: canUndo ? Colors.white : Colors.white.withAlpha(80),
+            color: canUndo ? paintEditorConfigs.style.appBarColor : paintEditorConfigs.style.appBarColor.withAlpha(80),
           ),
           onPressed: onUndo,
         ),
@@ -262,7 +262,7 @@ class PaintEditorAppBar extends StatelessWidget implements PreferredSizeWidget {
           padding: const EdgeInsets.symmetric(horizontal: 8),
           icon: Icon(
             paintEditorConfigs.icons.redoAction,
-            color: canRedo ? Colors.white : Colors.white.withAlpha(80),
+            color: canUndo ? paintEditorConfigs.style.appBarColor : paintEditorConfigs.style.appBarColor.withAlpha(80),
           ),
           onPressed: onRedo,
         ),

--- a/lib/features/paint_editor/widgets/paint_editor_appbar.dart
+++ b/lib/features/paint_editor/widgets/paint_editor_appbar.dart
@@ -253,7 +253,9 @@ class PaintEditorAppBar extends StatelessWidget implements PreferredSizeWidget {
           padding: const EdgeInsets.symmetric(horizontal: 8),
           icon: Icon(
             paintEditorConfigs.icons.undoAction,
-            color: canUndo ? paintEditorConfigs.style.appBarColor : paintEditorConfigs.style.appBarColor.withAlpha(80),
+            color: canUndo
+                ? paintEditorConfigs.style.appBarColor
+                : paintEditorConfigs.style.appBarColor.withAlpha(80),
           ),
           onPressed: onUndo,
         ),
@@ -262,7 +264,9 @@ class PaintEditorAppBar extends StatelessWidget implements PreferredSizeWidget {
           padding: const EdgeInsets.symmetric(horizontal: 8),
           icon: Icon(
             paintEditorConfigs.icons.redoAction,
-            color: canUndo ? paintEditorConfigs.style.appBarColor : paintEditorConfigs.style.appBarColor.withAlpha(80),
+            color: canUndo
+                ? paintEditorConfigs.style.appBarColor
+                : paintEditorConfigs.style.appBarColor.withAlpha(80),
           ),
           onPressed: onRedo,
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 8.0.1
+version: 8.0.2
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 issue_tracker: https://github.com/hm21/pro_image_editor/issues/


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Allows for setting icon colors for customized appBars

![image](https://github.com/user-attachments/assets/a7782b5f-6006-4adb-b637-18c60198decd)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
Used `paintEditorConfigs.style.appBarColor` for icon colors of the appBar
