### PR TITLE
fix: Fix the vertical size calculation & the zoom on layer disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.9.1
+ - **FIX**(Main-Editor & Paint-Editor): Fix the main editor size calculation to reduce layers shiftting
+
 ## 9.9.0
  - **FEAT**(Sticker-Editor): Added `builder` parameter to `StickerEditorConfigs`, which will replace `buildStickers` in the future. The new `builder` supports directly returning a `WidgetLayer` instead of just a `Widget`, enabling more flexibility and control.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 9.9.3
-- **FIX**(Main-Editor & Paint-Editor): Fix the main editor size calculation to reduce layers shiftting and fix the disable layers not allowign zoom gestures on main editor
+- **FIX**(Layers): Corrected size calculation to prevent layer shifting.
+- **FIX**(Main-Editor): Fixed an issue where disabled layers blocked zoom gestures.
 
 ## 9.9.2
  - **FIX**(Crop-Rotate-Editor): Ensure the editor respects the `maxOutputSize` constraint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 9.9.1
- - **FIX**(Main-Editor & Paint-Editor): Fix the main editor size calculation to reduce layers shiftting
+ - **FIX**(Main-Editor & Paint-Editor): Fix the main editor size calculation to reduce layers shiftting and fix the disable layers not allowign zoom gestures on main editor
 
 ## 9.9.0
  - **FEAT**(Sticker-Editor): Added `builder` parameter to `StickerEditorConfigs`, which will replace `buildStickers` in the future. The new `builder` supports directly returning a `WidgetLayer` instead of just a `Widget`, enabling more flexibility and control.

--- a/lib/core/mixins/standalone_editor.dart
+++ b/lib/core/mixins/standalone_editor.dart
@@ -303,17 +303,7 @@ mixin StandaloneEditorState<T extends StatefulWidget,
     super.dispose();
   }
 
