### PR TITLE
feat(callback): add onEscapeButton callback for custom ESC key handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.1.10
+- **FEAT**(callback): Introduced `onEscapeButton` callback inside `MainEditorCallbacks` to allow external handling of the Escape key logic.
+
 ## 8.1.9
 - **FIX**(text-editor): Ensure text editor layer scales correctly when editing.  
 Added `enableMainEditorZoomFactor` to `textEditorConfigs` to apply the zoom factor in the text editor as well. Resolves [#349](https://github.com/hm21/pro_image_editor/issues/349).

--- a/lib/core/models/editor_callbacks/main_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/main_editor_callbacks.dart
@@ -26,6 +26,7 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
     this.onEditorZoomScaleStart,
     this.onEditorZoomScaleUpdate,
     this.onEditorZoomScaleEnd,
+    this.onEscapeButton,
     super.onInit,
     super.onAfterViewInit,
     super.onUpdateUI,
@@ -37,23 +38,23 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
   /// A callback function that is triggered when a layer is added.
   ///
   /// The [Layer] parameter provides information about the added layer.
-  final ValueChanged<Layer>? onAddLayer;
+  final Function(Layer)? onAddLayer;
 
   /// A callback function that is triggered when a layer is updated.
   ///
   /// The [Layer] parameter provides information about the updated layer.
-  final ValueChanged<Layer>? onUpdateLayer;
+  final Function(Layer)? onUpdateLayer;
 
   /// A callback function that is triggered when a layer is removed.
   ///
   /// The [Layer] parameter provides information about the removed layer.
-  final ValueChanged<Layer>? onRemoveLayer;
+  final Function(Layer)? onRemoveLayer;
 
   /// A callback function that is triggered when a sub-editor is opened.
   ///
   /// The [SubEditor] parameter provides information about the opened
   /// sub-editor.
-  final ValueChanged<SubEditor>? onOpenSubEditor;
+  final Function(SubEditor)? onOpenSubEditor;
 
   /// A callback that is triggered when a sub-editor finishes closing.
   ///
@@ -63,7 +64,7 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
   /// resources or updating the UI.
   ///
   /// This can be `null` if no action is required when the sub-editor closes.
-  final ValueChanged<SubEditor>? onEndCloseSubEditor;
+  final Function(SubEditor)? onEndCloseSubEditor;
 
   /// A callback that is triggered when a sub-editor starts to close.
   ///
@@ -74,7 +75,7 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
   ///
   /// This can be `null` if no action is required at the start of the close
   /// process.
-  final ValueChanged<SubEditor>? onStartCloseSubEditor;
+  final Function(SubEditor)? onStartCloseSubEditor;
 
   /// A callback function that is triggered when the user `tap` on the body.
   final Function()? onTap;
@@ -87,23 +88,29 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
   /// on the body.
   final Function()? onLongPress;
 
+  /// A function that handles pressing the ESC key.
+  ///
+  /// This function is called when the ESC key is pressed.
+  /// By default it is null, which runs the default "close" behavior.
+  final Function()? onEscapeButton;
+
   /// A callback function that is triggered when a scaling gesture starts.
   ///
   /// The [ScaleStartDetails] parameter provides information about the scaling
   /// gesture.
-  final ValueChanged<ScaleStartDetails>? onScaleStart;
+  final Function(ScaleStartDetails)? onScaleStart;
 
   /// A callback function that is triggered when a scaling gesture is updated.
   ///
   /// The [ScaleUpdateDetails] parameter provides information about the scaling
   /// gesture.
-  final ValueChanged<ScaleUpdateDetails>? onScaleUpdate;
+  final Function(ScaleUpdateDetails)? onScaleUpdate;
 
   /// A callback function that is triggered when a scaling gesture ends.
   ///
   /// The [ScaleEndDetails] parameter provides information about the scaling
   /// gesture.
-  final ValueChanged<ScaleEndDetails>? onScaleEnd;
+  final Function(ScaleEndDetails)? onScaleEnd;
 
   /// Called when the user ends a pan or scale gesture on the widget.
   ///

--- a/lib/core/models/editor_configs/main_editor_configs.dart
+++ b/lib/core/models/editor_configs/main_editor_configs.dart
@@ -33,6 +33,8 @@ class MainEditorConfigs {
   /// When set to `true`, the escape button will be enabled, allowing users
   /// to exit the editor or perform a specific action when the escape button
   /// is pressed. When set to `false`, the escape button will be disabled.
+  ///
+  /// This flag has no effect when the `onEscapeButton` callback is set.
   final bool enableEscapeButton;
 
   /// {@template enableZoom}

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -385,6 +385,7 @@ class ProImageEditorState extends State<ProImageEditor>
     _controllers = MainEditorControllers(configs, callbacks);
     _desktopInteractionManager = DesktopInteractionManager(
       configs: configs,
+      callbacks: callbacks,
       context: context,
       onUpdateUI: mainEditorCallbacks?.handleUpdateUI,
       setState: setState,

--- a/lib/features/main_editor/services/desktop_interaction_manager.dart
+++ b/lib/features/main_editor/services/desktop_interaction_manager.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 // Project imports:
+import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/layers/layer.dart';
 
@@ -31,6 +32,7 @@ class DesktopInteractionManager {
   ///   onUpdateUI: myUpdateUICallback,
   ///   setState: mySetStateFunction,
   ///   configs: myEditorConfigs,
+  ///   callbacks: myEditorCallbacks,
   /// )
   /// ```
   DesktopInteractionManager({
@@ -38,6 +40,7 @@ class DesktopInteractionManager {
     required this.onUpdateUI,
     required this.setState,
     required this.configs,
+    required this.callbacks,
   });
 
   /// The build context associated with the desktop interaction manager.
@@ -65,6 +68,9 @@ class DesktopInteractionManager {
   /// during desktop interactions.
   final ProImageEditorConfigs configs;
 
+  /// A class representing callbacks for the Image Editor.
+  final ProImageEditorCallbacks callbacks;
+
   bool _ctrlDown = false;
   bool _shiftDown = false;
 
@@ -85,7 +91,9 @@ class DesktopInteractionManager {
       if (event is KeyDownEvent) {
         switch (key) {
           case 'Escape':
-            if (configs.mainEditor.enableEscapeButton) {
+            if (callbacks.mainEditorCallbacks?.onEscapeButton != null) {
+              callbacks.mainEditorCallbacks!.onEscapeButton!();
+            } else if (configs.mainEditor.enableEscapeButton) {
               onEscape();
             }
             break;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 8.1.9
+version: 8.1.10
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 issue_tracker: https://github.com/hm21/pro_image_editor/issues/


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently we can only toggle ESC on and off, but this is difficult since it needs to rebuild the editor or refresh the configurations. This custom behavior allows user space take care of what to do, for example whether to call `closeEditor` or `doneEditing`

Issue Number: #354


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
