### PR TITLE
Pass WidgetLayer in setLayer instead of just Widget

### DIFF
--- a/example/lib/features/stickers_example.dart
+++ b/example/lib/features/stickers_example.dart
@@ -98,34 +98,37 @@ class _StickersExampleState extends State<StickersExample>
                       );
                       LoadingDialog.instance.hide();
                       setLayer(
-                        Sticker(index: index),
-
-                        /// The `exportConfigs` parameter is optional but
-                        /// useful if you want to import or export history and
-                        /// directly load the same sticker.
-                        ///
-                        /// If `exportConfigs` is not added, the editor will
-                        /// convert the exported state history to a `Uint8List`
-                        /// to restore the layer. However, this may reduce
-                        /// quality and cause a delay during export.
-                        ///
-                        /// If you use the ID parameter, it is important to set
-                        /// up a `widgetLoader` inside the `ImportEditorConfigs`
-                        ///  when importing the state history.
-                        /// Refer to the [import-example](https://github.com/hm21/pro_image_editor/blob/stable/example/lib/features/import_export_example.dart)
-                        /// for details on how this works.
-                        exportConfigs: WidgetLayerExportConfigs(
-                          id: 'sticker-$index',
-
-                          /// Alternatively, you can use one of the parameters
-                          /// listed below instead of the id, which does not
-                          /// require setting up the widgetLoader. However,
-                          /// please note that for complex widgets, this
-                          /// approach may slightly alter their size.
+                        WidgetLayer(
+                          widget: Sticker(
+                            index: index
+                          ),
+                          /// The `exportConfigs` parameter is optional but
+                          /// useful if you want to import or export history and
+                          /// directly load the same sticker.
                           ///
-                          /// networkUrl: '',
-                          /// assetPath: '',
-                          /// fileUrl: '',
+                          /// If `exportConfigs` is not added, the editor will
+                          /// convert the exported state history to a `Uint8List`
+                          /// to restore the layer. However, this may reduce
+                          /// quality and cause a delay during export.
+                          ///
+                          /// If you use the ID parameter, it is important to set
+                          /// up a `widgetLoader` inside the `ImportEditorConfigs`
+                          ///  when importing the state history.
+                          /// Refer to the [import-example](https://github.com/hm21/pro_image_editor/blob/stable/example/lib/features/import_export_example.dart)
+                          /// for details on how this works.
+                          exportConfigs: WidgetLayerExportConfigs(
+                            id: 'sticker-$index',
+
+                            /// Alternatively, you can use one of the parameters
+                            /// listed below instead of the id, which does not
+                            /// require setting up the widgetLoader. However,
+                            /// please note that for complex widgets, this
+                            /// approach may slightly alter their size.
+                            ///
+                            /// networkUrl: '',
+                            /// assetPath: '',
+                            /// fileUrl: '',
+                          )
                         ),
                       );
                     },

--- a/example/lib/features/stickers_example.dart
+++ b/example/lib/features/stickers_example.dart
@@ -107,12 +107,12 @@ class _StickersExampleState extends State<StickersExample>
                           /// directly load the same sticker.
                           ///
                           /// If `exportConfigs` is not added, the editor will
-                          /// convert the exported state history to a `Uint8List`
+                          /// convert the exported state history to `Uint8List`
                           /// to restore the layer. However, this may reduce
                           /// quality and cause a delay during export.
                           ///
-                          /// If you use the ID parameter, it is important to set
-                          /// up a `widgetLoader` inside the `ImportEditorConfigs`
+                          /// If you use the ID parameter, it's important to set
+                          /// up a `widgetLoader` inside `ImportEditorConfigs`
                           ///  when importing the state history.
                           /// Refer to the [import-example](https://github.com/hm21/pro_image_editor/blob/stable/example/lib/features/import_export_example.dart)
                           /// for details on how this works.

--- a/example/lib/shared/widgets/demo_build_stickers.dart
+++ b/example/lib/shared/widgets/demo_build_stickers.dart
@@ -21,7 +21,7 @@ class DemoBuildStickers extends StatelessWidget {
   });
 
   /// Callback function to set the selected sticker in the image editor layer.
-  final Function(Widget) setLayer;
+  final Function(WidgetLayer) setLayer;
 
   /// Controls the scroll behavior of the sticker grid.
   final ScrollController scrollController;
@@ -104,7 +104,7 @@ class DemoBuildStickers extends StatelessWidget {
     );
   }
 
