### PR TITLE
feat(zoom): Add double-tap to zoom functionality and enhance zoom configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.6.0
+- **FEAT**(double-tap):  Support double-tap to zoom in/out when zoom is enabled. More details in Feature-Request [#429](https://github.com/hm21/pro_image_editor/pull/429).
+
 ## 9.5.2
 - **FIX**(zoom): Fixed issue where config `enableMainEditorZoomFactor` had no effect when creating a new text-layer. Resolves [#426](https://github.com/hm21/pro_image_editor/issues/426).
 

--- a/lib/core/models/editor_callbacks/main_editor/main_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/main_editor/main_editor_callbacks.dart
@@ -31,6 +31,7 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
     this.onEscapeButton,
     this.helperLines = const HelperLinesCallbacks(),
     this.onSelectedLayerChanged,
+    this.onEditorZoomMatrix4Change,
     super.onInit,
     super.onAfterViewInit,
     super.onUpdateUI,
@@ -182,6 +183,9 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
   ///  * [onEditorZoomScaleEnd], which handles the end of the same interaction.
   final GestureScaleUpdateCallback? onEditorZoomScaleUpdate;
 
+  /// Called when the editor zoom matrix changes.
+  final Function(Matrix4 value)? onEditorZoomMatrix4Change;
+
   /// {@template flutter.widgets.PopScope.onPopInvoked}
   /// Called after a route pop was handled.
   /// {@endtemplate}
@@ -320,6 +324,7 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
     GestureScaleEndCallback? onEditorZoomScaleEnd,
     GestureScaleStartCallback? onEditorZoomScaleStart,
     GestureScaleUpdateCallback? onEditorZoomScaleUpdate,
+    Function(Matrix4 value)? onEditorZoomMatrix4Change,
     PopInvokedWithResultCallback<dynamic>? onPopInvoked,
     HelperLinesCallbacks? helperLines,
     ValueChanged<String>? onSelectedLayerChanged,
@@ -350,6 +355,8 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
           onEditorZoomScaleStart ?? this.onEditorZoomScaleStart,
       onEditorZoomScaleUpdate:
           onEditorZoomScaleUpdate ?? this.onEditorZoomScaleUpdate,
+      onEditorZoomMatrix4Change:
+          onEditorZoomMatrix4Change ?? this.onEditorZoomMatrix4Change,
       onPopInvoked: onPopInvoked ?? this.onPopInvoked,
       helperLines: helperLines ?? this.helperLines,
       onSelectedLayerChanged:

--- a/lib/core/models/editor_callbacks/paint_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/paint_editor_callbacks.dart
@@ -19,6 +19,7 @@ class PaintEditorCallbacks extends StandaloneEditorCallbacks {
     this.onEditorZoomScaleEnd,
     this.onEditorZoomMatrix4Change,
     this.onOpacityChange,
+    this.onDoubleTap,
     super.onInit,
     super.onAfterViewInit,
     super.onUndo,
@@ -53,6 +54,10 @@ class PaintEditorCallbacks extends StandaloneEditorCallbacks {
 
   /// A callback function that is triggered when the color is changed.
   final Function()? onColorChanged;
+
+  /// A callback function that is triggered when the user `doubleTap`
+  /// on the body.
+  final Function()? onDoubleTap;
 
   /// Called when the user ends a pan or scale gesture on the widget.
   ///
@@ -189,6 +194,7 @@ class PaintEditorCallbacks extends StandaloneEditorCallbacks {
     GestureScaleStartCallback? onEditorZoomScaleStart,
     Function(Matrix4 value)? onEditorZoomMatrix4Change,
     GestureScaleUpdateCallback? onEditorZoomScaleUpdate,
+    Function()? onDoubleTap,
     Function()? onInit,
     Function()? onAfterViewInit,
     Function()? onUpdateUI,
@@ -211,6 +217,7 @@ class PaintEditorCallbacks extends StandaloneEditorCallbacks {
           onEditorZoomMatrix4Change ?? this.onEditorZoomMatrix4Change,
       onEditorZoomScaleUpdate:
           onEditorZoomScaleUpdate ?? this.onEditorZoomScaleUpdate,
+      onDoubleTap: onDoubleTap ?? this.onDoubleTap,
       onInit: onInit ?? this.onInit,
       onAfterViewInit: onAfterViewInit ?? this.onAfterViewInit,
       onUpdateUI: onUpdateUI ?? this.onUpdateUI,

--- a/lib/core/models/editor_configs/main_editor_configs.dart
+++ b/lib/core/models/editor_configs/main_editor_configs.dart
@@ -1,25 +1,31 @@
 import 'package:flutter/widgets.dart';
+
 import '/features/crop_rotate_editor/models/transform_factors.dart';
 import '/shared/utils/decode_image.dart';
 import '../custom_widgets/main_editor_widgets.dart';
 import '../icons/main_editor_icons.dart';
 import '../styles/main_editor_style.dart';
+import 'utils/zoom_configs.dart';
 
 export '../custom_widgets/main_editor_widgets.dart';
 export '../icons/main_editor_icons.dart';
 export '../styles/main_editor_style.dart';
 
 /// Configuration options for a main editor.
-class MainEditorConfigs {
+class MainEditorConfigs extends ZoomConfigs {
   /// Creates an instance of MainEditorConfigs with optional settings.
   const MainEditorConfigs({
-    this.enableZoom = false,
+    super.enableZoom,
+    super.editorMinScale,
+    super.editorMaxScale,
+    super.enableDoubleTapZoom,
+    super.doubleTapZoomFactor,
+    super.doubleTapZoomDuration,
+    super.doubleTapZoomCurve,
+    super.boundaryMargin,
+    this.transformSetup,
     this.enableCloseButton = true,
     this.enableEscapeButton = true,
-    this.editorMinScale = 1.0,
-    this.editorMaxScale = 5.0,
-    this.transformSetup,
-    this.boundaryMargin = EdgeInsets.zero,
     this.style = const MainEditorStyle(),
     this.icons = const MainEditorIcons(),
     this.widgets = const MainEditorWidgets(),
@@ -36,56 +42,6 @@ class MainEditorConfigs {
   ///
   /// This flag has no effect when the `onEscapeButton` callback is set.
   final bool enableEscapeButton;
-
-  /// {@template enableZoom}
-  /// Indicates whether the editor supports zoom functionality.
-  ///
-  /// When set to `true`, the editor allows users to zoom in and out, providing
-  /// enhanced accessibility and usability, especially on smaller screens or for
-  /// users with visual impairments. If set to `false`, the zoom functionality
-  /// is disabled, and the editor's content remains at a fixed scale.
-  ///
-  /// Default value is `false`.
-  /// {@endtemplate}
-  final bool enableZoom;
-
-  /// The minimum scale factor for the editor.
-  ///
-  /// This value determines the lowest level of zoom that can be applied to the
-  /// editor content. It only has an effect when [enableZoom] is set to
-  /// `true`.
-  /// If [enableZoom] is `false`, this value is ignored.
-  ///
-  /// Default value is 1.0.
-  final double editorMinScale;
-
-  /// The maximum scale factor for the editor.
-  ///
-  /// This value determines the highest level of zoom that can be applied to the
-  /// editor content. It only has an effect when [enableZoom] is set to
-  /// `true`.
-  /// If [enableZoom] is `false`, this value is ignored.
-  ///
-  /// Default value is 5.0.
-  final double editorMaxScale;
-
-  /// Zoom boundary
-  ///
-  /// A margin for the visible boundaries of the child.
-  ///
-  /// Any transformation that results in the viewport being able to view
-  /// outside of the boundaries will be stopped at the boundary.
-  /// The boundaries do not rotate with the rest of the scene, so they are
-  /// always aligned with the viewport.
-  ///
-  /// To produce no boundaries at all, pass infinite [EdgeInsets], such as
-  /// EdgeInsets.all(double.infinity).
-  ///
-  /// No edge can be NaN.
-  ///
-  /// Defaults to [EdgeInsets.zero], which results in boundaries that are the
-  /// exact same size and position as the [child].
-  final EdgeInsets boundaryMargin;
 
   /// Initializes the editor with pre-configured transformations,
   /// such as cropping, based on the provided setup.
@@ -109,26 +65,35 @@ class MainEditorConfigs {
   MainEditorConfigs copyWith({
     bool? enableCloseButton,
     bool? enableEscapeButton,
-    bool? enableZoom,
-    double? editorMinScale,
-    double? editorMaxScale,
     MainEditorTransformSetup? transformSetup,
-    EdgeInsets? boundaryMargin,
     MainEditorStyle? style,
     MainEditorIcons? icons,
     MainEditorWidgets? widgets,
+    bool? enableZoom,
+    double? editorMinScale,
+    double? editorMaxScale,
+    EdgeInsets? boundaryMargin,
+    bool? enableDoubleTapZoom,
+    double? doubleTapZoomFactor,
+    Duration? doubleTapZoomDuration,
+    Curve? doubleTapZoomCurve,
   }) {
     return MainEditorConfigs(
       enableCloseButton: enableCloseButton ?? this.enableCloseButton,
       enableEscapeButton: enableEscapeButton ?? this.enableEscapeButton,
+      transformSetup: transformSetup ?? this.transformSetup,
+      style: style ?? this.style,
+      icons: icons ?? this.icons,
+      widgets: widgets ?? this.widgets,
       enableZoom: enableZoom ?? this.enableZoom,
       editorMinScale: editorMinScale ?? this.editorMinScale,
       editorMaxScale: editorMaxScale ?? this.editorMaxScale,
-      transformSetup: transformSetup ?? this.transformSetup,
+      enableDoubleTapZoom: enableDoubleTapZoom ?? this.enableDoubleTapZoom,
+      doubleTapZoomFactor: doubleTapZoomFactor ?? this.doubleTapZoomFactor,
+      doubleTapZoomDuration:
+          doubleTapZoomDuration ?? this.doubleTapZoomDuration,
+      doubleTapZoomCurve: doubleTapZoomCurve ?? this.doubleTapZoomCurve,
       boundaryMargin: boundaryMargin ?? this.boundaryMargin,
-      style: style ?? this.style,
-      widgets: widgets ?? this.widgets,
-      icons: icons ?? this.icons,
     );
   }
 }
@@ -163,13 +128,4 @@ class MainEditorTransformSetup {
   ///
   /// Returns a new instance of [MainEditorTransformSetup] with the updated
   /// fields.
-  MainEditorTransformSetup copyWith({
-    TransformConfigs? transformConfigs,
-    ImageInfos? imageInfos,
-  }) {
-    return MainEditorTransformSetup(
-      transformConfigs: transformConfigs ?? this.transformConfigs,
-      imageInfos: imageInfos ?? this.imageInfos,
-    );
-  }
 }

--- a/lib/core/models/editor_configs/paint_editor/paint_editor_configs.dart
+++ b/lib/core/models/editor_configs/paint_editor/paint_editor_configs.dart
@@ -5,6 +5,7 @@ import '../../custom_widgets/paint_editor_widgets.dart';
 import '../../icons/paint_editor_icons.dart';
 import '../../styles/paint_editor_style.dart';
 import '../utils/editor_safe_area.dart';
+import '../utils/zoom_configs.dart';
 import 'censor_configs.dart';
 
 export '../../custom_widgets/paint_editor_widgets.dart';
@@ -35,16 +36,21 @@ export 'censor_configs.dart';
 ///   initialPaintMode: PaintMode.freeStyle,
 /// );
 /// ```
-class PaintEditorConfigs {
+class PaintEditorConfigs extends ZoomConfigs {
   /// Creates an instance of PaintEditorConfigs with optional settings.
   ///
   /// By default, the editor is enabled, and most drawing tools are enabled.
   /// Other properties are set to reasonable defaults.
   const PaintEditorConfigs({
     this.enabled = true,
-    this.enableZoom = false,
-    this.editorMinScale = 1.0,
-    this.editorMaxScale = 5.0,
+    super.enableZoom,
+    super.editorMinScale,
+    super.editorMaxScale,
+    super.enableDoubleTapZoom,
+    super.doubleTapZoomFactor,
+    super.doubleTapZoomDuration,
+    super.doubleTapZoomCurve,
+    super.boundaryMargin,
     this.enableModeFreeStyle = true,
     this.enableModeArrow = true,
     this.enableModeLine = true,
@@ -60,7 +66,6 @@ class PaintEditorConfigs {
     this.isInitiallyFilled = false,
     this.showLayers = true,
     this.enableShareZoomMatrix = true,
-    this.boundaryMargin = EdgeInsets.zero,
     this.minScale = double.negativeInfinity,
     this.maxScale = double.infinity,
     this.enableFreeStyleHighPerformanceScaling,
@@ -79,16 +84,6 @@ class PaintEditorConfigs {
 
   /// Indicates whether the paint editor is enabled.
   final bool enabled;
-
-  /// Indicates whether the editor supports zoom functionality.
-  ///
-  /// When set to `true`, the editor allows users to zoom in and out, providing
-  /// enhanced accessibility and usability, especially on smaller screens or for
-  /// users with visual impairments. If set to `false`, the zoom functionality
-  /// is disabled, and the editor's content remains at a fixed scale.
-  ///
-  /// Default value is `false`.
-  final bool enableZoom;
 
   /// Indicating whether the free-style drawing option is enabled.
   final bool enableModeFreeStyle;
@@ -168,50 +163,12 @@ class PaintEditorConfigs {
   /// Indicates the initial paint mode.
   final PaintMode initialPaintMode;
 
-  /// The minimum scale factor for the editor.
-  ///
-  /// This value determines the lowest level of zoom that can be applied to the
-  /// editor content. It only has an effect when [enableZoom] is set to
-  /// `true`.
-  /// If [enableZoom] is `false`, this value is ignored.
-  ///
-  /// Default value is 1.0.
-  final double editorMinScale;
-
-  /// The maximum scale factor for the editor.
-  ///
-  /// This value determines the highest level of zoom that can be applied to the
-  /// editor content. It only has an effect when [enableZoom] is set to
-  /// `true`.
-  /// If [enableZoom] is `false`, this value is ignored.
-  ///
-  /// Default value is 5.0.
-  final double editorMaxScale;
-
   /// Configuration settings for the censor tool in the paint editor.
   ///
   /// This property holds an instance of [CensorConfigs] which contains
   /// various settings and options for the censoring functionality within
   /// the paint editor.
   final CensorConfigs censorConfigs;
-
-  /// Zoom boundary
-  ///
-  /// A margin for the visible boundaries of the child.
-  ///
-  /// Any transformation that results in the viewport being able to view
-  /// outside of the boundaries will be stopped at the boundary.
-  /// The boundaries do not rotate with the rest of the scene, so they are
-  /// always aligned with the viewport.
-  ///
-  /// To produce no boundaries at all, pass infinite [EdgeInsets], such as
-  /// EdgeInsets.all(double.infinity).
-  ///
-  /// No edge can be NaN.
-  ///
-  /// Defaults to [EdgeInsets.zero], which results in boundaries that are the
-  /// exact same size and position as the [child].
-  final EdgeInsets boundaryMargin;
 
   /// The minimum scale factor from the layer.
   final double minScale;
@@ -239,15 +196,6 @@ class PaintEditorConfigs {
   /// others unchanged.
   PaintEditorConfigs copyWith({
     bool? enabled,
-    bool? showToggleFillButton,
-    bool? showLineWidthAdjustmentButton,
-    bool? showOpacityAdjustmentButton,
-    bool? isInitiallyFilled,
-    bool? enableFreeStyleHighPerformanceScaling,
-    bool? enableFreeStyleHighPerformanceMoving,
-    bool? enableFreeStyleHighPerformanceHero,
-    bool? showLayers,
-    bool? enableZoom,
     bool? enableModeFreeStyle,
     bool? enableModeArrow,
     bool? enableModeLine,
@@ -257,23 +205,34 @@ class PaintEditorConfigs {
     bool? enableModeBlur,
     bool? enableModePixelate,
     bool? enableModeEraser,
+    bool? showToggleFillButton,
+    bool? showLineWidthAdjustmentButton,
+    bool? showOpacityAdjustmentButton,
+    bool? isInitiallyFilled,
+    bool? showLayers,
     bool? enableShareZoomMatrix,
+    bool? enableFreeStyleHighPerformanceScaling,
+    bool? enableFreeStyleHighPerformanceMoving,
+    bool? enableFreeStyleHighPerformanceHero,
     PaintMode? initialPaintMode,
-    double? editorMinScale,
-    double? editorMaxScale,
+    CensorConfigs? censorConfigs,
     double? minScale,
     double? maxScale,
-    CensorConfigs? censorConfigs,
     EditorSafeArea? safeArea,
-    EdgeInsets? boundaryMargin,
     PaintEditorStyle? style,
     PaintEditorIcons? icons,
     PaintEditorWidgets? widgets,
+    bool? enableZoom,
+    double? editorMinScale,
+    double? editorMaxScale,
+    EdgeInsets? boundaryMargin,
+    bool? enableDoubleTapZoom,
+    double? doubleTapZoomFactor,
+    Duration? doubleTapZoomDuration,
+    Curve? doubleTapZoomCurve,
   }) {
     return PaintEditorConfigs(
-      safeArea: safeArea ?? this.safeArea,
       enabled: enabled ?? this.enabled,
-      enableZoom: enableZoom ?? this.enableZoom,
       enableModeFreeStyle: enableModeFreeStyle ?? this.enableModeFreeStyle,
       enableModeArrow: enableModeArrow ?? this.enableModeArrow,
       enableModeLine: enableModeLine ?? this.enableModeLine,
@@ -283,15 +242,15 @@ class PaintEditorConfigs {
       enableModeBlur: enableModeBlur ?? this.enableModeBlur,
       enableModePixelate: enableModePixelate ?? this.enableModePixelate,
       enableModeEraser: enableModeEraser ?? this.enableModeEraser,
-      enableShareZoomMatrix:
-          enableShareZoomMatrix ?? this.enableShareZoomMatrix,
       showToggleFillButton: showToggleFillButton ?? this.showToggleFillButton,
       showLineWidthAdjustmentButton:
           showLineWidthAdjustmentButton ?? this.showLineWidthAdjustmentButton,
       showOpacityAdjustmentButton:
           showOpacityAdjustmentButton ?? this.showOpacityAdjustmentButton,
-      showLayers: showLayers ?? this.showLayers,
       isInitiallyFilled: isInitiallyFilled ?? this.isInitiallyFilled,
+      showLayers: showLayers ?? this.showLayers,
+      enableShareZoomMatrix:
+          enableShareZoomMatrix ?? this.enableShareZoomMatrix,
       enableFreeStyleHighPerformanceScaling:
           enableFreeStyleHighPerformanceScaling ??
               this.enableFreeStyleHighPerformanceScaling,
@@ -301,15 +260,22 @@ class PaintEditorConfigs {
       enableFreeStyleHighPerformanceHero: enableFreeStyleHighPerformanceHero ??
           this.enableFreeStyleHighPerformanceHero,
       initialPaintMode: initialPaintMode ?? this.initialPaintMode,
-      editorMinScale: editorMinScale ?? this.editorMinScale,
       censorConfigs: censorConfigs ?? this.censorConfigs,
-      editorMaxScale: editorMaxScale ?? this.editorMaxScale,
-      boundaryMargin: boundaryMargin ?? this.boundaryMargin,
       minScale: minScale ?? this.minScale,
       maxScale: maxScale ?? this.maxScale,
+      safeArea: safeArea ?? this.safeArea,
       style: style ?? this.style,
       icons: icons ?? this.icons,
       widgets: widgets ?? this.widgets,
+      enableZoom: enableZoom ?? this.enableZoom,
+      editorMinScale: editorMinScale ?? this.editorMinScale,
+      editorMaxScale: editorMaxScale ?? this.editorMaxScale,
+      enableDoubleTapZoom: enableDoubleTapZoom ?? this.enableDoubleTapZoom,
+      doubleTapZoomFactor: doubleTapZoomFactor ?? this.doubleTapZoomFactor,
+      doubleTapZoomDuration:
+          doubleTapZoomDuration ?? this.doubleTapZoomDuration,
+      doubleTapZoomCurve: doubleTapZoomCurve ?? this.doubleTapZoomCurve,
+      boundaryMargin: boundaryMargin ?? this.boundaryMargin,
     );
   }
 }

--- a/lib/core/models/editor_configs/utils/zoom_configs.dart
+++ b/lib/core/models/editor_configs/utils/zoom_configs.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/widgets.dart';
+
+/// Configuration interface for zoom behavior in an editor or viewer.
+///
+/// Provides control over zoom enablement, scale limits, double-tap behavior,
+/// and boundary constraints.
+abstract class ZoomConfigs {
+  /// Creates a set of zoom configuration options.
+  const ZoomConfigs({
+    this.enableZoom = false,
+    this.editorMinScale = 1,
+    this.editorMaxScale = 5,
+    this.boundaryMargin = EdgeInsets.zero,
+    this.enableDoubleTapZoom = true,
+    this.doubleTapZoomFactor = 2,
+    this.doubleTapZoomDuration = const Duration(milliseconds: 180),
+    this.doubleTapZoomCurve = Curves.easeInOut,
+  });
+
+  /// {@template enableZoom}
+  /// Indicates whether the editor supports zoom functionality.
+  ///
+  /// When set to `true`, the editor allows users to zoom in and out, providing
+  /// enhanced accessibility and usability, especially on smaller screens or for
+  /// users with visual impairments. If set to `false`, the zoom functionality
+  /// is disabled, and the editor's content remains at a fixed scale.
+  ///
+  /// Default value is `false`.
+  /// {@endtemplate}
+  final bool enableZoom;
+
+  /// The minimum scale factor for the editor.
+  ///
+  /// This value determines the lowest level of zoom that can be applied to the
+  /// editor content. It only has an effect when [enableZoom] is set to
+  /// `true`.
+  /// If [enableZoom] is `false`, this value is ignored.
+  ///
+  /// Default value is 1.0.
+  final double editorMinScale;
+
+  /// The maximum scale factor for the editor.
+  ///
+  /// This value determines the highest level of zoom that can be applied to the
+  /// editor content. It only has an effect when [enableZoom] is set to
+  /// `true`.
+  /// If [enableZoom] is `false`, this value is ignored.
+  ///
+  /// Default value is 5.0.
+  final double editorMaxScale;
+
+  /// Zoom boundary
+  ///
+  /// A margin for the visible boundaries of the child.
+  ///
+  /// Any transformation that results in the viewport being able to view
+  /// outside of the boundaries will be stopped at the boundary.
+  /// The boundaries do not rotate with the rest of the scene, so they are
+  /// always aligned with the viewport.
+  ///
+  /// To produce no boundaries at all, pass infinite [EdgeInsets], such as
+  /// EdgeInsets.all(double.infinity).
+  ///
+  /// No edge can be NaN.
+  ///
+  /// Defaults to [EdgeInsets.zero], which results in boundaries that are the
+  /// exact same size and position as the [child].
+  final EdgeInsets boundaryMargin;
+
+  /// Whether double-tap to zoom is enabled.
+  ///
+  /// If `true`, users can double-tap to zoom in or out based on the current
+  /// zoom level. If `false`, double-tap gestures are ignored.
+  final bool enableDoubleTapZoom;
+
+  /// The zoom scale factor applied on double-tap.
+  ///
+  /// This determines how much to zoom in or out when the user double-taps.
+  /// For example, a value of 2.0 doubles the current scale.
+  final double doubleTapZoomFactor;
+
+  /// The duration of the zoom animation on double-tap.
+  ///
+  /// Controls how long the zoom animation takes to complete when a
+  /// double-tap gesture is detected.
+  final Duration doubleTapZoomDuration;
+
+  /// The animation curve used for double-tap zooming.
+  ///
+  /// Defines the easing curve of the zoom animation triggered by
+  /// double-tapping.
+  final Curve doubleTapZoomCurve;
+}

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -28,6 +28,7 @@ import '/shared/utils/file_constructor_utils.dart';
 import '/shared/widgets/adaptive_dialog.dart';
 import '/shared/widgets/extended/extended_interactive_viewer.dart';
 import '/shared/widgets/screen_resize_detector.dart';
+import '../../shared/mixins/editor_zoom.mixin.dart';
 import '../filter_editor/types/filter_matrix.dart';
 import '../filter_editor/widgets/filter_generator.dart';
 import '../tune_editor/models/tune_adjustment_matrix.dart';
@@ -358,11 +359,13 @@ class ProImageEditorState extends State<ProImageEditor>
         ImageEditorConvertedConfigs,
         SimpleConfigsAccessState,
         SimpleCallbacksAccessState,
-        MainEditorGlobalKeys {
+        MainEditorGlobalKeys,
+        EditorZoomMixin {
   final _bottomBarKey = GlobalKey();
   final _removeAreaKey = GlobalKey();
   final _backgroundImageColorFilterKey = GlobalKey<ColorFilterGeneratorState>();
-  final _interactiveViewer = GlobalKey<ExtendedInteractiveViewerState>();
+  @override
+  final interactiveViewer = GlobalKey<ExtendedInteractiveViewerState>();
   late final StreamController<void> _rebuildController;
 
   /// Helper class for managing sizes and layout calculations.
@@ -547,7 +550,7 @@ class ProImageEditorState extends State<ProImageEditor>
   }
 
   void _checkInteractiveViewer() {
-    _interactiveViewer.currentState?.setEnableInteraction(
+    interactiveViewer.currentState?.setEnableInteraction(
       selectedLayerIndex < 0 && layerInteractionManager.selectedLayerId.isEmpty,
     );
   }
@@ -972,15 +975,11 @@ class ProImageEditorState extends State<ProImageEditor>
     });
   }
 
-  /// Resets the zoom and pan of the image editor.
+  @override
   void resetZoom() {
-    _interactiveViewer.currentState?.reset();
+    super.resetZoom();
     _controllers.cropLayerPainterCtrl.add(null);
   }
-
-  /// Returns the current scale factor of the image editor.
-  double get editorScaleFactor =>
-      _interactiveViewer.currentState?.scaleFactor ?? 1.0;
 
   /// Handle the start of a scaling operation.
   ///
@@ -1069,10 +1068,9 @@ class ProImageEditorState extends State<ProImageEditor>
           details: details,
           editorSize: sizesManager.bodySize,
           layerTheme: layerInteraction.style,
-          editorScaleFactor:
-              _interactiveViewer.currentState?.scaleFactor ?? 1.0,
+          editorScaleFactor: interactiveViewer.currentState?.scaleFactor ?? 1.0,
           editorScaleOffset:
-              _interactiveViewer.currentState?.offset ?? Offset.zero,
+              interactiveViewer.currentState?.offset ?? Offset.zero,
         );
       _activeLayer!.key.currentState!.setState(() {});
       checkUpdateHelperLineUI();
@@ -1080,7 +1078,7 @@ class ProImageEditorState extends State<ProImageEditor>
     }
 
     double editorScaleFactor =
-        _interactiveViewer.currentState?.scaleFactor ?? 1.0;
+        interactiveViewer.currentState?.scaleFactor ?? 1.0;
 
     layerInteractionManager.enabledHitDetection = false;
     if (details.pointerCount == 1) {
@@ -1147,7 +1145,7 @@ class ProImageEditorState extends State<ProImageEditor>
         theme: _theme,
         callbacks: callbacks,
         scaleFactor: textEditorConfigs.enableMainEditorZoomFactor
-            ? _interactiveViewer.currentState?.scaleFactor ?? 1.0
+            ? interactiveViewer.currentState?.scaleFactor ?? 1.0
             : 1.0,
       ),
 
@@ -1355,7 +1353,7 @@ class ProImageEditorState extends State<ProImageEditor>
       onEditorZoomMatrix4Change: (value) {
         callbacks.paintEditorCallbacks?.onEditorZoomMatrix4Change?.call(value);
         if (paintEditorConfigs.enableShareZoomMatrix) {
-          _interactiveViewer.currentState?.transformMatrix4 = value;
+          interactiveViewer.currentState?.transformMatrix4 = value;
         }
       },
     );
@@ -1377,7 +1375,7 @@ class ProImageEditorState extends State<ProImageEditor>
           appliedBlurFactor: stateManager.activeBlur,
           appliedFilters: stateManager.activeFilters,
           appliedTuneAdjustments: stateManager.activeTuneAdjustments,
-          initialZoomMatrix: _interactiveViewer.currentState?.transformMatrix4,
+          initialZoomMatrix: interactiveViewer.currentState?.transformMatrix4,
         ),
       ),
       duration: const Duration(milliseconds: 150),
@@ -1413,7 +1411,7 @@ class ProImageEditorState extends State<ProImageEditor>
         theme: _theme,
         callbacks: callbacks,
         scaleFactor: textEditorConfigs.enableMainEditorZoomFactor
-            ? _interactiveViewer.currentState?.scaleFactor ?? 1.0
+            ? interactiveViewer.currentState?.scaleFactor ?? 1.0
             : 1.0,
       ),
       duration: duration,
@@ -2254,6 +2252,13 @@ class ProImageEditorState extends State<ProImageEditor>
               duration: const Duration(milliseconds: 200),
               child: Listener(
                 behavior: HitTestBehavior.translucent,
+                onPointerDown: (details) {
+                  bool isDoubleTap = detectDoubleTap(details);
+                  if (!isDoubleTap) return;
+
+                  handleDoubleTap(context, details, mainEditorConfigs);
+                  mainEditorCallbacks?.onDoubleTap?.call();
+                },
                 onPointerSignal: isDesktop && _activeLayer != null
                     ? (event) {
                         if (_activeLayer == null) return;
@@ -2275,7 +2280,6 @@ class ProImageEditorState extends State<ProImageEditor>
                     widget.videoController?.togglePlayState();
                     mainEditorCallbacks?.onTap?.call();
                   },
-                  onDoubleTap: mainEditorCallbacks?.onDoubleTap,
                   onLongPress: mainEditorCallbacks?.onLongPress,
                   onScaleStart: _onScaleStart,
                   onScaleUpdate: _onScaleUpdate,
@@ -2308,7 +2312,7 @@ class ProImageEditorState extends State<ProImageEditor>
       processFinalImage: _isProcessingFinalImage,
       rebuildController: _rebuildController,
       stateManager: stateManager,
-      interactiveViewerKey: _interactiveViewer,
+      interactiveViewerKey: interactiveViewer,
       state: this,
       videoController: widget.videoController,
       isVideoEditor: _isVideoEditor,
@@ -2367,7 +2371,7 @@ class ProImageEditorState extends State<ProImageEditor>
       sizesManager: sizesManager,
       layerInteractionManager: layerInteractionManager,
       controllers: _controllers,
-      interactiveViewer: _interactiveViewer,
+      interactiveViewer: interactiveViewer,
       helperLines: helperLines,
       configs: configs,
     );

--- a/lib/features/main_editor/widgets/main_editor_interactive_content.dart
+++ b/lib/features/main_editor/widgets/main_editor_interactive_content.dart
@@ -174,10 +174,7 @@ class MainEditorInteractiveContent extends StatelessWidget {
     var paintConfigs = configs.paintEditor;
     return ExtendedInteractiveViewer(
       key: interactiveViewerKey,
-      boundaryMargin: mainConfigs.boundaryMargin,
-      enableZoom: mainConfigs.enableZoom,
-      minScale: mainConfigs.editorMinScale,
-      maxScale: mainConfigs.editorMaxScale,
+      zoomConfigs: mainConfigs,
       onInteractionStart: (details) {
         callbacks.mainEditorCallbacks?.onEditorZoomScaleStart?.call(details);
         layerInteractionManager.freeStyleHighPerformanceEditorZoom =
@@ -196,6 +193,10 @@ class MainEditorInteractiveContent extends StatelessWidget {
         layerInteractionManager.freeStyleHighPerformanceEditorZoom = false;
         controllers.uiLayerCtrl.add(null);
         controllers.cropLayerPainterCtrl.add(null);
+      },
+      onMatrix4Change: (value) {
+        controllers.cropLayerPainterCtrl.add(null);
+        callbacks.mainEditorCallbacks?.onEditorZoomMatrix4Change?.call(value);
       },
       child: isVideoEditor
           ? Stack(

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:pro_image_editor/shared/mixins/editor_zoom.mixin.dart';
 
 import '/core/constants/image_constants.dart';
 import '/core/mixins/converted_callbacks.dart';
@@ -198,9 +199,11 @@ class PaintEditorState extends State<PaintEditor>
     with
         ImageEditorConvertedConfigs,
         ImageEditorConvertedCallbacks,
-        StandaloneEditorState<PaintEditor, PaintEditorInitConfigs> {
+        StandaloneEditorState<PaintEditor, PaintEditorInitConfigs>,
+        EditorZoomMixin {
   final _paintCanvas = GlobalKey<PaintCanvasState>();
-  final _interactiveViewer = GlobalKey<ExtendedInteractiveViewerState>();
+  @override
+  final interactiveViewer = GlobalKey<ExtendedInteractiveViewerState>();
 
   /// Controller for managing paint operations within the widget's context.
   late final PaintController paintCtrl;
@@ -474,7 +477,7 @@ class PaintEditorState extends State<PaintEditor>
     paintCtrl.setMode(mode);
     paintEditorCallbacks?.handlePaintModeChanged(mode);
     rebuildController.add(null);
-    _interactiveViewer.currentState?.setEnableInteraction(
+    interactiveViewer.currentState?.setEnableInteraction(
       mode == PaintMode.moveAndZoom,
     );
     _paintCanvas.currentState?.setState(() {});
@@ -754,80 +757,88 @@ class PaintEditorState extends State<PaintEditor>
 
   List<Widget> _buildInteractiveContent() {
     return [
-      ExtendedInteractiveViewer(
-        key: _interactiveViewer,
-        initialMatrix4: paintEditorConfigs.enableShareZoomMatrix
-            ? initConfigs.initialZoomMatrix
-            : null,
-        enableZoom: _enableZoom,
-        boundaryMargin: paintEditorConfigs.boundaryMargin,
-        minScale: paintEditorConfigs.editorMinScale,
-        maxScale: paintEditorConfigs.editorMaxScale,
-        enableInteraction: paintMode == PaintMode.moveAndZoom,
-        onInteractionStart: (details) {
-          _freeStyleHighPerformance =
-              (paintEditorConfigs.enableFreeStyleHighPerformanceMoving ??
-                      !isDesktop) ||
-                  (paintEditorConfigs.enableFreeStyleHighPerformanceScaling ??
-                      !isDesktop);
+      Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: (details) {
+          bool isDoubleTap = detectDoubleTap(details);
+          if (!isDoubleTap) return;
 
-          callbacks.paintEditorCallbacks?.onEditorZoomScaleStart?.call(details);
-          setState(() {});
+          handleDoubleTap(context, details, paintEditorConfigs);
+          paintEditorCallbacks?.onDoubleTap?.call();
         },
-        onInteractionUpdate:
-            callbacks.paintEditorCallbacks?.onEditorZoomScaleUpdate,
-        onInteractionEnd: (details) {
-          _freeStyleHighPerformance = false;
-          callbacks.paintEditorCallbacks?.onEditorZoomScaleEnd?.call(details);
-          setState(() {});
-        },
-        onMatrix4Change:
-            callbacks.paintEditorCallbacks?.onEditorZoomMatrix4Change,
-        child: Stack(
-          alignment: Alignment.center,
-          fit: StackFit.expand,
-          children: [
-            if (initConfigs.convertToUint8List && isVideoEditor)
-              _buildBackground(),
-            ContentRecorder(
-              autoDestroyController: false,
-              controller: screenshotCtrl,
-              child: Stack(
-                alignment: Alignment.center,
-                fit: StackFit.expand,
-                children: [
-                  if (!widget.paintOnly)
-                    if (!initConfigs.convertToUint8List || !isVideoEditor)
-                      _buildBackground()
-                    else
-                      SizedBox(
-                        width: configs.imageGeneration.maxOutputSize.width,
-                        height: configs.imageGeneration.maxOutputSize.height,
-                      ),
+        child: ExtendedInteractiveViewer(
+          key: interactiveViewer,
+          initialMatrix4: paintEditorConfigs.enableShareZoomMatrix
+              ? initConfigs.initialZoomMatrix
+              : null,
+          zoomConfigs: paintEditorConfigs,
+          enableInteraction: paintMode == PaintMode.moveAndZoom,
+          onInteractionStart: (details) {
+            _freeStyleHighPerformance =
+                (paintEditorConfigs.enableFreeStyleHighPerformanceMoving ??
+                        !isDesktop) ||
+                    (paintEditorConfigs.enableFreeStyleHighPerformanceScaling ??
+                        !isDesktop);
 
-                  /// Build layers
-                  if (paintEditorConfigs.showLayers && layers != null)
-                    LayerStack(
-                      configs: configs,
-                      layers: layers!,
-                      transformHelper: TransformHelper(
-                        mainBodySize:
-                            getMinimumSize(mainBodySize, editorBodySize),
-                        mainImageSize:
-                            getMinimumSize(mainImageSize, editorBodySize),
-                        editorBodySize: editorBodySize,
-                        transformConfigs: initialTransformConfigs,
+            callbacks.paintEditorCallbacks?.onEditorZoomScaleStart
+                ?.call(details);
+            setState(() {});
+          },
+          onInteractionUpdate:
+              callbacks.paintEditorCallbacks?.onEditorZoomScaleUpdate,
+          onInteractionEnd: (details) {
+            _freeStyleHighPerformance = false;
+            callbacks.paintEditorCallbacks?.onEditorZoomScaleEnd?.call(details);
+            setState(() {});
+          },
+          onMatrix4Change:
+              callbacks.paintEditorCallbacks?.onEditorZoomMatrix4Change,
+          child: Stack(
+            alignment: Alignment.center,
+            fit: StackFit.expand,
+            children: [
+              if (initConfigs.convertToUint8List && isVideoEditor)
+                _buildBackground(),
+              ContentRecorder(
+                autoDestroyController: false,
+                controller: screenshotCtrl,
+                child: Stack(
+                  alignment: Alignment.center,
+                  fit: StackFit.expand,
+                  children: [
+                    if (!widget.paintOnly)
+                      if (!initConfigs.convertToUint8List || !isVideoEditor)
+                        _buildBackground()
+                      else
+                        SizedBox(
+                          width: configs.imageGeneration.maxOutputSize.width,
+                          height: configs.imageGeneration.maxOutputSize.height,
+                        ),
+
+                    /// Build layers
+                    if (paintEditorConfigs.showLayers && layers != null)
+                      LayerStack(
+                        configs: configs,
+                        layers: layers!,
+                        transformHelper: TransformHelper(
+                          mainBodySize:
+                              getMinimumSize(mainBodySize, editorBodySize),
+                          mainImageSize:
+                              getMinimumSize(mainImageSize, editorBodySize),
+                          editorBodySize: editorBodySize,
+                          transformConfigs: initialTransformConfigs,
+                        ),
+                        overlayColor: paintEditorConfigs.style.background,
                       ),
-                      overlayColor: paintEditorConfigs.style.background,
-                    ),
-                  _buildPainter(),
-                  if (paintEditorConfigs.widgets.bodyItemsRecorded != null)
-                    ...paintEditorConfigs.widgets.bodyItemsRecorded!(
-                        this, rebuildController.stream),
-                ],
+                    _buildPainter(),
+                    if (paintEditorConfigs.widgets.bodyItemsRecorded != null)
+                      ...paintEditorConfigs.widgets.bodyItemsRecorded!(
+                          this, rebuildController.stream),
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
 

--- a/lib/shared/mixins/editor_zoom.mixin.dart
+++ b/lib/shared/mixins/editor_zoom.mixin.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/widgets.dart';
+
+import '/core/models/editor_configs/utils/zoom_configs.dart';
+import '../utils/debounce.dart';
+import '../widgets/extended/extended_interactive_viewer.dart';
+
+/// A mixin that provides zoom-related behavior for image or content editors.
+///
+/// This includes logic for double-tap detection, zoom control, and reset
+/// actions. It expects a [GlobalKey] reference to an
+/// [ExtendedInteractiveViewerState] implementation.
+mixin EditorZoomMixin<T extends StatefulWidget> on State<T> {
+  /// Stores the position of the last pointer down event, used for zoom focus.
+  Offset? _lastTapDownOffset;
+
+  /// A debounce utility to track timing between double-tap events.
+  final _doubleTapDebounce = Debounce(const Duration(milliseconds: 300));
+
+  /// Helper counter to track consecutive tap events.
+  int _doubleTapCountHelper = 0;
+
+  /// A reference to the [ExtendedInteractiveViewer]'s global key.
+  ///
+  /// This must be implemented by the consuming widget to control zoom behavior.
+  GlobalKey<ExtendedInteractiveViewerState> get interactiveViewer;
+
+  @override
+  void dispose() {
+    _doubleTapDebounce.dispose();
+    super.dispose();
+  }
+
+  /// Detects whether a [PointerDownEvent] is part of a double-tap gesture.
+  ///
+  /// Returns `true` if two taps occur within the debounce duration.
+  @protected
+  bool detectDoubleTap(PointerDownEvent details) {
+    _lastTapDownOffset = details.position;
+    _doubleTapCountHelper++;
+    _doubleTapDebounce(() {
+      _doubleTapCountHelper = 0;
+    });
+    return _doubleTapCountHelper == 2;
+  }
+
+  /// Handles a confirmed double-tap gesture and performs a zoom action.
+  ///
+  /// Converts the global tap position to local coordinates and zooms in using
+  /// the configuration provided in [configs].
+  @protected
+  void handleDoubleTap(
+    BuildContext context,
+    PointerDownEvent details,
+    ZoomConfigs configs,
+  ) {
+    if (configs.enableDoubleTapZoom && _lastTapDownOffset != null) {
+      final renderBox = context.findRenderObject() as RenderBox;
+      final localTap = renderBox.globalToLocal(_lastTapDownOffset!);
+      interactiveViewer.currentState?.quickZoomTo(
+        localTap,
+        configs.doubleTapZoomFactor,
+        curve: configs.doubleTapZoomCurve,
+        duration: configs.doubleTapZoomDuration,
+      );
+    }
+  }
+
+  /// Programmatically zooms the editor to a given offset and/or scale.
+  ///
+  /// If [offset] or [scale] is null, defaults will be used.
+  void zoomTo({Offset? offset, double? scale}) {
+    interactiveViewer.currentState?.zoomTo(offset: offset, scale: scale);
+  }
+
+  /// Returns the current scale factor of the image editor.
+  double get editorScaleFactor =>
+      interactiveViewer.currentState?.scaleFactor ?? 1.0;
+
+  /// Resets the zoom and pan of the image editor.
+  void resetZoom() {
+    interactiveViewer.currentState?.reset();
+  }
+}

--- a/lib/shared/widgets/extended/extended_interactive_viewer.dart
+++ b/lib/shared/widgets/extended/extended_interactive_viewer.dart
@@ -1,42 +1,19 @@
 import 'package:flutter/widgets.dart';
+import '/core/models/editor_configs/utils/zoom_configs.dart';
 
 /// A widget that provides interactive viewing capabilities with zoom and pan
 /// functionality.
 ///
 /// The [ExtendedInteractiveViewer] wraps a given child widget and allows users
-/// to interact with it through zooming and panning. The interactivity can be
-/// enabled or disabled, and the zoom levels can be controlled with [minScale]
-/// and [maxScale].
-///
-/// Example usage:
-/// ```dart
-/// ExtendedInteractiveViewer(
-///   enableZoom: true,
-///   enableInteraction: true,
-///   minScale: 0.5,
-///   maxScale: 3.0,
-///   child: YourWidget(),
-/// );
+/// to interact with it through zooming and panning.
 /// ```
-///
-/// The [ExtendedInteractiveViewer] requires the following parameters:
-/// - [child]: The widget to be displayed and interacted with.
-/// - [enableZoom]: A boolean indicating whether zoom functionality is
-/// enabled.
-/// - [minScale]: The minimum scale factor for zooming.
-/// - [maxScale]: The maximum scale factor for zooming.
-///
-/// Optionally, you can control the interactivity using [enableInteraction].
 class ExtendedInteractiveViewer extends StatefulWidget {
   /// Creates an [ExtendedInteractiveViewer] with the given parameters.
   const ExtendedInteractiveViewer({
     super.key,
     required this.child,
     this.enableInteraction = true,
-    required this.boundaryMargin,
-    required this.enableZoom,
-    required this.minScale,
-    required this.maxScale,
+    required this.zoomConfigs,
     required this.onInteractionStart,
     required this.onInteractionUpdate,
     required this.onInteractionEnd,
@@ -44,35 +21,20 @@ class ExtendedInteractiveViewer extends StatefulWidget {
     this.initialMatrix4,
   });
 
-  /// A margin for the visible boundaries of the child.
-  final EdgeInsets boundaryMargin;
+  /// Configuration options that control zoom behavior and limits.
+  ///
+  /// Provides settings such as whether zoom is enabled, min/max scale factors,
+  /// double-tap zoom behavior, and boundary constraints.
+  final ZoomConfigs zoomConfigs;
 
   /// The child widget to be displayed and interacted with.
   final Widget child;
-
-  /// Indicates whether the editor supports zoom functionality.
-  ///
-  /// When set to `true`, the editor allows users to zoom in and out. If set to
-  /// `false`, the content remains at a fixed scale.
-  final bool enableZoom;
 
   /// Indicates whether user interactions such as panning and zooming are
   /// enabled.
   ///
   /// Default value is `true`.
   final bool enableInteraction;
-
-  /// The minimum scale factor for zooming.
-  ///
-  /// This determines the lowest level of zoom that can be applied to the child
-  /// widget, ensuring content remains usable.
-  final double minScale;
-
-  /// The maximum scale factor for zooming.
-  ///
-  /// This determines the highest level of zoom that can be applied to the child
-  /// widget.
-  final double maxScale;
 
   /// Called when the user ends a pan or scale gesture on the widget.
   ///
@@ -148,8 +110,10 @@ class ExtendedInteractiveViewer extends StatefulWidget {
 }
 
 /// The state for [ExtendedInteractiveViewer], managing the interactivity state.
-class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer> {
+class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer>
+    with TickerProviderStateMixin {
   late TransformationController _transformCtrl;
+  late final AnimationController _animationCtrl;
   late bool _enableInteraction;
 
   @override
@@ -159,12 +123,17 @@ class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer> {
       ..addListener(() {
         widget.onMatrix4Change?.call(_transformCtrl.value);
       });
+    _animationCtrl = AnimationController(
+      vsync: this,
+      duration: widget.zoomConfigs.doubleTapZoomDuration,
+    );
     _enableInteraction = widget.enableInteraction;
   }
 
   @override
   void dispose() {
     _transformCtrl.dispose();
+    _animationCtrl.dispose();
     super.dispose();
   }
 
@@ -188,6 +157,81 @@ class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer> {
     _transformCtrl.value = Matrix4.identity();
   }
 
+  /// Instantly sets the zoom transformation to a specific [offset] and [scale].
+  ///
+  /// If [offset] is null, [Offset.zero] is used. If [scale] is null, 1.0 is
+  /// used.
+  /// This method bypasses animation and immediately updates the view.
+  void zoomTo({Offset? offset, double? scale}) {
+    final effectiveOffset = offset ?? Offset.zero;
+    final effectiveScale = scale ?? 1.0;
+
+    _transformCtrl.value = Matrix4.identity()
+      ..translate(effectiveOffset.dx, effectiveOffset.dy)
+      ..scale(effectiveScale);
+  }
+
+  /// Animates zooming to a specific [offset] and [scale] over [duration].
+  ///
+  /// The transition uses the provided [curve] to control easing. If [offset]
+  /// or [scale] is null, they default to [Offset.zero] and 1.0 respectively.
+  Future<void> animateZoomToPoint({
+    Offset? offset,
+    double? scale,
+    Duration duration = const Duration(milliseconds: 300),
+    Curve curve = Curves.easeInOut,
+  }) async {
+    if (_animationCtrl.isAnimating) return;
+    final effectiveOffset = offset ?? Offset.zero;
+    final effectiveScale = scale ?? 1.0;
+
+    final targetMatrix = Matrix4.identity()
+      ..translate(effectiveOffset.dx, effectiveOffset.dy)
+      ..scale(effectiveScale);
+
+    final tween = Matrix4Tween(
+      begin: _transformCtrl.value,
+      end: targetMatrix,
+    );
+
+    _animationCtrl
+      ..duration = duration
+      ..reset();
+
+    final animation = tween.animate(CurvedAnimation(
+      parent: _animationCtrl,
+      curve: curve,
+    ));
+
+    void listener() {
+      _transformCtrl.value = animation.value;
+    }
+
+    _animationCtrl.addListener(listener);
+    await _animationCtrl.forward();
+    _animationCtrl.removeListener(listener);
+  }
+
+  /// Quickly toggles zoom in or out based on the current [scaleFactor].
+  ///
+  /// If the view is currently zoomed in (scale > 1), this will reset to the
+  /// default scale and position. Otherwise, it will zoom in to [scale] centered
+  /// around the given [offset]. Uses animation with optional [duration] and
+  /// [curve].
+  Future<void> quickZoomTo(
+    Offset offset,
+    double scale, {
+    Duration? duration,
+    Curve? curve,
+  }) async {
+    if (!_enableInteraction) return;
+    if (scaleFactor > 1) {
+      await animateZoomToPoint(offset: Offset.zero, scale: 1);
+    } else {
+      await animateZoomToPoint(offset: -offset, scale: scale);
+    }
+  }
+
   /// The factor by which the current transformation is scaled.
   /// Returns the maximum scale factor applied on any axis.
   double get scaleFactor {
@@ -206,7 +250,7 @@ class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer> {
 
   @override
   Widget build(BuildContext context) {
-    if (!widget.enableZoom) return widget.child;
+    if (!widget.zoomConfigs.enableZoom) return widget.child;
 
     /// If we disable the interaction we need to return it as Transform widget
     /// that the InteractiveViewer will not absorb the scale events.
@@ -217,12 +261,12 @@ class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer> {
       );
     }
     return InteractiveViewer(
-      boundaryMargin: widget.boundaryMargin,
+      boundaryMargin: widget.zoomConfigs.boundaryMargin,
       transformationController: _transformCtrl,
       panEnabled: _enableInteraction,
       scaleEnabled: _enableInteraction,
-      minScale: widget.minScale,
-      maxScale: widget.maxScale,
+      minScale: widget.zoomConfigs.editorMinScale,
+      maxScale: widget.zoomConfigs.editorMaxScale,
       onInteractionStart: widget.onInteractionStart,
       onInteractionUpdate: widget.onInteractionUpdate,
       onInteractionEnd: widget.onInteractionEnd,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 9.5.2
+version: 9.6.0
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
- Introduced double-tap to zoom feature in the main and paint editors.
- Updated MainEditorConfigs and PaintEditorConfigs to extend ZoomConfigs for better zoom management.
- Implemented EditorZoomMixin to handle zoom-related behaviors across editors.
- Refactored ExtendedInteractiveViewer to utilize zoom configurations.
- Enhanced changelog to reflect the new feature in version 9.6.0.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
