### PR TITLE
feat(layer-interaction): add enableEdit option and fix layer move issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.0.1
+- **FIX**(layer-interaction): Fix issue where layers remove-area still appear when attempting to move a layer, even when `enableMove` is set to `false`. Resolves issue [#332](https://github.com/hm21/pro_image_editor/issues/332)
+- **FEAT**(layer-interaction): Introduce `enableEdit` to the layer interaction options, allowing users to disable direct editing of text layers.
+
 ## 8.0.0
 
 #### Features

--- a/lib/core/models/layers/layer_interaction.dart
+++ b/lib/core/models/layers/layer_interaction.dart
@@ -14,11 +14,13 @@ class LayerInteraction {
   /// - [enableScale]: Enables the ability to scale the layer.
   /// - [enableRotate]: Enables the ability to rotate the layer.
   /// - [enableSelection]: Enables the ability to select the layer.
+  /// - [enableEdit]: Enables the ability to edit the layer.
   LayerInteraction({
     this.enableMove = true,
     this.enableScale = true,
     this.enableRotate = true,
     this.enableSelection = true,
+    this.enableEdit = true,
   });
 
   /// Creates a [LayerInteraction] instance from a [Map].
@@ -38,6 +40,7 @@ class LayerInteraction {
       enableScale: map[keyConverter('enableScale')] ?? false,
       enableRotate: map[keyConverter('enableRotate')] ?? false,
       enableSelection: map[keyConverter('enableSelection')] ?? false,
+      enableEdit: map[keyConverter('enableEdit')] ?? false,
     );
   }
 
@@ -49,6 +52,7 @@ class LayerInteraction {
   /// - [enableScale]
   /// - [enableRotate]
   /// - [enableSelection]
+  /// - [enableEdit]
   ///
   /// This factory constructor allows for quick initialization of a
   /// [LayerInteraction] object with uniform interaction capabilities.
@@ -58,6 +62,7 @@ class LayerInteraction {
       enableScale: value,
       enableRotate: value,
       enableSelection: value,
+      enableEdit: value,
     );
   }
 
@@ -73,6 +78,10 @@ class LayerInteraction {
   /// Whether selecting the layer is enabled.
   bool enableSelection;
 
+  /// Whether the layer is editable. This option currently affects only
+  /// TextLayers or WidgetLayers when the onTapEditSticker callback is set.
+  bool enableEdit;
+
   /// Creates a copy of this [LayerInteraction] with optional overrides.
   ///
   /// - [enableMove]: If provided, overrides the current `enableMove` setting.
@@ -81,17 +90,21 @@ class LayerInteraction {
   ///   setting.
   /// - [enableSelection]: If provided, overrides the current `enableSelection`
   ///   setting.
+  /// - [enableEdit]: if provided, overrides the current `enableEdit`
+  ///   setting.
   LayerInteraction copyWith({
     bool? enableMove,
     bool? enableScale,
     bool? enableRotate,
     bool? enableSelection,
+    bool? enableEdit,
   }) {
     return LayerInteraction(
       enableMove: enableMove ?? this.enableMove,
       enableScale: enableScale ?? this.enableScale,
       enableRotate: enableRotate ?? this.enableRotate,
       enableSelection: enableSelection ?? this.enableSelection,
+      enableEdit: enableEdit ?? this.enableEdit,
     );
   }
 
@@ -105,6 +118,7 @@ class LayerInteraction {
       'enableScale': enableScale,
       'enableRotate': enableRotate,
       'enableSelection': enableSelection,
+      'enableEdit': enableEdit,
     };
   }
 
@@ -121,6 +135,7 @@ class LayerInteraction {
         'enableRotate': enableRotate,
       if (interaction.enableSelection != enableSelection)
         'enableSelection': enableSelection,
+      if (interaction.enableEdit != enableEdit) 'enableEdit': enableEdit,
     };
   }
 
@@ -130,7 +145,8 @@ class LayerInteraction {
     return 'LayerInteraction(enableMove: $enableMove, '
         'enableScale: $enableScale, '
         'enableRotate: $enableRotate, '
-        'enableSelection: $enableSelection)';
+        'enableSelection: $enableSelection, '
+        'enableEdit: $enableEdit)';
   }
 
   /// Compares this [LayerInteraction] instance with another for equality.
@@ -145,7 +161,8 @@ class LayerInteraction {
         other.enableMove == enableMove &&
         other.enableScale == enableScale &&
         other.enableRotate == enableRotate &&
-        other.enableSelection == enableSelection;
+        other.enableSelection == enableSelection &&
+        other.enableEdit == enableEdit;
   }
 
   /// Returns a hash code for this [LayerInteraction] instance.
@@ -154,6 +171,7 @@ class LayerInteraction {
     return enableMove.hashCode ^
         enableScale.hashCode ^
         enableRotate.hashCode ^
-        enableSelection.hashCode;
+        enableSelection.hashCode ^
+        enableEdit.hashCode;
   }
 }

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -2077,6 +2077,9 @@ class ProImageEditorState extends State<ProImageEditor>
   }
 
   Widget _buildRemoveIcon() {
+    if (_activeLayer?.interaction.enableMove == false) {
+      return const SizedBox.shrink();
+    }
     return MainEditorRemoveLayerArea(
       layerInteraction: layerInteraction,
       layerInteractionManager: layerInteractionManager,

--- a/lib/features/main_editor/widgets/main_editor_layers.dart
+++ b/lib/features/main_editor/widgets/main_editor_layers.dart
@@ -115,7 +115,7 @@ class MainEditorLayers extends StatelessWidget {
       layerInteractionManager.selectedLayerId =
           layer.id == layerInteractionManager.selectedLayerId ? '' : layer.id;
       checkInteractiveViewer();
-    } else if (layer is TextLayer) {
+    } else if (layer is TextLayer && layer.interaction.enableEdit) {
       onTextLayerTap(layer);
     }
   }

--- a/lib/shared/services/import_export/constants/minified_keys.dart
+++ b/lib/shared/services/import_export/constants/minified_keys.dart
@@ -69,6 +69,7 @@ const Map<String, String> kMinifiedLayerInteractionKeys = {
   'enableScale': 's',
   'enableRotate': 'r',
   'enableSelection': 't',
+  'enableEdit': 'e',
 };
 
 /// A constant map containing minified paint-item keys for import/export

--- a/lib/shared/services/import_export/utils/key_minifier.dart
+++ b/lib/shared/services/import_export/utils/key_minifier.dart
@@ -1,4 +1,4 @@
-import 'package:pro_image_editor/shared/services/import_export/constants/minified_keys.dart';
+import '/shared/services/import_export/constants/minified_keys.dart';
 
 /// A service class responsible for minifying or preserving keys in data
 /// structures, such as for history, layers, references, and other maps.

--- a/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
+++ b/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
@@ -2,15 +2,15 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:pro_image_editor/core/models/custom_widgets/utils/custom_widgets_typedef.dart';
-import 'package:pro_image_editor/shared/widgets/reactive_widgets/reactive_custom_widget.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';
+import '/core/models/custom_widgets/utils/custom_widgets_typedef.dart';
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/layers/layer.dart';
 import '/plugins/defer_pointer/defer_pointer.dart';
+import '/shared/widgets/reactive_widgets/reactive_custom_widget.dart';
 import '../models/layer_item_interaction.dart';
 import 'layer_interaction_border_painter.dart';
 import 'layer_interaction_button.dart';
@@ -210,7 +210,8 @@ class _LayerInteractionHelperWidgetState
   }
 
   List<LayerInteractionItem> _buildDefaultInteractions() {
-    bool isLayerEditable = widget.layerData.runtimeType == TextLayer ||
+    bool isLayerEditable = widget.layerData.interaction.enableEdit &&
+            widget.layerData.runtimeType == TextLayer ||
         (widget.layerData.runtimeType == WidgetLayer &&
             widget.callbacks.stickerEditorCallbacks?.onTapEditSticker != null);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 8.0.0
+version: 8.0.1
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 issue_tracker: https://github.com/hm21/pro_image_editor/issues/


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #332


## What is the new behavior?

- Fix issue where layers remove-area still appear when attempting to move a layer, even when `enableMove` is set to `false`.
- Introduce `enableEdit` to the layer interaction options, allowing users to disable direct editing of text layers.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
