### PR TITLE
fix(widget-layer): include exportConfigs on copyWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.9.5
+- **FIX**(widget-layer): `copyWith` now correctly includes `exportConfigs`. 
+
 ## 9.9.4
 - **FIX**(Main-Editor): Corrected editor name handling in `openPage` to ensure proper behavior of `onOpenSubEditor`, `onStartCloseSubEditor` and `onEndCloseSubEditor`. This resolves issue [#474](https://github.com/hm21/pro_image_editor/issues/474).
 

--- a/lib/core/models/layers/widget_layer.dart
+++ b/lib/core/models/layers/widget_layer.dart
@@ -174,6 +174,7 @@ class WidgetLayer extends Layer {
     bool? flipX,
     bool? flipY,
     LayerInteraction? interaction,
+    WidgetLayerExportConfigs? exportConfigs,
   }) {
     return WidgetLayer(
       widget: widget ?? this.widget,
@@ -184,6 +185,7 @@ class WidgetLayer extends Layer {
       flipX: flipX ?? this.flipX,
       flipY: flipY ?? this.flipY,
       interaction: interaction ?? this.interaction,
+      exportConfigs: exportConfigs ?? this.exportConfigs
     );
   }
 }

--- a/lib/core/models/layers/widget_layer.dart
+++ b/lib/core/models/layers/widget_layer.dart
@@ -185,7 +185,7 @@ class WidgetLayer extends Layer {
       flipX: flipX ?? this.flipX,
       flipY: flipY ?? this.flipY,
       interaction: interaction ?? this.interaction,
-      exportConfigs: exportConfigs ?? this.exportConfigs
+      exportConfigs: exportConfigs ?? this.exportConfigs,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 9.9.4
+version: 9.9.5
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [x] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [x] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [X] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
exportConfigs were being lost when copying `WidgetLayer` and could lead to data loss upon export.

Issue Number: N/A

## New Behavior
WidgetLayerExportConfigs are carried over when copying widgets, and allow overrides.

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
