### PR TITLE
fix(layer-stack): ensure overlay color is based on active subeditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.3.5
+- **FIX**(layer-stack): Resolved an issue where the outside overlay color on layers depended on the crop_rotate_editor instead of the active subeditor.
+
 ## 8.3.4
 - **FIX**(grounded-design): Resolved an issue in the grounded design where switching between screens caused an error due to the ScrollController.
 

--- a/lib/features/blur_editor/blur_editor.dart
+++ b/lib/features/blur_editor/blur_editor.dart
@@ -313,6 +313,7 @@ class BlurEditorState extends State<BlurEditor>
                       transformConfigs: initialTransformConfigs,
                       editorBodySize: editorBodySize,
                     ),
+                    overlayColor: blurEditorConfigs.style.background,
                     configs: configs,
                     layers: layers!,
                     clipBehavior: Clip.none,

--- a/lib/features/crop_rotate_editor/crop_rotate_editor.dart
+++ b/lib/features/crop_rotate_editor/crop_rotate_editor.dart
@@ -2317,6 +2317,7 @@ class CropRotateEditorState extends State<CropRotateEditor>
                     configs: configs,
                     layers: _rawLayers,
                     clipBehavior: Clip.none,
+                    overlayColor: cropRotateEditorConfigs.style.background,
                   ),
                 ),
             ],
@@ -2363,6 +2364,7 @@ class CropRotateEditorState extends State<CropRotateEditor>
                 configs: configs,
                 layers: _layers,
                 clipBehavior: Clip.none,
+                overlayColor: cropRotateEditorConfigs.style.background,
               ),
           ],
         );

--- a/lib/features/filter_editor/filter_editor.dart
+++ b/lib/features/filter_editor/filter_editor.dart
@@ -330,6 +330,7 @@ class FilterEditorState extends State<FilterEditor>
                     configs: configs,
                     layers: layers!,
                     clipBehavior: Clip.none,
+                    overlayColor: filterEditorConfigs.style.background,
                   ),
                 if (filterEditorConfigs.widgets.bodyItemsRecorded != null)
                   ...filterEditorConfigs.widgets.bodyItemsRecorded!(

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -813,6 +813,7 @@ class PaintEditorState extends State<PaintEditor>
                     editorBodySize: editorBodySize,
                     transformConfigs: initialTransformConfigs,
                   ),
+                  overlayColor: paintEditorConfigs.style.background,
                 ),
               _buildPainter(),
               if (paintEditorConfigs.widgets.bodyItemsRecorded != null)

--- a/lib/features/tune_editor/tune_editor.dart
+++ b/lib/features/tune_editor/tune_editor.dart
@@ -477,6 +477,7 @@ class TuneEditorState extends State<TuneEditor>
       configs: configs,
       layers: layers!,
       clipBehavior: Clip.none,
+      overlayColor: tuneEditorConfigs.style.background,
     );
   }
 

--- a/lib/shared/widgets/layer/layer_stack.dart
+++ b/lib/shared/widgets/layer/layer_stack.dart
@@ -16,7 +16,7 @@ import 'layer_widget.dart';
 /// This widget manages the display and transformation of multiple layers,
 /// allowing for complex image editing operations such as cropping, rotating,
 /// and layering effects.
