### PR TITLE
fix(crop-rotate-editor): prevent crash when clamping with reversed limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.9.1
+ - **FIX**(Crop-Rotate-Editor): Prevent crashes when clamping values with reversed lower and upper limits. This resolves issue [#462](https://github.com/hm21/pro_image_editor/issues/462).
+
 ## 9.9.0
  - **FEAT**(Sticker-Editor): Added `builder` parameter to `StickerEditorConfigs`, which will replace `buildStickers` in the future. The new `builder` supports directly returning a `WidgetLayer` instead of just a `Widget`, enabling more flexibility and control.
 

--- a/lib/designs/whatsapp/whatsapp_done_btn.dart
+++ b/lib/designs/whatsapp/whatsapp_done_btn.dart
@@ -65,7 +65,7 @@ class _WhatsAppDoneBtnState extends State<WhatsAppDoneBtn> {
     return CupertinoButton(
       onPressed: widget.onPressed,
       padding: const EdgeInsets.symmetric(horizontal: 7),
-      minSize: 0,
+      minimumSize: Size.zero,
       child: Text(
         widget.configs.i18n.done,
         style: TextStyle(

--- a/lib/features/crop_rotate_editor/crop_rotate_editor.dart
+++ b/lib/features/crop_rotate_editor/crop_rotate_editor.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart' hide Image;
 import 'package:flutter/services.dart';
+import 'package:pro_image_editor/shared/extensions/double_extension.dart';
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/mixins/converted_configs.dart';
@@ -1539,8 +1540,8 @@ class CropRotateEditorState extends State<CropRotateEditor>
           switch (_currentCropAreaPart) {
             case CropAreaPart.topLeft:
               cropRect = Rect.fromLTRB(
-                dx.clamp(minLeft, maxRight),
-                dy.clamp(minTop, maxBottom),
+                dx.safeMinClamp(minLeft, maxRight),
+                dy.safeMinClamp(minTop, maxBottom),
                 cropRect.right,
                 cropRect.bottom,
               );
@@ -1549,31 +1550,31 @@ class CropRotateEditorState extends State<CropRotateEditor>
             case CropAreaPart.topRight:
               cropRect = Rect.fromLTRB(
                 cropRect.left,
-                dy.clamp(minTop, maxBottom),
-                dx.clamp(cornerGap + cropRect.left, minRight),
+                dy.safeMinClamp(minTop, maxBottom),
+                dx.safeMinClamp(cornerGap + cropRect.left, minRight),
                 cropRect.bottom,
               );
 
               break;
             case CropAreaPart.bottomLeft:
               cropRect = Rect.fromLTRB(
-                dx.clamp(minLeft, maxRight),
+                dx.safeMinClamp(minLeft, maxRight),
                 cropRect.top,
                 cropRect.right,
-                dy.clamp(cornerGap + cropRect.top, minBottom),
+                dy.safeMinClamp(cornerGap + cropRect.top, minBottom),
               );
               break;
             case CropAreaPart.bottomRight:
               cropRect = Rect.fromLTRB(
                 cropRect.left,
                 cropRect.top,
-                dx.clamp(cornerGap + cropRect.left, minRight),
-                dy.clamp(cornerGap + cropRect.top, minBottom),
+                dx.safeMinClamp(cornerGap + cropRect.left, minRight),
+                dy.safeMinClamp(cornerGap + cropRect.top, minBottom),
               );
               break;
             case CropAreaPart.left:
               cropRect = Rect.fromLTRB(
-                dx.clamp(minLeft, maxRight),
+                dx.safeMinClamp(minLeft, maxRight),
                 cropRect.top,
                 cropRect.right,
                 cropRect.bottom,
@@ -1584,14 +1585,14 @@ class CropRotateEditorState extends State<CropRotateEditor>
               cropRect = Rect.fromLTRB(
                 cropRect.left,
                 cropRect.top,
-                dx.clamp(cornerGap + cropRect.left, minRight),
+                dx.safeMinClamp(cornerGap + cropRect.left, minRight),
                 cropRect.bottom,
               );
               break;
             case CropAreaPart.top:
               cropRect = Rect.fromLTRB(
                 cropRect.left,
-                dy.clamp(minTop, maxBottom),
+                dy.safeMaxClamp(minTop, maxBottom),
                 cropRect.right,
                 cropRect.bottom,
               );
@@ -1601,7 +1602,7 @@ class CropRotateEditorState extends State<CropRotateEditor>
                 cropRect.left,
                 cropRect.top,
                 cropRect.right,
-                dy.clamp(cornerGap + cropRect.top, minBottom),
+                dy.safeMinClamp(cornerGap + cropRect.top, minBottom),
               );
               break;
             default:

--- a/lib/shared/extensions/double_extension.dart
+++ b/lib/shared/extensions/double_extension.dart
@@ -1,0 +1,40 @@
+import 'dart:math';
+
+/// Extension for [double] values that provides safe clamping methods.
+extension DoubleExtension on double {
+  /// Clamps the double value between [lowerLimit] and [upperLimit],
+  /// ensuring [lowerLimit] is not greater than [upperLimit].
+  ///
+  /// Returns the clamped value as a double.
+  ///
+  /// Example:
+  /// ```dart
+  /// 3.5.safeMinClamp(8, 5); // returns 5
+  /// 5.5.safeMinClamp(2, 10); // returns 5.5
+  /// 12.0.safeMinClamp(2, 10); // returns 10.0
+  /// ```
+  double safeMinClamp(num lowerLimit, num upperLimit) {
+    return clamp(
+      min(lowerLimit, upperLimit),
+      upperLimit,
+    ).toDouble();
+  }
+
+  /// Clamps the double value between [lowerLimit] and [upperLimit],
+  /// ensuring [upperLimit] is not less than [lowerLimit].
+  ///
+  /// Returns the clamped value as a double.
+  ///
+  /// Example:
+  /// ```dart
+  /// 12.safeMinClamp(8, 5); // returns 8
+  /// 1.5.safeMaxClamp(2, 10); // returns 2.0
+  /// 5.5.safeMaxClamp(2, 10); // returns 5.5
+  /// ```
+  double safeMaxClamp(num lowerLimit, num upperLimit) {
+    return clamp(
+      lowerLimit,
+      max(lowerLimit, upperLimit),
+    ).toDouble();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 9.9.0
+version: 9.9.1
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #462


## What is the new behavior?
Ensure clamping logic handles cases where lower and upper limits are swapped.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
