### PR TITLE
feat: allow onEscapeButton remapping

### DIFF
--- a/lib/core/models/editor_configs/main_editor_configs.dart
+++ b/lib/core/models/editor_configs/main_editor_configs.dart
@@ -15,7 +15,7 @@ class MainEditorConfigs {
   const MainEditorConfigs({
     this.enableZoom = false,
     this.enableCloseButton = true,
-    this.enableEscapeButton = true,
+    this.onEscapeButton,
     this.editorMinScale = 1.0,
     this.editorMaxScale = 5.0,
     this.transformSetup,
@@ -28,12 +28,11 @@ class MainEditorConfigs {
   /// Determines whether the close button is displayed on the widget.
   final bool enableCloseButton;
 
-  /// A boolean flag to enable or disable the escape button functionality.
+  /// A function that handles pressing the ESC key.
   ///
-  /// When set to `true`, the escape button will be enabled, allowing users
-  /// to exit the editor or perform a specific action when the escape button
-  /// is pressed. When set to `false`, the escape button will be disabled.
-  final bool enableEscapeButton;
+  /// This function is called when the ESC key is pressed.
+  /// By default it is null, which runs the default onEscape behavior.
+  final Function()? onEscapeButton;
 
   /// {@template enableZoom}
   /// Indicates whether the editor supports zoom functionality.
@@ -106,7 +105,7 @@ class MainEditorConfigs {
   /// others unchanged.
   MainEditorConfigs copyWith({
     bool? enableCloseButton,
-    bool? enableEscapeButton,
+    Function()? onEscapeButton,
     bool? enableZoom,
     double? editorMinScale,
     double? editorMaxScale,
@@ -118,7 +117,7 @@ class MainEditorConfigs {
   }) {
     return MainEditorConfigs(
       enableCloseButton: enableCloseButton ?? this.enableCloseButton,
-      enableEscapeButton: enableEscapeButton ?? this.enableEscapeButton,
+      onEscapeButton: onEscapeButton ?? this.onEscapeButton,
       enableZoom: enableZoom ?? this.enableZoom,
       editorMinScale: editorMinScale ?? this.editorMinScale,
       editorMaxScale: editorMaxScale ?? this.editorMaxScale,

--- a/lib/features/main_editor/services/desktop_interaction_manager.dart
+++ b/lib/features/main_editor/services/desktop_interaction_manager.dart
@@ -85,7 +85,9 @@ class DesktopInteractionManager {
       if (event is KeyDownEvent) {
         switch (key) {
           case 'Escape':
-            if (configs.mainEditor.enableEscapeButton) {
+            if (configs.mainEditor.onEscapeButton != null) {
+              configs.mainEditor.onEscapeButton!();
+            } else {
               onEscape();
             }
             break;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
Allows remapping the Escape Button behavior from `MainEditorConfigs` defining `onEscapeButton`
The naming of the function could be better, feel free to improve, if you accept this PR.

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently we can only toggle ESC on and off, but this is difficult since it needs to rebuild the editor or refresh the configurations. This custom behavior allows user space take care of what to do, for example whether to call `closeEditor` or `doneEditing`

Issue Number: https://github.com/hm21/pro_image_editor/discussions/354


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
