### PR TITLE
fix(import/export): resolve issue with importing exported stickers in JSON file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 8.0.4
+- **FIX**(export/import): Resolve an issue where exported stickers within the JSON file could no longer be imported Resolves issue [#334](https://github.com/hm21/pro_image_editor/issues/334)
+
 ## 8.0.3
 - **FIX**(blur-editor): Resolve issue where the slider animation does not work in the blur editor.
 - **FIX**(layer-context-menu): Resolve issue where the context menu is incorrectly positioned when the editor is embedded within the screen.

--- a/lib/shared/services/import_export/import_state_history.dart
+++ b/lib/shared/services/import_export/import_state_history.dart
@@ -67,7 +67,7 @@ class ImportStateHistory {
     final version = map[minifier.convertMainKey('version')] as String? ??
         ExportImportVersion.version_1_0_0;
     final stateHistory = <EditorStateHistory>[];
-    final widgetRecords = _parseWidgetRecords(map, version);
+    final widgetRecords = _parseWidgetRecords(map, version, minifier);
     final lastRenderedImgSize =
         safeParseSize(map[minifier.convertMainKey('lastRenderedImgSize')]);
     final List<EditorImage> requirePrecacheList = [];
@@ -193,7 +193,10 @@ class ImportStateHistory {
   }
 
   static List<Uint8List> _parseWidgetRecords(
-      Map<String, dynamic> map, String version) {
+    Map<String, dynamic> map,
+    String version,
+    EditorKeyMinifier minifier,
+  ) {
     List<dynamic> items = [];
     switch (version) {
       case ExportImportVersion.version_1_0_0:
@@ -203,7 +206,9 @@ class ImportStateHistory {
         items = (map['stickers'] as List<dynamic>? ?? []);
         break;
       default:
-        items = (map['widgetRecords'] as List<dynamic>? ?? []);
+        items =
+            (map[minifier.convertMainKey('widgetRecords')] as List<dynamic>? ??
+                []);
         break;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 8.0.3
+version: 8.0.4
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 issue_tracker: https://github.com/hm21/pro_image_editor/issues/


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #334


## What is the new behavior?
Resolve an issue where exported stickers within the JSON file could no longer be imported.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