-class LayerStack extends StatefulWidget {
+class LayerStack extends StatelessWidget {
   /// Creates a [LayerStack].
   ///
   /// This widget is responsible for rendering a collection of layers within a
@@ -37,6 +37,7 @@ class LayerStack extends StatefulWidget {
     super.key,
     required this.configs,
     required this.layers,
+    required this.overlayColor,
     this.cutOutsideImageArea,
     this.freeStyleHighPerformance = false,
     this.transformHelper = const TransformHelper(
@@ -46,6 +47,9 @@ class LayerStack extends StatefulWidget {
     ),
     this.clipBehavior = Clip.hardEdge,
   });
+
+  /// The outside overlay color for layers.
+  final Color overlayColor;
 
   /// The configuration settings for the image editor.
   ///
@@ -84,76 +88,55 @@ class LayerStack extends StatefulWidget {
   /// elements on the canvas, at the potential cost of rendering quality.
   final bool freeStyleHighPerformance;
 
-  @override
-  State<LayerStack> createState() => _LayerStackState();
-}
-
-/// The state class for [LayerStack].
-///
-/// This class manages the rendering and transformation of layers within the
-/// stack, applying configurations and handling initialization logic.
-
-class _LayerStackState extends State<LayerStack> {
-  late final bool _cutOutsideImageArea;
-
-  @override
-  void initState() {
-    super.initState();
-    // Determine whether to cut content outside the image area based on widget
-    // settings.
-    _cutOutsideImageArea = widget.cutOutsideImageArea ??
-        widget.configs.imageGeneration.captureOnlyBackgroundImageArea ??
-        widget.configs.imageGeneration.cropToImageBounds;
-  }
+  bool get _cutOutsideImageArea =>
+      cutOutsideImageArea ??
+      configs.imageGeneration.captureOnlyBackgroundImageArea ??
+      configs.imageGeneration.cropToImageBounds;
 
   @override
   Widget build(BuildContext context) {
     // Retrieve transformation configurations, if available.
     TransformConfigs? transformConfigs =
-        widget.transformHelper.transformConfigs != null &&
-                widget.transformHelper.transformConfigs!.isNotEmpty
-            ? widget.transformHelper.transformConfigs
+        transformHelper.transformConfigs != null &&
+                transformHelper.transformConfigs!.isNotEmpty
+            ? transformHelper.transformConfigs
             : null;
 
     return Stack(
       children: [
         IgnorePointer(
           child: Transform.scale(
-            scale: widget.transformHelper.scale,
+            scale: transformHelper.scale,
             child: Stack(
                 fit: StackFit.expand,
                 alignment: Alignment.center,
-                clipBehavior: widget.clipBehavior,
-                children: widget.layers.map((layerItem) {
+                clipBehavior: clipBehavior,
+                children: layers.map((layerItem) {
                   return LayerWidget(
-                    configs: widget.configs,
-                    highPerformanceMode: widget.freeStyleHighPerformance,
-                    editorCenterX:
-                        widget.transformHelper.editorBodySize.width / 2,
-                    editorCenterY:
-                        widget.transformHelper.editorBodySize.height / 2,
+                    configs: configs,
+                    highPerformanceMode: freeStyleHighPerformance,
+                    editorCenterX: transformHelper.editorBodySize.width / 2,
+                    editorCenterY: transformHelper.editorBodySize.height / 2,
                     layerData: layerItem,
                   );
                 }).toList()),
           ),
         ),
-        if (widget.configs.imageGeneration.captureOnlyBackgroundImageArea ??
-            widget.configs.imageGeneration.cropToImageBounds)
+        if (configs.imageGeneration.captureOnlyBackgroundImageArea ??
+            configs.imageGeneration.cropToImageBounds)
           RepaintBoundary(
             child: Hero(
               tag: 'crop_layer_painter_hero',
               child: CustomPaint(
                 foregroundPainter: _cutOutsideImageArea
                     ? CropLayerPainter(
-                        opacity: widget.configs.mainEditor.style
-                            .outsideCaptureAreaLayerOpacity,
-                        backgroundColor:
-                            widget.configs.cropRotateEditor.style.background,
+                        opacity: configs
+                            .mainEditor.style.outsideCaptureAreaLayerOpacity,
+                        backgroundColor: overlayColor,
                         imgRatio: transformConfigs?.cropRect.size.aspectRatio ??
-                            widget.transformHelper.mainImageSize.aspectRatio,
-                        isRoundCropper: widget
-                                .configs.cropRotateEditor.roundCropper ??
-                            widget.configs.cropRotateEditor.enableRoundCropper,
+                            transformHelper.mainImageSize.aspectRatio,
+                        isRoundCropper: configs.cropRotateEditor.roundCropper ??
+                            configs.cropRotateEditor.enableRoundCropper,
                         is90DegRotated:
                             transformConfigs?.is90DegRotated ?? false,
                       )

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 8.3.4
+version: 8.3.5
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 issue_tracker: https://github.com/hm21/pro_image_editor/issues/


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Resolved an issue where the outside overlay color on layers was determined by the `crop_rotate_editor` instead of the active subeditor.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
