### PR TITLE
feat: select layer call back

### DIFF
--- a/lib/core/models/editor_callbacks/main_editor/main_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/main_editor/main_editor_callbacks.dart
@@ -31,6 +31,7 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
     this.onEditorZoomScaleEnd,
     this.onEscapeButton,
     this.helperLines = const HelperLinesCallbacks(),
+    this.onSelectedLayerChanged,
     super.onInit,
     super.onAfterViewInit,
     super.onUpdateUI,
@@ -203,6 +204,15 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
   /// An instance of [HelperLinesCallbacks] that manages callback functions
   /// for handling helper line hit events.
   final HelperLinesCallbacks helperLines;
+
+  /// A callback that is called when the selected layer of layer interaction
+  /// manager changes.
+  ///
+  /// The callback is called with the id of the newly selected layer. If no
+  /// layer is selected, the callback is called with blank.
+  ///
+  /// This callback is not called when [LayerInteractionSelectable] is disabled.
+  final ValueChanged<String>? onSelectedLayerChanged;
 
   /// Handles the addition of a layer.
   ///

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -378,6 +378,7 @@ class ProImageEditorState extends State<ProImageEditor>
   late final LayerInteractionManager layerInteractionManager =
       LayerInteractionManager(
     helperLinesCallbacks: mainEditorCallbacks?.helperLines,
+    onSelectedLayerChanged: mainEditorCallbacks?.onSelectedLayerChanged,
   );
 
   /// Manager class for managing the state of the editor.

--- a/lib/features/main_editor/services/layer_interaction_manager.dart
+++ b/lib/features/main_editor/services/layer_interaction_manager.dart
@@ -25,11 +25,15 @@ class LayerInteractionManager {
   ///   to handle helper line hit events.
   LayerInteractionManager({
     required this.helperLinesCallbacks,
+    this.onSelectedLayerChanged,
   });
 
   /// An optional instance of [HelperLinesCallbacks] that defines callback
   ///  functions for handling helper line interactions.
   final HelperLinesCallbacks? helperLinesCallbacks;
+
+  /// Callback function to be called when the selected layer changes.
+  final ValueChanged<String>? onSelectedLayerChanged;
 
   /// Debounce for scaling actions in the editor.
   late Debounce scaleDebounce;
@@ -112,7 +116,16 @@ class LayerInteractionManager {
   final double hitSpan = 10;
 
   /// The ID of the currently selected layer.
-  String selectedLayerId = '';
+  String _selectedLayerId = '';
+
+  /// Returns the ID of the currently selected layer.
+  String get selectedLayerId => _selectedLayerId;
+
+  /// Sets the ID of the currently selected layer.
+  set selectedLayerId(String id) {
+    _selectedLayerId = id;
+    onSelectedLayerChanged?.call(_selectedLayerId);
+  }
 
   /// Helper variable for scaling during rotation of a layer.
   double? rotateScaleLayerScaleHelper;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, the editor does not provide a callback mechanism to notify when a user selects a layer (such as text, sticker, or emoji). This limitation restricts developers from responding to layer selection events, such as updating the UI or triggering specific actions based on the selected layer.

## What is the new behavior?
This update introduces a new callback, onLayerSelected, within the ProImageEditorCallbacks class. This callback is invoked whenever a user selects a layer in the editor, providing the selected layer id. This enhancement allows developers to handle layer selection events externally, enabling functionalities like:
	•	Highlighting the selected layer in a custom UI panel.
	•	Displaying properties or options specific to the selected layer.
	•	Implementing custom behaviors or analytics based on user interactions with layers.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
