### PR TITLE
fix(generation): use captureOnlyBackgroundImageArea instead of captureOnlyDrawingBounds for background cropping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 8.1.4
+- **FIX**(generation): Use `captureOnlyBackgroundImageArea` instead of `captureOnlyDrawingBounds` for background cropping.
+
 # 8.1.3
 - **PERF**(capture-image): Improved image capture performance by minimizing its impact on the main thread.  
 

--- a/lib/shared/services/content_recorder/services/image_render_service.dart
+++ b/lib/shared/services/content_recorder/services/image_render_service.dart
@@ -153,7 +153,7 @@ class ImageRenderService {
     double pixelRatio,
   ) async {
     // If cropping is not required, return the image directly
-    if (!configs.captureOnlyDrawingBounds) {
+    if (!configs.captureOnlyBackgroundImageArea) {
       return boundary.toImage(pixelRatio: pixelRatio);
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 8.1.3
+version: 8.1.4
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 issue_tracker: https://github.com/hm21/pro_image_editor/issues/


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Use `captureOnlyBackgroundImageArea` instead of `captureOnlyDrawingBounds` for background cropping.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
