### PR TITLE
fix: resolve various UI and functionality issues in paint editor, layers, and import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
+# 8.1.2
+- **FIX**(paint-editor): Ensure bottombar selection updates in UI when changed.
+- **FIX**(paint-editor): Correct appBar canRedo to use the proper function instead of canUndo.
+
 # 8.1.1
 - **FIX**(crop_rotate_editor): Fixed an issue where the crop-rotate editor would throw multiple errors when reopened. Resolves issue [#236](https://github.com/hm21/pro_image_editor/issues/236) and [#237](https://github.com/hm21/pro_image_editor/issues/237).
 - **PERF**(mediaquery): Replaces MediaQuery.of(...) with MediaQuery.sizeOf(...) to optimize performance and minimize unnecessary widget rebuilds.  
-
 
 # 8.1.0
 - **FEAT**(layer): Added new methods `lockAllLayers` and `unlockAllLayers` to the main editor, enabling direct locking or unlocking of all layers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 8.1.2
 - **FIX**(paint-editor): Ensure bottombar selection updates in UI when changed.
 - **FIX**(paint-editor): Correct appBar canRedo to use the proper function instead of canUndo.
+- **FIX**(layer): Resolve issue where selecting layers that overlap did not function as expected. Resolves issue [#282](https://github.com/hm21/pro_image_editor/issues/282)
 
 # 8.1.1
 - **FIX**(crop_rotate_editor): Fixed an issue where the crop-rotate editor would throw multiple errors when reopened. Resolves issue [#236](https://github.com/hm21/pro_image_editor/issues/236) and [#237](https://github.com/hm21/pro_image_editor/issues/237).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **FIX**(paint-editor): Ensure bottombar selection updates in UI when changed.
 - **FIX**(paint-editor): Correct appBar canRedo to use the proper function instead of canUndo.
 - **FIX**(layer): Resolve issue where selecting layers that overlap did not function as expected. Resolves issue [#282](https://github.com/hm21/pro_image_editor/issues/282)
+- **FIX**(import): Resolve issue where transformations exported from the crop-rotate editor were not properly imported.
 
 # 8.1.1
 - **FIX**(crop_rotate_editor): Fixed an issue where the crop-rotate editor would throw multiple errors when reopened. Resolves issue [#236](https://github.com/hm21/pro_image_editor/issues/236) and [#237](https://github.com/hm21/pro_image_editor/issues/237).

--- a/lib/features/main_editor/widgets/main_editor_layers.dart
+++ b/lib/features/main_editor/widgets/main_editor_layers.dart
@@ -8,13 +8,14 @@ import '/features/main_editor/controllers/main_editor_controllers.dart';
 import '/features/main_editor/services/layer_interaction_manager.dart';
 import '/features/main_editor/services/sizes_manager.dart';
 import '/plugins/defer_pointer/defer_pointer.dart';
+import '/shared/utils/unique_id_generator.dart';
 import '/shared/widgets/extended/extended_mouse_cursor.dart';
 import '/shared/widgets/layer/layer_widget.dart';
 import '../main_editor.dart';
 
 /// A widget that manages and displays layers in the main editor, handling
 /// interactions, configurations, and callbacks for user actions.
-class MainEditorLayers extends StatelessWidget {
+class MainEditorLayers extends StatefulWidget {
   /// Creates a `MainEditorLayers` widget with the necessary configurations,
   /// managers, and callbacks.
   ///
@@ -99,86 +100,100 @@ class MainEditorLayers extends StatelessWidget {
   /// Callback triggered when the context menu is toggled.
   final Function(bool isOpen)? onContextMenuToggled;
 
+  @override
+  State<MainEditorLayers> createState() => _MainEditorLayersState();
+}
+
+class _MainEditorLayersState extends State<MainEditorLayers> {
+  final _deferId = ValueNotifier(generateUniqueId());
+
   // Helper methods for handling layer interactions
   void _handleEditTap(int index, Layer layer) {
     if (layer is TextLayer) {
-      onTextLayerTap(layer);
+      widget.onTextLayerTap(layer);
     } else if (layer is WidgetLayer) {
-      callbacks.stickerEditorCallbacks?.onTapEditSticker
-          ?.call(state, layer, index);
+      widget.callbacks.stickerEditorCallbacks?.onTapEditSticker
+          ?.call(widget.state, layer, index);
     }
   }
 
   void _handleLayerTap(Layer layer) {
-    if (layerInteractionManager.layersAreSelectable(configs) &&
+    if (widget.layerInteractionManager.layersAreSelectable(widget.configs) &&
         layer.interaction.enableSelection) {
-      layerInteractionManager.selectedLayerId =
-          layer.id == layerInteractionManager.selectedLayerId ? '' : layer.id;
-      checkInteractiveViewer();
+      widget.layerInteractionManager.selectedLayerId =
+          layer.id == widget.layerInteractionManager.selectedLayerId
+              ? ''
+              : layer.id;
+      widget.checkInteractiveViewer();
     } else if (layer is TextLayer && layer.interaction.enableEdit) {
-      onTextLayerTap(layer);
+      widget.onTextLayerTap(layer);
     }
   }
 
   void _handleTapUp(Layer layer) {
-    if (layerInteractionManager.hoverRemoveBtn) {
-      state.removeLayer(layer);
+    if (widget.layerInteractionManager.hoverRemoveBtn) {
+      widget.state.removeLayer(layer);
     }
-    controllers.uiLayerCtrl.add(null);
-    callbacks.mainEditorCallbacks?.handleUpdateUI();
-    state.selectedLayerIndex = -1;
-    checkInteractiveViewer();
+    widget.controllers.uiLayerCtrl.add(null);
+    widget.callbacks.mainEditorCallbacks?.handleUpdateUI();
+    widget.state.selectedLayerIndex = -1;
+    widget.checkInteractiveViewer();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _deferId.value = generateUniqueId();
+    });
   }
 
   void _handleTapDown(int index, Layer layer) {
-    state.selectedLayerIndex = index;
-    setTempLayer(layer);
-    checkInteractiveViewer();
+    widget.state.selectedLayerIndex = index;
+    widget.setTempLayer(layer);
+    widget.checkInteractiveViewer();
   }
 
   void _handleScaleRotateDown(int index, Size layerOriginalSize, Layer layer) {
-    state.selectedLayerIndex = index;
-    layerInteractionManager
+    widget.state.selectedLayerIndex = index;
+    widget.layerInteractionManager
       ..rotateScaleLayerSizeHelper = layerOriginalSize
       ..rotateScaleLayerScaleHelper = layer.scale;
-    checkInteractiveViewer();
+    widget.checkInteractiveViewer();
   }
 
   void _handleScaleRotateUp() {
-    layerInteractionManager
+    widget.layerInteractionManager
       ..rotateScaleLayerSizeHelper = null
       ..rotateScaleLayerScaleHelper = null;
-    state.setState(() => state.selectedLayerIndex = -1);
-    checkInteractiveViewer();
-    callbacks.mainEditorCallbacks?.handleUpdateUI();
+    widget.state.setState(() => widget.state.selectedLayerIndex = -1);
+    widget.checkInteractiveViewer();
+    widget.callbacks.mainEditorCallbacks?.handleUpdateUI();
   }
 
   void _handleRemoveLayer(Layer layer) {
-    state.setState(() => state.removeLayer(layer));
-    callbacks.mainEditorCallbacks?.handleUpdateUI();
+    widget.state.setState(() => widget.state.removeLayer(layer));
+    widget.callbacks.mainEditorCallbacks?.handleUpdateUI();
   }
 
   /// Handles mouse hover events to change the cursor style
   void _handleMouseHover(PointerHoverEvent event) {
-    final bool hasHit = activeLayers
+    final bool hasHit = widget.activeLayers
         .any((element) => element is PaintLayer && element.item.hit);
 
-    final activeCursor = mouseCursorsKey.currentState!.currentCursor;
-    final moveCursor = layerInteraction.style.hoverCursor;
+    final activeCursor = widget.mouseCursorsKey.currentState!.currentCursor;
+    final moveCursor = widget.layerInteraction.style.hoverCursor;
 
     if (hasHit && activeCursor != moveCursor) {
-      mouseCursorsKey.currentState!.setCursor(moveCursor);
+      widget.mouseCursorsKey.currentState!.setCursor(moveCursor);
     } else if (!hasHit && activeCursor != SystemMouseCursors.basic) {
-      mouseCursorsKey.currentState!.setCursor(SystemMouseCursors.basic);
+      widget.mouseCursorsKey.currentState!.setCursor(SystemMouseCursors.basic);
     }
   }
 
   @override
   Widget build(BuildContext context) {
     return IgnorePointer(
-      ignoring: selectedLayerIndex >= 0,
+      ignoring: widget.selectedLayerIndex >= 0,
       child: StreamBuilder<bool>(
-        stream: controllers.layerHeroResetCtrl.stream,
+        stream: widget.controllers.layerHeroResetCtrl.stream,
         initialData: false,
         builder: (context, resetLayerSnapshot) {
           // Render an empty container when resetting layers
@@ -194,22 +209,28 @@ class MainEditorLayers extends StatelessWidget {
   Widget _buildLayerRepaintBoundary() {
     return RepaintBoundary(
       child: ExtendedMouseRegion(
-        key: mouseCursorsKey,
+        key: widget.mouseCursorsKey,
         onHover: isDesktop ? _handleMouseHover : null,
-        child: DeferredPointerHandler(
-          child: StreamBuilder(
-            stream: controllers.uiLayerCtrl.stream,
-            builder: (context, snapshot) {
-              return Stack(
-                children: activeLayers
-                    .asMap()
-                    .entries
-                    .map(_buildLayerWidget)
-                    .toList(),
+        child: ValueListenableBuilder(
+            valueListenable: _deferId,
+            builder: (_, deferId, __) {
+              return DeferredPointerHandler(
+                id: deferId,
+                selectedLayerId: widget.layerInteractionManager.selectedLayerId,
+                child: StreamBuilder(
+                  stream: widget.controllers.uiLayerCtrl.stream,
+                  builder: (context, snapshot) {
+                    return Stack(
+                      children: widget.activeLayers
+                          .asMap()
+                          .entries
+                          .map(_buildLayerWidget)
+                          .toList(),
+                    );
+                  },
+                ),
               );
-            },
-          ),
-        ),
+            }),
       ),
     );
   }
@@ -220,22 +241,24 @@ class MainEditorLayers extends StatelessWidget {
     Layer layer = entry.value;
     return LayerWidget(
       key: layer.key,
-      configs: configs,
-      callbacks: callbacks,
-      editorCenterX: sizesManager.editorSize.width / 2,
-      editorCenterY: sizesManager.editorCenterY(selectedLayerIndex),
+      configs: widget.configs,
+      callbacks: widget.callbacks,
+      editorCenterX: widget.sizesManager.editorSize.width / 2,
+      editorCenterY:
+          widget.sizesManager.editorCenterY(widget.selectedLayerIndex),
       layerData: layer,
-      enableHitDetection: layerInteractionManager.enabledHitDetection,
-      selected: layerInteractionManager.selectedLayerId == layer.id,
-      isInteractive: !isSubEditorOpen,
-      highPerformanceMode: layerInteractionManager.freeStyleHighPerformance,
+      enableHitDetection: widget.layerInteractionManager.enabledHitDetection,
+      selected: widget.layerInteractionManager.selectedLayerId == layer.id,
+      isInteractive: !widget.isSubEditorOpen,
+      highPerformanceMode:
+          widget.layerInteractionManager.freeStyleHighPerformance,
       onEditTap: () => _handleEditTap(index, layer),
       onTap: _handleLayerTap,
       onTapUp: () => _handleTapUp(layer),
       onTapDown: () => _handleTapDown(index, layer),
       onScaleRotateDown: (details, layerOriginalSize) =>
           _handleScaleRotateDown(index, layerOriginalSize, layer),
-      onContextMenuToggled: onContextMenuToggled,
+      onContextMenuToggled: widget.onContextMenuToggled,
       onScaleRotateUp: (details) => _handleScaleRotateUp(),
       onRemoveTap: () => _handleRemoveLayer(layer),
     );

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -447,6 +447,7 @@ class PaintEditorState extends State<PaintEditor>
       mode == PaintMode.moveAndZoom,
     );
     _paintCanvas.currentState?.setState(() {});
+    setState(() {});
   }
 
   /// Undoes the last action performed in the paint editor.

--- a/lib/features/paint_editor/widgets/paint_editor_appbar.dart
+++ b/lib/features/paint_editor/widgets/paint_editor_appbar.dart
@@ -264,7 +264,7 @@ class PaintEditorAppBar extends StatelessWidget implements PreferredSizeWidget {
           padding: const EdgeInsets.symmetric(horizontal: 8),
           icon: Icon(
             paintEditorConfigs.icons.redoAction,
-            color: canUndo
+            color: canRedo
                 ? paintEditorConfigs.style.appBarColor
                 : paintEditorConfigs.style.appBarColor.withAlpha(80),
           ),

--- a/lib/features/paint_editor/widgets/paint_editor_bottombar.dart
+++ b/lib/features/paint_editor/widgets/paint_editor_bottombar.dart
@@ -58,6 +58,12 @@ class PaintEditorBottombar extends StatelessWidget {
   /// Callback triggered when a new paint mode is selected.
   final Function(PaintMode mode) setMode;
 
+  Color _getColor(PaintMode mode) {
+    return paintMode == mode
+        ? configs.style.bottomBarActiveItemColor
+        : configs.style.bottomBarInactiveItemColor;
+  }
+
   @override
   Widget build(BuildContext context) {
     double minWidth = min(MediaQuery.sizeOf(context).width, 600);
@@ -85,68 +91,58 @@ class PaintEditorBottombar extends StatelessWidget {
                       ? maxWidth
                       : double.infinity,
                 ),
-                child: StatefulBuilder(builder: (context, setStateBottomBar) {
-                  Color getColor(PaintMode mode) {
-                    return paintMode == mode
-                        ? configs.style.bottomBarActiveItemColor
-                        : configs.style.bottomBarInactiveItemColor;
-                  }
-
-                  return Wrap(
-                    direction: Axis.horizontal,
-                    alignment: WrapAlignment.spaceAround,
-                    runAlignment: WrapAlignment.spaceAround,
-                    crossAxisAlignment: WrapCrossAlignment.center,
-                    children: <Widget>[
-                      if (enableZoom) ...[
-                        FlatIconTextButton(
-                          label: Text(
-                            i18n.moveAndZoom,
-                            style: TextStyle(
-                              fontSize: 10.0,
-                              color: getColor(PaintMode.moveAndZoom),
-                            ),
+                child: Wrap(
+                  direction: Axis.horizontal,
+                  alignment: WrapAlignment.spaceAround,
+                  runAlignment: WrapAlignment.spaceAround,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: <Widget>[
+                    if (enableZoom) ...[
+                      FlatIconTextButton(
+                        label: Text(
+                          i18n.moveAndZoom,
+                          style: TextStyle(
+                            fontSize: 10.0,
+                            color: _getColor(PaintMode.moveAndZoom),
                           ),
-                          icon: Icon(
-                            configs.icons.moveAndZoom,
-                            color: getColor(PaintMode.moveAndZoom),
-                          ),
-                          onPressed: () {
-                            setMode(PaintMode.moveAndZoom);
-                            setStateBottomBar(() {});
-                          },
                         ),
-                        Container(
-                          margin: const EdgeInsets.symmetric(horizontal: 4),
-                          height: kBottomNavigationBarHeight - 14,
-                          width: 1,
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(2),
-                            color: configs.style.bottomBarInactiveItemColor,
-                          ),
-                        )
-                      ],
-                      ...List.generate(
-                        paintModes.length,
-                        (index) {
-                          PaintModeBottomBarItem item = paintModes[index];
-                          Color color = getColor(item.mode);
-                          return FlatIconTextButton(
-                            label: Text(
-                              item.label,
-                              style: TextStyle(fontSize: 10.0, color: color),
-                            ),
-                            icon: Icon(item.icon, color: color),
-                            onPressed: () {
-                              setMode(item.mode);
-                              setStateBottomBar(() {});
-                            },
-                          );
+                        icon: Icon(
+                          configs.icons.moveAndZoom,
+                          color: _getColor(PaintMode.moveAndZoom),
+                        ),
+                        onPressed: () {
+                          setMode(PaintMode.moveAndZoom);
                         },
                       ),
+                      Container(
+                        margin: const EdgeInsets.symmetric(horizontal: 4),
+                        height: kBottomNavigationBarHeight - 14,
+                        width: 1,
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(2),
+                          color: configs.style.bottomBarInactiveItemColor,
+                        ),
+                      )
                     ],
-                  );
-                }),
+                    ...List.generate(
+                      paintModes.length,
+                      (index) {
+                        PaintModeBottomBarItem item = paintModes[index];
+                        Color color = _getColor(item.mode);
+                        return FlatIconTextButton(
+                          label: Text(
+                            item.label,
+                            style: TextStyle(fontSize: 10.0, color: color),
+                          ),
+                          icon: Icon(item.icon, color: color),
+                          onPressed: () {
+                            setMode(item.mode);
+                          },
+                        );
+                      },
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/plugins/defer_pointer/defer_pointer.dart
+++ b/lib/plugins/defer_pointer/defer_pointer.dart
@@ -6,6 +6,7 @@ import 'dart:collection';
 // Flutter imports:
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import '/shared/utils/unique_id_generator.dart';
 
 part 'deferred_pointer_handler_link.dart';
 part 'deferred_pointer_handler.dart';

--- a/lib/plugins/defer_pointer/deferred_pointer_handler.dart
+++ b/lib/plugins/defer_pointer/deferred_pointer_handler.dart
@@ -6,9 +6,18 @@ part of 'defer_pointer.dart';
 /// Deferred painting (aka 'paint on top') is optional and can be defined per
 /// [DeferPointer].
 class DeferredPointerHandler extends StatefulWidget {
-  const DeferredPointerHandler({super.key, required this.child, this.link});
+  const DeferredPointerHandler({
+    super.key,
+    required this.child,
+    this.link,
+    this.id,
+    this.selectedLayerId,
+  });
   final Widget child;
   final DeferredPointerHandlerLink? link;
+  final String? id;
+  final String? selectedLayerId;
+
   @override
   DeferredPointerHandlerState createState() => DeferredPointerHandlerState();
 
@@ -31,21 +40,38 @@ class DeferredPointerHandlerState extends State<DeferredPointerHandler> {
   final DeferredPointerHandlerLink _link = DeferredPointerHandlerLink();
   get link => _link;
 
+  late String _id;
+
+  @override
+  void initState() {
+    super.initState();
+    _setId();
+  }
+
+  void _setId() {
+    _id = widget.id ?? generateUniqueId();
+  }
+
   @override
   void didUpdateWidget(covariant DeferredPointerHandler oldWidget) {
     if (widget.link != null) {
       _link.removeAll();
     }
+    if (widget.id != oldWidget.id) _setId();
     super.didUpdateWidget(oldWidget);
   }
 
   @override
   Widget build(BuildContext context) {
-    return _InheritedDeferredPaintSurface(
-      state: this,
-      child: _DeferredHitTargetRenderObjectWidget(
-        link: widget.link ?? _link,
-        child: widget.child,
+    return DeferManager(
+      id: _id,
+      selectedLayerId: widget.selectedLayerId ?? '',
+      child: _InheritedDeferredPaintSurface(
+        state: this,
+        child: _DeferredHitTargetRenderObjectWidget(
+          link: widget.link ?? _link,
+          child: widget.child,
+        ),
       ),
     );
   }
@@ -132,4 +158,30 @@ class _InheritedDeferredPaintSurface extends InheritedWidget {
   final DeferredPointerHandlerState state;
   @override
   bool updateShouldNotify(covariant InheritedWidget oldWidget) => false;
+}
+
+class DeferManager extends InheritedWidget {
+  const DeferManager({
+    super.key,
+    required super.child,
+    required this.id,
+    this.selectedLayerId = '',
+  });
+
+  final String selectedLayerId;
+  final String id;
+
+  static DeferManager? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<DeferManager>();
+  }
+
+  static DeferManager of(BuildContext context) {
+    final DeferManager? result = maybeOf(context);
+    assert(result != null, 'No DeferManager found in context');
+    return result!;
+  }
+
+  @override
+  bool updateShouldNotify(DeferManager oldWidget) =>
+      id != oldWidget.id || selectedLayerId != oldWidget.selectedLayerId;
 }

--- a/lib/shared/services/import_export/import_state_history.dart
+++ b/lib/shared/services/import_export/import_state_history.dart
@@ -149,7 +149,9 @@ class ImportStateHistory {
       final transformConfigs = historyItem[transformKey] != null &&
               Map.from(historyItem[transformKey]).isNotEmpty
           ? TransformConfigs.fromMap(historyItem[transformKey])
-          : TransformConfigs.empty();
+          : stateHistory.isNotEmpty
+              ? stateHistory.last.transformConfigs
+              : TransformConfigs.empty();
 
       stateHistory.add(EditorStateHistory(
         blur: blur,

--- a/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
+++ b/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
@@ -154,13 +154,20 @@ class _LayerInteractionHelperWidgetState
 
   @override
   Widget build(BuildContext context) {
-    if (!widget.isInteractive) {
+    String layerId = widget.layerData.id;
+    var deferManager = DeferManager.maybeOf(context);
+
+    if (!widget.isInteractive ||
+        (!widget.selected && deferManager?.selectedLayerId != '')) {
       // Return the child widget directly if the layer is not interactive.
       return widget.child;
     } else if (!widget.selected) {
       // Use a defer pointer if the layer is not selected, preventing
       // interaction.
-      return DeferPointer(child: widget.child);
+      return DeferPointer(
+        key: ValueKey('Defer-${deferManager?.id ?? ''}-$layerId'),
+        child: widget.child,
+      );
     }
 
     List<LayerInteractionItem> children =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 8.1.1
+version: 8.1.2
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 issue_tracker: https://github.com/hm21/pro_image_editor/issues/


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #282


## What is the new behavior?
- **FIX**(paint-editor): Ensure bottombar selection updates in UI when changed.
- **FIX**(paint-editor): Correct appBar canRedo to use the proper function instead of canUndo.
- **FIX**(layer): Resolve issue where selecting layers that overlap did not function as expected. Resolves issue [#282](https://github.com/hm21/pro_image_editor/issues/282)
- **FIX**(import): Resolve issue where transformations exported from the crop-rotate editor were not properly imported.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