-  /// Gets the minimum size between two sizes.
-  ///
-  /// This method returns the smaller of two sizes, ensuring that the resulting
-  /// size is neither null nor empty.
-  Size getMinimumSize(Size? a, Size b) {
-    return a == null || a.isEmpty
-        ? b.isEmpty
-            ? const Size(1, 1)
-            : b
-        : a;
-  }
+
 
   Future<Uint8List> _createTransparentImage() async {
     if (_transparentImageBytes != null) return _transparentImageBytes!;

--- a/lib/core/utils/size_utils.dart
+++ b/lib/core/utils/size_utils.dart
@@ -1,0 +1,17 @@
+import 'dart:ui';
+
+/// Gets the minimum size between two sizes.
+  ///
+  /// This method returns the smaller of two sizes, ensuring that the resulting
+  /// size is neither null nor empty. If the first size (`a`) 
+  /// is valid (non-null and non-empty), it is returned.
+  /// Otherwise, the second size (`b`) is checked. If `b` is also empty, 
+  /// a default size of (1, 1) is returned.
+  /// If `b` is valid, it is returned.
+  Size getValidSizeOrDefault(Size? a, Size b) {
+    return a == null || a.isEmpty
+        ? b.isEmpty
+            ? const Size(1, 1)
+            : b
+        : a;
+  }

--- a/lib/designs/grounded/widgets/bottombar/grounded_filter_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_filter_bar.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
-
+import 'package:pro_image_editor/core/utils/size_utils.dart';
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';
 import '/designs/grounded/grounded_design.dart';
 import '/pro_image_editor.dart';
+
 
 /// A widget that represents a filter bar in the image editor.
 ///
@@ -115,9 +116,9 @@ class _GroundedFilterBarState extends State<GroundedFilterBar>
               listHeight: kGroundedSubBarHeight,
               previewImageSize: const Size(48, 48),
               borderRadius: BorderRadius.circular(2),
-              mainBodySize: widget.editor.getMinimumSize(
+              mainBodySize: getValidSizeOrDefault(
                   widget.editor.mainBodySize, widget.editor.editorBodySize),
-              mainImageSize: widget.editor.getMinimumSize(
+              mainImageSize: getValidSizeOrDefault(
                   widget.editor.mainImageSize, widget.editor.editorBodySize),
               editorImage: widget.editor.editorImage!,
               activeFilters: widget.editor.appliedFilters,

--- a/lib/designs/grounded/widgets/bottombar/grounded_filter_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_filter_bar.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:pro_image_editor/core/utils/size_utils.dart';
+
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';
+import '/core/utils/size_utils.dart';
 import '/designs/grounded/grounded_design.dart';
 import '/pro_image_editor.dart';
 

--- a/lib/designs/whatsapp/whatsapp_done_btn.dart
+++ b/lib/designs/whatsapp/whatsapp_done_btn.dart
@@ -65,7 +65,6 @@ class _WhatsAppDoneBtnState extends State<WhatsAppDoneBtn> {
     return CupertinoButton(
       onPressed: widget.onPressed,
       padding: const EdgeInsets.symmetric(horizontal: 7),
-      minimumSize: Size.zero,
       child: Text(
         widget.configs.i18n.done,
         style: TextStyle(

--- a/lib/features/blur_editor/blur_editor.dart
+++ b/lib/features/blur_editor/blur_editor.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:pro_image_editor/core/utils/size_utils.dart';
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/mixins/converted_configs.dart';
@@ -296,9 +297,9 @@ class BlurEditorState extends State<BlurEditor>
                   LayerStack(
                     transformHelper: TransformHelper(
                       mainBodySize:
-                          getMinimumSize(mainBodySize, editorBodySize),
+                          getValidSizeOrDefault(mainBodySize, editorBodySize),
                       mainImageSize:
-                          getMinimumSize(mainImageSize, editorBodySize),
+                          getValidSizeOrDefault(mainImageSize, editorBodySize),
                       transformConfigs: initialTransformConfigs,
                       editorBodySize: editorBodySize,
                     ),
@@ -333,8 +334,10 @@ class BlurEditorState extends State<BlurEditor>
             stream: _uiBlurStream.stream,
             builder: (context, snapshot) {
               return FilteredWidget(
-                width: getMinimumSize(mainImageSize, editorBodySize).width,
-                height: getMinimumSize(mainImageSize, editorBodySize).height,
+                width:
+                    getValidSizeOrDefault(mainImageSize, editorBodySize).width,
+                height:
+                    getValidSizeOrDefault(mainImageSize, editorBodySize).height,
                 configs: configs,
                 image: editorImage,
                 videoPlayer: videoController?.videoPlayer,

--- a/lib/features/blur_editor/blur_editor.dart
+++ b/lib/features/blur_editor/blur_editor.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import '/core/utils/size_utils.dart';
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/mixins/converted_configs.dart';
@@ -14,6 +13,7 @@ import '/core/models/editor_image.dart';
 import '/core/models/init_configs/blur_editor_init_configs.dart';
 import '/core/models/transform_helper.dart';
 import '/core/platform/io/io_helper.dart';
+import '/core/utils/size_utils.dart';
 import '/features/blur_editor/widgets/blur_editor_bottombar.dart';
 import '/shared/controllers/video_controller.dart';
 import '/shared/services/content_recorder/widgets/content_recorder.dart';
@@ -169,6 +169,7 @@ class BlurEditorState extends State<BlurEditor>
 
   /// Represents the selected blur state.
   double get blurFactor => _blurFactor.value;
+
   set blurFactor(double value) {
     _blurFactor.value = value;
   }

--- a/lib/features/blur_editor/blur_editor.dart
+++ b/lib/features/blur_editor/blur_editor.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:pro_image_editor/core/utils/size_utils.dart';
+import '/core/utils/size_utils.dart';
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/mixins/converted_configs.dart';

--- a/lib/features/filter_editor/filter_editor.dart
+++ b/lib/features/filter_editor/filter_editor.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:pro_image_editor/core/utils/size_utils.dart';
 
 import '/core/constants/image_constants.dart';
 import '/core/mixins/converted_callbacks.dart';
@@ -311,9 +312,9 @@ class FilterEditorState extends State<FilterEditor>
                   LayerStack(
                     transformHelper: TransformHelper(
                       mainBodySize:
-                          getMinimumSize(mainBodySize, editorBodySize),
+                          getValidSizeOrDefault(mainBodySize, editorBodySize),
                       mainImageSize:
-                          getMinimumSize(mainImageSize, editorBodySize),
+                          getValidSizeOrDefault(mainImageSize, editorBodySize),
                       editorBodySize: editorBodySize,
                       transformConfigs: initialTransformConfigs,
                     ),
@@ -348,8 +349,10 @@ class FilterEditorState extends State<FilterEditor>
             stream: _uiFilterStream.stream,
             builder: (context, snapshot) {
               return FilteredWidget(
-                width: getMinimumSize(mainImageSize, editorBodySize).width,
-                height: getMinimumSize(mainImageSize, editorBodySize).height,
+                width:
+                    getValidSizeOrDefault(mainImageSize, editorBodySize).width,
+                height:
+                    getValidSizeOrDefault(mainImageSize, editorBodySize).height,
                 configs: configs,
                 image: editorImage,
                 videoPlayer: videoController?.videoPlayer,
@@ -406,8 +409,10 @@ class FilterEditorState extends State<FilterEditor>
             ),
             StatefulBuilder(builder: (context, setStateFilterList) {
               return FilterEditorItemList(
-                mainBodySize: getMinimumSize(mainBodySize, editorBodySize),
-                mainImageSize: getMinimumSize(mainImageSize, editorBodySize),
+                mainBodySize:
+                    getValidSizeOrDefault(mainBodySize, editorBodySize),
+                mainImageSize:
+                    getValidSizeOrDefault(mainImageSize, editorBodySize),
                 editorImage: editorImage,
                 image: editorImage != null
                     ? null

--- a/lib/features/filter_editor/filter_editor.dart
+++ b/lib/features/filter_editor/filter_editor.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:pro_image_editor/core/utils/size_utils.dart';
+import '/core/utils/size_utils.dart';
 
 import '/core/constants/image_constants.dart';
 import '/core/mixins/converted_callbacks.dart';

--- a/lib/features/filter_editor/filter_editor.dart
+++ b/lib/features/filter_editor/filter_editor.dart
@@ -4,7 +4,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import '/core/utils/size_utils.dart';
 
 import '/core/constants/image_constants.dart';
 import '/core/mixins/converted_callbacks.dart';
@@ -12,6 +11,7 @@ import '/core/mixins/converted_configs.dart';
 import '/core/mixins/standalone_editor.dart';
 import '/core/models/transform_helper.dart';
 import '/core/platform/io/io_helper.dart';
+import '/core/utils/size_utils.dart';
 import '/features/filter_editor/widgets/filter_editor_appbar.dart';
 import '/pro_image_editor.dart';
 import '/shared/services/content_recorder/widgets/content_recorder.dart';

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -1300,38 +1300,31 @@ class ProImageEditorState extends State<ProImageEditor>
 
           animation.addStatusListener(animationStatusListener);
           if (mainEditorConfigs.style.subEditorPage.requireReposition) {
-            return SafeArea(
-              child: Stack(
-                fit: StackFit.expand,
-                children: [
-                  Positioned(
-                    top: mainEditorConfigs.style.subEditorPage.positionTop,
-                    left: mainEditorConfigs.style.subEditorPage.positionLeft,
-                    right: mainEditorConfigs.style.subEditorPage.positionRight,
-                    bottom:
-                        mainEditorConfigs.style.subEditorPage.positionBottom,
-                    child: Center(
-                      child: Container(
-                        width: mainEditorConfigs
-                                .style.subEditorPage.enforceSizeFromMainEditor
-                            ? sizesManager.editorSize.width
-                            : null,
-                        height: mainEditorConfigs
-                                .style.subEditorPage.enforceSizeFromMainEditor
-                            ? sizesManager.editorSize.height
-                            : null,
-                        clipBehavior: Clip.hardEdge,
-                        decoration: BoxDecoration(
-                          borderRadius: mainEditorConfigs
-                              .style.subEditorPage.borderRadius,
-                        ),
-                        child: page,
+            return Positioned(
+                  top: mainEditorConfigs.style.subEditorPage.positionTop,
+                  left: mainEditorConfigs.style.subEditorPage.positionLeft,
+                  right: mainEditorConfigs.style.subEditorPage.positionRight,
+                  bottom:
+                      mainEditorConfigs.style.subEditorPage.positionBottom,
+                  child: Center(
+                    child: Container(
+                      width: mainEditorConfigs
+                              .style.subEditorPage.enforceSizeFromMainEditor
+                          ? sizesManager.editorSize.width
+                          : null,
+                      height: mainEditorConfigs
+                              .style.subEditorPage.enforceSizeFromMainEditor
+                          ? sizesManager.editorSize.height
+                          : null,
+                      clipBehavior: Clip.hardEdge,
+                      decoration: BoxDecoration(
+                        borderRadius: mainEditorConfigs
+                            .style.subEditorPage.borderRadius,
                       ),
+                      child: page,
                     ),
                   ),
-                ],
-              ),
-            );
+                );
           } else {
             return page;
           }
@@ -2202,22 +2195,16 @@ class ProImageEditorState extends State<ProImageEditor>
               value: mainEditorConfigs.style.uiOverlayStyle,
               child: Theme(
                 data: _theme,
-                child: SafeArea(
-                  top: mainEditorConfigs.safeArea.top,
-                  bottom: mainEditorConfigs.safeArea.bottom,
-                  left: mainEditorConfigs.safeArea.left,
-                  right: mainEditorConfigs.safeArea.right,
-                  child: LayoutBuilder(builder: (context, constraints) {
-                    sizesManager.editorSize = constraints.biggest;
-                    return Scaffold(
-                      backgroundColor: mainEditorConfigs.style.background,
-                      resizeToAvoidBottomInset: false,
-                      appBar: _buildAppBar(),
-                      body: _buildBody(),
-                      bottomNavigationBar: _buildBottomNavBar(),
-                    );
-                  }),
-                ),
+                child: LayoutBuilder(builder: (context, constraints) {
+                  sizesManager.editorSize = constraints.biggest;
+                  return Scaffold(
+                    backgroundColor: mainEditorConfigs.style.background,
+                    resizeToAvoidBottomInset: false,
+                    appBar: _buildAppBar(),
+                    body: _buildBody(),
+                    bottomNavigationBar: _buildBottomNavBar(),
+                  );
+                }),
               ),
             ),
           ),

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -1325,7 +1325,8 @@ class ProImageEditorState extends State<ProImageEditor>
                           borderRadius: mainEditorConfigs
                               .style.subEditorPage.borderRadius,
                         ),
-                        child: page,)
+                        child: page,
+                      )
                     ),
                   ),
                 ],

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -1300,31 +1300,37 @@ class ProImageEditorState extends State<ProImageEditor>
 
           animation.addStatusListener(animationStatusListener);
           if (mainEditorConfigs.style.subEditorPage.requireReposition) {
-            return Positioned(
-                  top: mainEditorConfigs.style.subEditorPage.positionTop,
-                  left: mainEditorConfigs.style.subEditorPage.positionLeft,
-                  right: mainEditorConfigs.style.subEditorPage.positionRight,
-                  bottom:
-                      mainEditorConfigs.style.subEditorPage.positionBottom,
-                  child: Center(
-                    child: Container(
-                      width: mainEditorConfigs
-                              .style.subEditorPage.enforceSizeFromMainEditor
-                          ? sizesManager.editorSize.width
-                          : null,
-                      height: mainEditorConfigs
-                              .style.subEditorPage.enforceSizeFromMainEditor
-                          ? sizesManager.editorSize.height
-                          : null,
-                      clipBehavior: Clip.hardEdge,
-                      decoration: BoxDecoration(
-                        borderRadius: mainEditorConfigs
-                            .style.subEditorPage.borderRadius,
-                      ),
-                      child: page,
+            return SafeArea(
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  Positioned(
+                    top: mainEditorConfigs.style.subEditorPage.positionTop,
+                    left: mainEditorConfigs.style.subEditorPage.positionLeft,
+                    right: mainEditorConfigs.style.subEditorPage.positionRight,
+                    bottom:
+                        mainEditorConfigs.style.subEditorPage.positionBottom,
+                    child: Center(
+                      child: Container(
+                        width: mainEditorConfigs
+                                .style.subEditorPage.enforceSizeFromMainEditor
+                            ? sizesManager.editorSize.width
+                            : null,
+                        height: mainEditorConfigs
+                                .style.subEditorPage.enforceSizeFromMainEditor
+                            ? sizesManager.editorSize.height
+                            : null,
+                        clipBehavior: Clip.hardEdge,
+                        decoration: BoxDecoration(
+                          borderRadius: mainEditorConfigs
+                              .style.subEditorPage.borderRadius,
+                        ),
+                        child: page,)
                     ),
                   ),
-                );
+                ],
+              ),
+            );
           } else {
             return page;
           }
@@ -2195,16 +2201,22 @@ class ProImageEditorState extends State<ProImageEditor>
               value: mainEditorConfigs.style.uiOverlayStyle,
               child: Theme(
                 data: _theme,
-                child: LayoutBuilder(builder: (context, constraints) {
-                  sizesManager.editorSize = constraints.biggest;
-                  return Scaffold(
-                    backgroundColor: mainEditorConfigs.style.background,
-                    resizeToAvoidBottomInset: false,
-                    appBar: _buildAppBar(),
-                    body: _buildBody(),
-                    bottomNavigationBar: _buildBottomNavBar(),
-                  );
-                }),
+                child: SafeArea(
+                  top: mainEditorConfigs.safeArea.top,
+                  bottom: mainEditorConfigs.safeArea.bottom,
+                  left: mainEditorConfigs.safeArea.left,
+                  right: mainEditorConfigs.safeArea.right,
+                  child: LayoutBuilder(builder: (context, constraints) {
+                    sizesManager.editorSize = constraints.biggest;
+                    return Scaffold(
+                      backgroundColor: mainEditorConfigs.style.background,
+                      resizeToAvoidBottomInset: false,
+                      appBar: _buildAppBar(),
+                      body: _buildBody(),
+                      bottomNavigationBar: _buildBottomNavBar(),
+                    );
+                  }),
+                ),
               ),
             ),
           ),

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -763,13 +763,13 @@ class ProImageEditorState extends State<ProImageEditor>
     _checkInteractiveViewer();
     _controllers.uiLayerCtrl.add(null);
 
-    /* 
+    /*
     String selectedLayerId = _layerInteractionManager.selectedLayerId;
     _layerInteractionManager.selectedLayerId = '';
     setState(() {});
     takeScreenshot();
     if (selectedLayerId.isNotEmpty) {
-      /// Skip one frame to ensure captured image in separate thread will not 
+      /// Skip one frame to ensure captured image in separate thread will not
       /// capture the border.
       WidgetsBinding.instance.addPostFrameCallback((_) async {
         _layerInteractionManager.selectedLayerId = selectedLayerId;
@@ -1311,22 +1311,23 @@ class ProImageEditorState extends State<ProImageEditor>
                     bottom:
                         mainEditorConfigs.style.subEditorPage.positionBottom,
                     child: Center(
-                        child: Container(
-                      width: mainEditorConfigs
-                              .style.subEditorPage.enforceSizeFromMainEditor
-                          ? sizesManager.editorSize.width
-                          : null,
-                      height: mainEditorConfigs
-                              .style.subEditorPage.enforceSizeFromMainEditor
-                          ? sizesManager.editorSize.height
-                          : null,
-                      clipBehavior: Clip.hardEdge,
-                      decoration: BoxDecoration(
-                        borderRadius:
-                            mainEditorConfigs.style.subEditorPage.borderRadius,
+                      child: Container(
+                        width: mainEditorConfigs
+                                .style.subEditorPage.enforceSizeFromMainEditor
+                            ? sizesManager.editorSize.width
+                            : null,
+                        height: mainEditorConfigs
+                                .style.subEditorPage.enforceSizeFromMainEditor
+                            ? sizesManager.editorSize.height
+                            : null,
+                        clipBehavior: Clip.hardEdge,
+                        decoration: BoxDecoration(
+                          borderRadius: mainEditorConfigs
+                              .style.subEditorPage.borderRadius,
+                        ),
+                        child: page,
                       ),
-                      child: page,
-                    )),
+                    ),
                   ),
                 ],
               ),

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -1311,23 +1311,22 @@ class ProImageEditorState extends State<ProImageEditor>
                     bottom:
                         mainEditorConfigs.style.subEditorPage.positionBottom,
                     child: Center(
-                      child: Container(
-                        width: mainEditorConfigs
-                                .style.subEditorPage.enforceSizeFromMainEditor
-                            ? sizesManager.editorSize.width
-                            : null,
-                        height: mainEditorConfigs
-                                .style.subEditorPage.enforceSizeFromMainEditor
-                            ? sizesManager.editorSize.height
-                            : null,
-                        clipBehavior: Clip.hardEdge,
-                        decoration: BoxDecoration(
-                          borderRadius: mainEditorConfigs
-                              .style.subEditorPage.borderRadius,
-                        ),
-                        child: page,
-                      )
-                    ),
+                        child: Container(
+                      width: mainEditorConfigs
+                              .style.subEditorPage.enforceSizeFromMainEditor
+                          ? sizesManager.editorSize.width
+                          : null,
+                      height: mainEditorConfigs
+                              .style.subEditorPage.enforceSizeFromMainEditor
+                          ? sizesManager.editorSize.height
+                          : null,
+                      clipBehavior: Clip.hardEdge,
+                      decoration: BoxDecoration(
+                        borderRadius:
+                            mainEditorConfigs.style.subEditorPage.borderRadius,
+                      ),
+                      child: page,
+                    )),
                   ),
                 ],
               ),

--- a/lib/features/main_editor/widgets/main_editor_layers.dart
+++ b/lib/features/main_editor/widgets/main_editor_layers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:pro_image_editor/core/utils/size_utils.dart';
 
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
@@ -12,6 +13,7 @@ import '/shared/utils/unique_id_generator.dart';
 import '/shared/widgets/extended/mouse_region/extended_rebuild_mouse_region.dart';
 import '/shared/widgets/layer/layer_widget.dart';
 import '../main_editor.dart';
+
 
 /// A widget that manages and displays layers in the main editor, handling
 /// interactions, configurations, and callbacks for user actions.
@@ -102,6 +104,9 @@ class MainEditorLayers extends StatefulWidget {
 
 class _MainEditorLayersState extends State<MainEditorLayers> {
   final _deferId = ValueNotifier(generateUniqueId());
+
+  /// Represents the dimensions of the body.
+  Size editorBodySize = Size.infinite;
 
   /// Key for managing mouse cursor regions.
   final _mouseCursorsKey = GlobalKey<ExtendedRebuildMouseRegionState>();
@@ -198,7 +203,10 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
           // Render an empty container when resetting layers
           if (resetLayerSnapshot.data!) return const SizedBox.shrink();
 
-          return _buildLayerRepaintBoundary();
+          return LayoutBuilder(builder: (context, constraints) {
+            editorBodySize = constraints.biggest;
+            return _buildLayerRepaintBoundary();
+          });
         },
       ),
     );
@@ -236,15 +244,17 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
 
   /// Builds a single layer widget
   Widget _buildLayerWidget(MapEntry<int, Layer> entry) {
+    var bodySize = 
+      getValidSizeOrDefault(widget.sizesManager.bodySize, editorBodySize);
+
     int index = entry.key;
     Layer layer = entry.value;
     return LayerWidget(
       key: layer.key,
       configs: widget.configs,
       callbacks: widget.callbacks,
-      editorCenterX: widget.sizesManager.editorSize.width / 2,
-      editorCenterY:
-          widget.sizesManager.editorCenterY(widget.selectedLayerIndex),
+      editorCenterX: bodySize.width / 2,
+      editorCenterY: bodySize.height / 2,
       layerData: layer,
       enableHitDetection: widget.layerInteractionManager.enabledHitDetection,
       selected: widget.layerInteractionManager.selectedLayerId == layer.id,

--- a/lib/features/main_editor/widgets/main_editor_layers.dart
+++ b/lib/features/main_editor/widgets/main_editor_layers.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import '/core/utils/size_utils.dart';
 
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/layers/layer.dart';
+import '/core/utils/size_utils.dart';
 import '/features/main_editor/controllers/main_editor_controllers.dart';
 import '/features/main_editor/services/layer_interaction_manager.dart';
 import '/features/main_editor/services/sizes_manager.dart';
@@ -13,7 +13,6 @@ import '/shared/utils/unique_id_generator.dart';
 import '/shared/widgets/extended/mouse_region/extended_rebuild_mouse_region.dart';
 import '/shared/widgets/layer/layer_widget.dart';
 import '../main_editor.dart';
-
 
 /// A widget that manages and displays layers in the main editor, handling
 /// interactions, configurations, and callbacks for user actions.
@@ -244,8 +243,8 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
 
   /// Builds a single layer widget
   Widget _buildLayerWidget(MapEntry<int, Layer> entry) {
-    var bodySize = 
-      getValidSizeOrDefault(widget.sizesManager.bodySize, editorBodySize);
+    var bodySize =
+        getValidSizeOrDefault(widget.sizesManager.bodySize, editorBodySize);
 
     int index = entry.key;
     Layer layer = entry.value;

--- a/lib/features/main_editor/widgets/main_editor_layers.dart
+++ b/lib/features/main_editor/widgets/main_editor_layers.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:pro_image_editor/core/utils/size_utils.dart';
+import '/core/utils/size_utils.dart';
 
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:pro_image_editor/core/utils/size_utils.dart';
 import 'package:pro_image_editor/shared/mixins/editor_zoom.mixin.dart';
 
 import '/core/constants/image_constants.dart';
@@ -822,10 +823,10 @@ class PaintEditorState extends State<PaintEditor>
                         configs: configs,
                         layers: layers!,
                         transformHelper: TransformHelper(
-                          mainBodySize:
-                              getMinimumSize(mainBodySize, editorBodySize),
-                          mainImageSize:
-                              getMinimumSize(mainImageSize, editorBodySize),
+                          mainBodySize: getValidSizeOrDefault(
+                              mainBodySize, editorBodySize),
+                          mainImageSize: getValidSizeOrDefault(
+                              mainImageSize, editorBodySize),
                           editorBodySize: editorBodySize,
                           transformConfigs: initialTransformConfigs,
                         ),
@@ -861,8 +862,8 @@ class PaintEditorState extends State<PaintEditor>
       configs: configs,
       transformConfigs: initialTransformConfigs ?? TransformConfigs.empty(),
       child: FilteredWidget(
-        width: getMinimumSize(mainImageSize, editorBodySize).width,
-        height: getMinimumSize(mainImageSize, editorBodySize).height,
+        width: getValidSizeOrDefault(mainImageSize, editorBodySize).width,
+        height: getValidSizeOrDefault(mainImageSize, editorBodySize).height,
         configs: configs,
         image: editorImage,
         videoPlayer: videoController?.videoPlayer,

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -720,28 +720,26 @@ class PaintEditorState extends State<PaintEditor>
   /// Builds the main body of the paint editor.
   /// Returns a [Widget] representing the editor's body.
   Widget _buildBody() {
-    return SafeArea(
-      child: LayoutBuilder(builder: (context, constraints) {
-        editorBodySize = constraints.biggest;
-        return Theme(
-          data: theme,
-          child: Material(
-            color:
-                initConfigs.convertToUint8List && initConfigs.convertToUint8List
-                    ? paintEditorConfigs.style.background
-                    : Colors.transparent,
-            textStyle: platformTextStyle(context, designMode),
-            child: Stack(
-              alignment: Alignment.center,
-              fit: StackFit.expand,
-              children: _fakeHeroBytes != null
-                  ? _buildFakeHero()
-                  : _buildInteractiveContent(),
-            ),
+    return LayoutBuilder(builder: (context, constraints) {
+      editorBodySize = constraints.biggest;
+      return Theme(
+        data: theme,
+        child: Material(
+          color:
+              initConfigs.convertToUint8List && initConfigs.convertToUint8List
+                  ? paintEditorConfigs.style.background
+                  : Colors.transparent,
+          textStyle: platformTextStyle(context, designMode),
+          child: Stack(
+            alignment: Alignment.center,
+            fit: StackFit.expand,
+            children: _fakeHeroBytes != null
+                ? _buildFakeHero()
+                : _buildInteractiveContent(),
           ),
-        );
-      }),
-    );
+        ),
+      );
+    });
   }
 
   List<Widget> _buildFakeHero() {

--- a/lib/features/tune_editor/tune_editor.dart
+++ b/lib/features/tune_editor/tune_editor.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:pro_image_editor/core/utils/size_utils.dart';
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/mixins/converted_configs.dart';
@@ -468,8 +469,10 @@ class TuneEditorState extends State<TuneEditor>
             stream: uiStream.stream,
             builder: (context, snapshot) {
               return FilteredWidget(
-                width: getMinimumSize(mainImageSize, editorBodySize).width,
-                height: getMinimumSize(mainImageSize, editorBodySize).height,
+                width:
+                    getValidSizeOrDefault(mainImageSize, editorBodySize).width,
+                height:
+                    getValidSizeOrDefault(mainImageSize, editorBodySize).height,
                 configs: configs,
                 image: editorImage,
                 videoPlayer: videoController?.videoPlayer,
@@ -485,8 +488,8 @@ class TuneEditorState extends State<TuneEditor>
   Widget _buildLayers() {
     return LayerStack(
       transformHelper: TransformHelper(
-        mainBodySize: getMinimumSize(mainBodySize, editorBodySize),
-        mainImageSize: getMinimumSize(mainImageSize, editorBodySize),
+        mainBodySize: getValidSizeOrDefault(mainBodySize, editorBodySize),
+        mainImageSize: getValidSizeOrDefault(mainImageSize, editorBodySize),
         editorBodySize: editorBodySize,
         transformConfigs: initialTransformConfigs,
       ),

--- a/lib/features/tune_editor/tune_editor.dart
+++ b/lib/features/tune_editor/tune_editor.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:pro_image_editor/core/utils/size_utils.dart';
+import '/core/utils/size_utils.dart';
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/mixins/converted_configs.dart';

--- a/lib/features/tune_editor/tune_editor.dart
+++ b/lib/features/tune_editor/tune_editor.dart
@@ -4,13 +4,13 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import '/core/utils/size_utils.dart';
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/standalone_editor.dart';
 import '/core/models/transform_helper.dart';
 import '/core/platform/io/io_helper.dart';
+import '/core/utils/size_utils.dart';
 import '/features/tune_editor/widgets/tune_editor_bottombar.dart';
 import '/pro_image_editor.dart';
 import '/shared/services/content_recorder/widgets/content_recorder.dart';

--- a/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
+++ b/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
@@ -162,18 +162,23 @@ class _LayerInteractionHelperWidgetState
 
   @override
   Widget build(BuildContext context) {
+    if (widget.forceIgnoreGestures) {
+      return IgnorePointer(
+          ignoring: widget.forceIgnoreGestures, child: widget.child);
+    }
+
+    String layerId = widget.layerData.id;
     var deferManager = DeferManager.maybeOf(context);
 
     if (!widget.isInteractive ||
         (!widget.selected && deferManager?.selectedLayerId != '')) {
       // Return the child widget directly if the layer is not interactive.
-      return IgnorePointer(
-          ignoring: widget.forceIgnoreGestures, child: widget.child);
+      return widget.child;
     } else if (!widget.selected) {
       // Use a defer pointer if the layer is not selected, preventing
       // interaction.
-      return IgnorePointer(
-        ignoring: widget.forceIgnoreGestures,
+      return DeferPointer(
+        key: ValueKey('Defer-${deferManager?.id ?? ''}-$layerId'),
         child: widget.child,
       );
     }
@@ -183,8 +188,7 @@ class _LayerInteractionHelperWidgetState
 
     return TooltipVisibility(
       visible: layerInteraction.style.showTooltips,
-      child: IgnorePointer(
-        ignoring: widget.forceIgnoreGestures,
+      child: DeferPointer(
         child: Stack(
           fit: StackFit.passthrough,
           alignment: Alignment.center,

--- a/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
+++ b/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
@@ -60,6 +60,7 @@ class LayerInteractionHelperWidget extends StatefulWidget
     this.selected = false,
     this.isInteractive = false,
     this.callbacks = const ProImageEditorCallbacks(),
+    this.forceIgnoreGestures = false,
   });
 
   /// The configuration settings for the image editor.
@@ -120,6 +121,13 @@ class LayerInteractionHelperWidget extends StatefulWidget
   /// tooltips.
   final bool isInteractive;
 
+  /// Determines whether gesture interactions should be forcibly ignored.
+  ///
+  /// When set to `true`, all gesture interactions with the associated widget
+  /// will be ignored, regardless of other conditions. This can be useful in
+  /// scenarios where you want to temporarily disable user interaction.
+  final bool forceIgnoreGestures;
+
   /// Indicates whether the layer is selected.
   ///
   /// If true, the layer is highlighted, and interaction buttons are displayed.
@@ -154,18 +162,18 @@ class _LayerInteractionHelperWidgetState
 
   @override
   Widget build(BuildContext context) {
-    String layerId = widget.layerData.id;
     var deferManager = DeferManager.maybeOf(context);
 
     if (!widget.isInteractive ||
         (!widget.selected && deferManager?.selectedLayerId != '')) {
       // Return the child widget directly if the layer is not interactive.
-      return widget.child;
+      return IgnorePointer(
+          ignoring: widget.forceIgnoreGestures, child: widget.child);
     } else if (!widget.selected) {
       // Use a defer pointer if the layer is not selected, preventing
       // interaction.
-      return DeferPointer(
-        key: ValueKey('Defer-${deferManager?.id ?? ''}-$layerId'),
+      return IgnorePointer(
+        ignoring: widget.forceIgnoreGestures,
         child: widget.child,
       );
     }
@@ -175,7 +183,8 @@ class _LayerInteractionHelperWidgetState
 
     return TooltipVisibility(
       visible: layerInteraction.style.showTooltips,
-      child: DeferPointer(
+      child: IgnorePointer(
+        ignoring: widget.forceIgnoreGestures,
         child: Stack(
           fit: StackFit.passthrough,
           alignment: Alignment.center,

--- a/lib/shared/widgets/layer/layer_widget.dart
+++ b/lib/shared/widgets/layer/layer_widget.dart
@@ -298,6 +298,8 @@ class _LayerWidgetState extends State<LayerWidget>
       callbacks: callbacks,
       selected: widget.selected,
       onEditLayer: widget.onEditTap,
+      forceIgnoreGestures:
+          !(interaction.enableSelection || interaction.enableEdit),
       isInteractive: widget.isInteractive,
       onScaleRotateDown: (details) {
         widget.onScaleRotateDown?.call(details, context.size ?? Size.zero);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 9.9.0
+version: 9.9.1
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #465 #467


## What is the new behavior?
refactor: replace getMinimumSize with getValidSizeOrDefault in various editors
fix: add `forceIgnoreGestures` to allow zoom gestures when a layer is disable

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