-  SliverGrid _buildDemoStickers(int offset, Function(Widget) setLayer) {
+  SliverGrid _buildDemoStickers(int offset, Function(WidgetLayer) setLayer) {
     return SliverGrid.builder(
         gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: 80,
@@ -115,42 +115,44 @@ class DemoBuildStickers extends StatelessWidget {
         itemBuilder: (context, index) {
           String url =
               'https://picsum.photos/id/${offset + (index + 3) * 3}/2000';
-          var widget = ClipRRect(
-            borderRadius: BorderRadius.circular(7),
-            child: Image.network(
-              url,
-              width: 120,
-              height: 120,
-              fit: BoxFit.cover,
-              loadingBuilder: (context, child, loadingProgress) {
-                return AnimatedSwitcher(
-                  layoutBuilder: (currentChild, previousChildren) {
-                    return SizedBox(
-                      width: 120,
-                      height: 120,
-                      child: Stack(
-                        fit: StackFit.expand,
-                        alignment: Alignment.center,
-                        children: <Widget>[
-                          ...previousChildren,
-                          if (currentChild != null) currentChild,
-                        ],
-                      ),
-                    );
-                  },
-                  duration: const Duration(milliseconds: 200),
-                  child: loadingProgress == null
-                      ? child
-                      : Center(
-                          child: CircularProgressIndicator(
-                            value: loadingProgress.expectedTotalBytes != null
-                                ? loadingProgress.cumulativeBytesLoaded /
-                                    loadingProgress.expectedTotalBytes!
-                                : null,
-                          ),
+          var widget = WidgetLayer(
+            widget: ClipRRect(
+              borderRadius: BorderRadius.circular(7),
+              child: Image.network(
+                url,
+                width: 120,
+                height: 120,
+                fit: BoxFit.cover,
+                loadingBuilder: (context, child, loadingProgress) {
+                  return AnimatedSwitcher(
+                    layoutBuilder: (currentChild, previousChildren) {
+                      return SizedBox(
+                        width: 120,
+                        height: 120,
+                        child: Stack(
+                          fit: StackFit.expand,
+                          alignment: Alignment.center,
+                          children: <Widget>[
+                            ...previousChildren,
+                            if (currentChild != null) currentChild,
+                          ],
                         ),
-                );
-              },
+                      );
+                    },
+                    duration: const Duration(milliseconds: 200),
+                    child: loadingProgress == null
+                        ? child
+                        : Center(
+                            child: CircularProgressIndicator(
+                              value: loadingProgress.expectedTotalBytes != null
+                                  ? loadingProgress.cumulativeBytesLoaded /
+                                      loadingProgress.expectedTotalBytes!
+                                  : null,
+                            ),
+                          ),
+                  );
+                },
+              ),
             ),
           );
           return GestureDetector(
@@ -170,7 +172,7 @@ class DemoBuildStickers extends StatelessWidget {
             },
             child: MouseRegion(
               cursor: SystemMouseCursors.click,
-              child: widget,
+              child: widget.widget,
             ),
           );
         });

--- a/lib/core/models/editor_configs/sticker_editor_configs.dart
+++ b/lib/core/models/editor_configs/sticker_editor_configs.dart
@@ -107,8 +107,6 @@ class StickerEditorConfigs {
 /// manipulated within the user interface.
 typedef BuildStickers = Widget Function(
   Function(
-    Widget widget, {
-    WidgetLayerExportConfigs? exportConfigs,
-  }) setLayer,
+    WidgetLayer widgetLayer) setLayer,
   ScrollController scrollController,
 );

--- a/lib/features/sticker_editor/sticker_editor.dart
+++ b/lib/features/sticker_editor/sticker_editor.dart
@@ -67,14 +67,9 @@ class StickerEditorState extends State<StickerEditor>
   ///
   /// [widget] is the widget to be set as the layer.
   void setLayer(
-    Widget widget, {
-    WidgetLayerExportConfigs? exportConfigs,
-  }) {
+    WidgetLayer widgetLayer) {
     Navigator.of(context).pop(
-      WidgetLayer(
-        widget: widget,
-        exportConfigs: exportConfigs ?? const WidgetLayerExportConfigs(),
-      ),
+      widgetLayer,
     );
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
Allows developrs to pass an entire WidgetLayer through the Sticker configs, to support parameters like scale and other transformation properties.

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Other... Please describe: API Change


## What is the current behavior?
Follow up the discussion: https://github.com/hm21/pro_image_editor/discussions/458
The idea is to allow passing Layer properties to the Stickers `setLayer` API as per the standard examples and usage model.

## What is the new behavior?
The wrapper on Widget does not add much on its own, allowing developers to pass `WidgetLayer` possess much more control over the layer being added through the Stickers.

```dart

typedef BuildStickers = Widget Function(
  Function(
    WidgetLayer widgetLayer) setLayer,
  ScrollController scrollController,
);

setLayer(
  WidgetLayer(
    widget: Sticker(
      image: widget.galleryImages[index],
      color: color,
    ),
    exportConfigs: WidgetLayerExportConfigs( )
  ),
)
```

This is a **breaking change**, and needs developrs to pass `WidgetLayer` instead of juts the Widget. `exportConfigs` may be passed along too, instead of inside the `setLayer` callback (much better as well this way, imho).

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
