### PR TITLE
fix(SafeArea): add missing SafeArea inside the showModalBottomSheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 9.11.2
+- **FIX**(main-editor): Add missing `showModalBottomSheet` parameter to `SafeArea`.
+- **FIX**(paint-editor): Add missing `showModalBottomSheet` parameter to `SafeArea`.
+- **FIX**(text-editor): Add missing `showModalBottomSheet` parameter to `SafeArea`.
+- **FIX**(crop-rotate-editor): Add missing `showModalBottomSheet` parameter to `SafeArea`.
+- **FIX**(whatsapp-example): Add missing `showModalBottomSheet` parameter to `SafeArea`.
+- **FIX**(recoder_layer-example): Add missing `showModalBottomSheet` parameter to `SafeArea`.
+- **FIX**(movable-background-image-example): Add missing `showModalBottomSheet` parameter to `SafeArea`.
+- **FIX**(frame-example): Add missing `showModalBottomSheet` parameter to `SafeArea`.
+
 ## 9.11.1
 - **FIX**(video-editor): Add missing `image` parameter to `GroundedFilterBar`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,7 @@
 # Changelog
 
 ## 9.11.2
-- **FIX**(main-editor): Add missing `showModalBottomSheet` parameter to `SafeArea`.
-- **FIX**(paint-editor): Add missing `showModalBottomSheet` parameter to `SafeArea`.
-- **FIX**(text-editor): Add missing `showModalBottomSheet` parameter to `SafeArea`.
-- **FIX**(crop-rotate-editor): Add missing `showModalBottomSheet` parameter to `SafeArea`.
-- **FIX**(whatsapp-example): Add missing `showModalBottomSheet` parameter to `SafeArea`.
-- **FIX**(recoder_layer-example): Add missing `showModalBottomSheet` parameter to `SafeArea`.
-- **FIX**(movable-background-image-example): Add missing `showModalBottomSheet` parameter to `SafeArea`.
-- **FIX**(frame-example): Add missing `showModalBottomSheet` parameter to `SafeArea`.
+- **FIX**(bottom-sheet): Wrap bottom sheets in `SafeArea` to ensure proper display within device safe zones.
 
 ## 9.11.1
 - **FIX**(video-editor): Add missing `image` parameter to `GroundedFilterBar`.

--- a/example/lib/features/design_examples/whatsapp_example.dart
+++ b/example/lib/features/design_examples/whatsapp_example.dart
@@ -78,8 +78,8 @@ class _WhatsAppExampleState extends State<WhatsAppExample>
         showDragHandle: false,
         isScrollControlled: true,
         useSafeArea: true,
-        builder: (context) {
-          return Padding(
+        builder: (context) => SafeArea(
+          child: Padding(
             padding: const EdgeInsets.only(top: 12.0),
             child: ClipRRect(
               borderRadius: const BorderRadius.only(
@@ -92,8 +92,8 @@ class _WhatsAppExampleState extends State<WhatsAppExample>
                 callbacks: editor.callbacks,
               ),
             ),
-          );
-        },
+          ),
+        ),
       );
     }
 

--- a/example/lib/features/frame_example.dart
+++ b/example/lib/features/frame_example.dart
@@ -149,8 +149,8 @@ class _FrameExampleState extends State<FrameExample>
         constraints: BoxConstraints(
           minWidth: min(MediaQuery.sizeOf(context).width, 360),
         ),
-        builder: (context) {
-          return Material(
+        builder: (context) => SafeArea(
+          child: Material(
             color: Colors.transparent,
             child: SingleChildScrollView(
               child: Padding(
@@ -180,8 +180,8 @@ class _FrameExampleState extends State<FrameExample>
                 ),
               ),
             ),
-          );
-        },
+          ),
+        ),
       );
     }
   }

--- a/example/lib/features/movable_background_image.dart
+++ b/example/lib/features/movable_background_image.dart
@@ -147,8 +147,8 @@ class _MovableBackgroundImageExampleState
         constraints: BoxConstraints(
           minWidth: min(MediaQuery.sizeOf(context).width, 360),
         ),
-        builder: (context) {
-          return Material(
+        builder: (context) => SafeArea(
+          child: Material(
             color: Colors.transparent,
             child: SingleChildScrollView(
               child: Padding(
@@ -178,8 +178,8 @@ class _MovableBackgroundImageExampleState
                 ),
               ),
             ),
-          );
-        },
+          ),
+        ),
       );
     }
   }
@@ -219,8 +219,8 @@ class _MovableBackgroundImageExampleState
   void _openReorderSheet(ProImageEditorState editor) {
     showModalBottomSheet(
       context: context,
-      builder: (context) {
-        return ReorderLayerSheet(
+      builder: (context) => SafeArea(
+        child: ReorderLayerSheet(
           layers: editor.activeLayers,
           onReorder: (oldIndex, newIndex) {
             editor.moveLayerListPosition(
@@ -229,8 +229,8 @@ class _MovableBackgroundImageExampleState
             );
             Navigator.pop(context);
           },
-        );
-      },
+        ),
+      ),
     );
   }
 

--- a/example/lib/features/reorder_layer_example.dart
+++ b/example/lib/features/reorder_layer_example.dart
@@ -88,8 +88,8 @@ class _ReorderLayerExampleState extends State<ReorderLayerExample>
                                   onPressed: () {
                                     showModalBottomSheet(
                                       context: context,
-                                      builder: (context) {
-                                        return ReorderLayerSheet(
+                                      builder: (context) => SafeArea(
+                                        child: ReorderLayerSheet(
                                           layers: editor.activeLayers,
                                           onReorder: (oldIndex, newIndex) {
                                             editor.moveLayerListPosition(
@@ -98,8 +98,8 @@ class _ReorderLayerExampleState extends State<ReorderLayerExample>
                                             );
                                             Navigator.pop(context);
                                           },
-                                        );
-                                      },
+                                        ),
+                                      ),
                                     );
                                   },
                                   icon: const Icon(

--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -13,6 +13,7 @@
 #include <media_kit_video/media_kit_video_plugin.h>
 #include <pro_video_editor/pro_video_editor_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
+#include <volume_controller/volume_controller_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_saver_registrar =
@@ -36,4 +37,7 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+  g_autoptr(FlPluginRegistrar) volume_controller_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "VolumeControllerPlugin");
+  volume_controller_plugin_register_with_registrar(volume_controller_registrar);
 }

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -10,10 +10,10 @@ list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_video
   pro_video_editor
   url_launcher_linux
+  volume_controller
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
-  media_kit_native_event_loop
   onnxruntime
 )
 

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -17,10 +17,10 @@ import media_kit_video
 import package_info_plus
 import path_provider_foundation
 import pro_video_editor
-import screen_brightness_macos
 import shared_preferences_foundation
 import url_launcher_macos
 import video_player_avfoundation
+import volume_controller
 import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -36,9 +36,9 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ProVideoEditorPlugin.register(with: registry.registrar(forPlugin: "ProVideoEditorPlugin"))
-  ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
+  VolumeControllerPlugin.register(with: registry.registrar(forPlugin: "VolumeControllerPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -15,8 +15,8 @@
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
 #include <pro_video_editor/pro_video_editor_plugin_c_api.h>
-#include <screen_brightness_windows/screen_brightness_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
+#include <volume_controller/volume_controller_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
@@ -37,8 +37,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("MediaKitVideoPluginCApi"));
   ProVideoEditorPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ProVideoEditorPluginCApi"));
-  ScreenBrightnessWindowsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("ScreenBrightnessWindowsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
+  VolumeControllerPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("VolumeControllerPluginCApi"));
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -12,12 +12,11 @@ list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_libs_windows_video
   media_kit_video
   pro_video_editor
-  screen_brightness_windows
   url_launcher_windows
+  volume_controller
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
-  media_kit_native_event_loop
   onnxruntime
 )
 

--- a/lib/features/crop_rotate_editor/crop_rotate_editor.dart
+++ b/lib/features/crop_rotate_editor/crop_rotate_editor.dart
@@ -1092,19 +1092,19 @@ class CropRotateEditorState extends State<CropRotateEditor>
         backgroundColor:
             cropRotateEditorConfigs.style.aspectRatioSheetBackgroundColor,
         isScrollControlled: true,
-        builder: (BuildContext context) {
-          return cropRotateEditorConfigs.widgets.aspectRatioOptions?.call(
-                this,
-                rebuildController.stream,
-                aspectRatio,
-                _mainImageSize.aspectRatio,
-              ) ??
-              CropAspectRatioOptions(
-                aspectRatio: aspectRatio,
-                configs: configs,
-                originalAspectRatio: _mainImageSize.aspectRatio,
-              );
-        }).then((value) {
+        builder: (BuildContext context) => SafeArea(
+              child: cropRotateEditorConfigs.widgets.aspectRatioOptions?.call(
+                    this,
+                    rebuildController.stream,
+                    aspectRatio,
+                    _mainImageSize.aspectRatio,
+                  ) ??
+                  CropAspectRatioOptions(
+                    aspectRatio: aspectRatio,
+                    configs: configs,
+                    originalAspectRatio: _mainImageSize.aspectRatio,
+                  ),
+            )).then((value) {
       if (value != null) {
         updateAspectRatio(value);
       }

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -284,7 +284,7 @@ class ProImageEditor extends StatefulWidget
   /// - [byteArray] - Raw image data as a `Uint8List` (highest priority).
   /// - [file] - A `File` instance representing a local image file.
   /// - [networkUrl] - URL pointing to an image on the internet.
-  /// - [assetPath] - Path to an image stored in the app’s assets.
+  /// - [assetPath] - Path to an image stored in the app's assets.
   /// - [editorImage] - An `EditorImage` instance containing one of the above.
   /// - [configs] - Optional configuration settings for the editor.
   /// - [callbacks] - Required callbacks for handling image editor events.
@@ -1643,32 +1643,31 @@ class ProImageEditorState extends State<ProImageEditor>
         showDragHandle: emojiEditorConfigs.style.showDragHandle,
         isScrollControlled: true,
         useSafeArea: true,
-        builder: (BuildContext context) {
-          if (!useDraggableSheet) {
-            return ConstrainedBox(
-              constraints: effectiveBoxConstraints ??
-                  BoxConstraints(
-                      maxHeight: 300 + MediaQuery.viewInsetsOf(context).bottom),
-              child: EmojiEditor(configs: configs),
-            );
-          }
-
-          return DraggableScrollableSheet(
-              expand: sheetTheme.expand,
-              initialChildSize: sheetTheme.initialChildSize,
-              maxChildSize: sheetTheme.maxChildSize,
-              minChildSize: sheetTheme.minChildSize,
-              shouldCloseOnMinExtent: sheetTheme.shouldCloseOnMinExtent,
-              snap: sheetTheme.snap,
-              snapAnimationDuration: sheetTheme.snapAnimationDuration,
-              snapSizes: sheetTheme.snapSizes,
-              builder: (_, controller) {
-                return EmojiEditor(
-                  configs: configs,
-                  scrollController: controller,
-                );
-              });
-        });
+        builder: (BuildContext context) => SafeArea(
+              child: !useDraggableSheet
+                  ? ConstrainedBox(
+                      constraints: effectiveBoxConstraints ??
+                          BoxConstraints(
+                              maxHeight: 300 +
+                                  MediaQuery.viewInsetsOf(context).bottom),
+                      child: EmojiEditor(configs: configs),
+                    )
+                  : DraggableScrollableSheet(
+                      expand: sheetTheme.expand,
+                      initialChildSize: sheetTheme.initialChildSize,
+                      maxChildSize: sheetTheme.maxChildSize,
+                      minChildSize: sheetTheme.minChildSize,
+                      shouldCloseOnMinExtent: sheetTheme.shouldCloseOnMinExtent,
+                      snap: sheetTheme.snap,
+                      snapAnimationDuration: sheetTheme.snapAnimationDuration,
+                      snapSizes: sheetTheme.snapSizes,
+                      builder: (_, controller) {
+                        return EmojiEditor(
+                          configs: configs,
+                          scrollController: controller,
+                        );
+                      }),
+            ));
     ServicesBinding.instance.keyboard.addHandler(_onKeyEvent);
     if (layer == null || !mounted) return;
     layer.scale = emojiEditorConfigs.initScale;
@@ -1695,24 +1694,24 @@ class ProImageEditorState extends State<ProImageEditor>
         showDragHandle: stickerEditorConfigs.style.showDragHandle,
         isScrollControlled: true,
         useSafeArea: true,
-        builder: (_) {
-          return DraggableScrollableSheet(
-            expand: sheetTheme.expand,
-            initialChildSize: sheetTheme.initialChildSize,
-            maxChildSize: sheetTheme.maxChildSize,
-            minChildSize: sheetTheme.minChildSize,
-            shouldCloseOnMinExtent: sheetTheme.shouldCloseOnMinExtent,
-            snap: sheetTheme.snap,
-            snapAnimationDuration: sheetTheme.snapAnimationDuration,
-            snapSizes: sheetTheme.snapSizes,
-            builder: (_, controller) {
-              return StickerEditor(
-                configs: configs,
-                scrollController: controller,
-              );
-            },
-          );
-        });
+        builder: (_) => SafeArea(
+              child: DraggableScrollableSheet(
+                expand: sheetTheme.expand,
+                initialChildSize: sheetTheme.initialChildSize,
+                maxChildSize: sheetTheme.maxChildSize,
+                minChildSize: sheetTheme.minChildSize,
+                shouldCloseOnMinExtent: sheetTheme.shouldCloseOnMinExtent,
+                snap: sheetTheme.snap,
+                snapAnimationDuration: sheetTheme.snapAnimationDuration,
+                snapSizes: sheetTheme.snapSizes,
+                builder: (_, controller) {
+                  return StickerEditor(
+                    configs: configs,
+                    scrollController: controller,
+                  );
+                },
+              ),
+            ));
     ServicesBinding.instance.keyboard.addHandler(_onKeyEvent);
     if (layer == null || !mounted) return;
 

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -404,25 +404,22 @@ class PaintEditorState extends State<PaintEditor>
   void openLinWidthBottomSheet() {
     showModalBottomSheet(
       context: context,
-      backgroundColor: paintEditorConfigs.style.lineWidthBottomSheetBackground,
-      builder: (BuildContext context) => SafeArea(
-        child: SliderBottomSheet<PaintEditorState>(
-          title: i18n.paintEditor.lineWidth,
-          headerTextStyle: paintEditorConfigs.style.lineWidthBottomSheetTitle,
-          min: 2,
-          max: 40,
-          divisions: 19,
-          closeButton: paintEditorConfigs.widgets.lineWidthCloseButton,
-          customSlider: paintEditorConfigs.widgets.sliderLineWidth,
-          state: this,
-          value: paintCtrl.strokeWidth,
-          designMode: designMode,
-          theme: theme,
-          rebuildController: rebuildController,
-          onValueChanged: (value) {
-            setStrokeWidth(value);
-          },
-        ),
+      builder: (BuildContext context) => SliderBottomSheet<PaintEditorState>(
+        title: i18n.paintEditor.lineWidth,
+        headerTextStyle: paintEditorConfigs.style.lineWidthBottomSheetTitle,
+        min: 2,
+        max: 40,
+        divisions: 19,
+        closeButton: paintEditorConfigs.widgets.lineWidthCloseButton,
+        customSlider: paintEditorConfigs.widgets.sliderLineWidth,
+        state: this,
+        value: paintCtrl.strokeWidth,
+        designMode: designMode,
+        theme: theme,
+        rebuildController: rebuildController,
+        onValueChanged: (value) {
+          setStrokeWidth(value);
+        },
       ),
     );
   }
@@ -431,25 +428,22 @@ class PaintEditorState extends State<PaintEditor>
   void openOpacityBottomSheet() {
     showModalBottomSheet(
       context: context,
-      backgroundColor: paintEditorConfigs.style.opacityBottomSheetBackground,
-      builder: (BuildContext context) => SafeArea(
-        child: SliderBottomSheet<PaintEditorState>(
-          title: i18n.paintEditor.changeOpacity,
-          headerTextStyle: paintEditorConfigs.style.opacityBottomSheetTitle,
-          max: 1,
-          min: 0,
-          divisions: 100,
-          closeButton: paintEditorConfigs.widgets.changeOpacityCloseButton,
-          customSlider: paintEditorConfigs.widgets.sliderChangeOpacity,
-          state: this,
-          value: paintCtrl.opacity,
-          designMode: designMode,
-          theme: theme,
-          rebuildController: rebuildController,
-          onValueChanged: (value) {
-            setOpacity(value);
-          },
-        ),
+      builder: (BuildContext context) => SliderBottomSheet<PaintEditorState>(
+        title: i18n.paintEditor.changeOpacity,
+        headerTextStyle: paintEditorConfigs.style.opacityBottomSheetTitle,
+        max: 1,
+        min: 0,
+        divisions: 100,
+        closeButton: paintEditorConfigs.widgets.changeOpacityCloseButton,
+        customSlider: paintEditorConfigs.widgets.sliderChangeOpacity,
+        state: this,
+        value: paintCtrl.opacity,
+        designMode: designMode,
+        theme: theme,
+        rebuildController: rebuildController,
+        onValueChanged: (value) {
+          setOpacity(value);
+        },
       ),
     );
   }

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -405,8 +405,8 @@ class PaintEditorState extends State<PaintEditor>
     showModalBottomSheet(
       context: context,
       backgroundColor: paintEditorConfigs.style.lineWidthBottomSheetBackground,
-      builder: (BuildContext context) {
-        return SliderBottomSheet<PaintEditorState>(
+      builder: (BuildContext context) => SafeArea(
+        child: SliderBottomSheet<PaintEditorState>(
           title: i18n.paintEditor.lineWidth,
           headerTextStyle: paintEditorConfigs.style.lineWidthBottomSheetTitle,
           min: 2,
@@ -422,8 +422,8 @@ class PaintEditorState extends State<PaintEditor>
           onValueChanged: (value) {
             setStrokeWidth(value);
           },
-        );
-      },
+        ),
+      ),
     );
   }
 
@@ -432,8 +432,8 @@ class PaintEditorState extends State<PaintEditor>
     showModalBottomSheet(
       context: context,
       backgroundColor: paintEditorConfigs.style.opacityBottomSheetBackground,
-      builder: (BuildContext context) {
-        return SliderBottomSheet<PaintEditorState>(
+      builder: (BuildContext context) => SafeArea(
+        child: SliderBottomSheet<PaintEditorState>(
           title: i18n.paintEditor.changeOpacity,
           headerTextStyle: paintEditorConfigs.style.opacityBottomSheetTitle,
           max: 1,
@@ -449,8 +449,8 @@ class PaintEditorState extends State<PaintEditor>
           onValueChanged: (value) {
             setOpacity(value);
           },
-        );
-      },
+        ),
+      ),
     );
   }
 

--- a/lib/features/text_editor/text_editor.dart
+++ b/lib/features/text_editor/text_editor.dart
@@ -267,8 +267,8 @@ class TextEditorState extends State<TextEditor>
     showModalBottomSheet(
       context: context,
       backgroundColor: textEditorConfigs.style.fontScaleBottomSheetBackground,
-      builder: (BuildContext context) {
-        return SliderBottomSheet<TextEditorState>(
+      builder: (BuildContext context) => SafeArea(
+        child: SliderBottomSheet<TextEditorState>(
           value: _fontScale,
           title: i18n.textEditor.fontScale,
           headerTextStyle: textEditorConfigs.style.fontSizeBottomSheetTitle,
@@ -288,8 +288,8 @@ class TextEditorState extends State<TextEditor>
           onValueChanged: (value) {
             fontScale = value;
           },
-        );
-      },
+        ),
+      ),
     );
   }
 

--- a/lib/features/text_editor/text_editor.dart
+++ b/lib/features/text_editor/text_editor.dart
@@ -267,28 +267,26 @@ class TextEditorState extends State<TextEditor>
     showModalBottomSheet(
       context: context,
       backgroundColor: textEditorConfigs.style.fontScaleBottomSheetBackground,
-      builder: (BuildContext context) => SafeArea(
-        child: SliderBottomSheet<TextEditorState>(
-          value: _fontScale,
-          title: i18n.textEditor.fontScale,
-          headerTextStyle: textEditorConfigs.style.fontSizeBottomSheetTitle,
-          resetIcon: textEditorConfigs.icons.resetFontScale,
-          max: textEditorConfigs.maxFontScale,
-          min: textEditorConfigs.minFontScale,
-          divisions: (textEditorConfigs.maxFontScale -
-                  textEditorConfigs.minFontScale) ~/
-              0.1,
-          state: this,
-          showFactorInTitle: true,
-          closeButton: textEditorConfigs.widgets.fontSizeCloseButton,
-          customSlider: textEditorConfigs.widgets.sliderFontSize,
-          designMode: designMode,
-          theme: widget.theme,
-          rebuildController: _rebuildController,
-          onValueChanged: (value) {
-            fontScale = value;
-          },
-        ),
+      builder: (BuildContext context) => SliderBottomSheet<TextEditorState>(
+        value: _fontScale,
+        title: i18n.textEditor.fontScale,
+        headerTextStyle: textEditorConfigs.style.fontSizeBottomSheetTitle,
+        resetIcon: textEditorConfigs.icons.resetFontScale,
+        max: textEditorConfigs.maxFontScale,
+        min: textEditorConfigs.minFontScale,
+        divisions:
+            (textEditorConfigs.maxFontScale - textEditorConfigs.minFontScale) ~/
+                0.1,
+        state: this,
+        showFactorInTitle: true,
+        closeButton: textEditorConfigs.widgets.fontSizeCloseButton,
+        customSlider: textEditorConfigs.widgets.sliderFontSize,
+        designMode: designMode,
+        theme: widget.theme,
+        rebuildController: _rebuildController,
+        onValueChanged: (value) {
+          fontScale = value;
+        },
       ),
     );
   }

--- a/lib/shared/widgets/slider_bottom_sheet.dart
+++ b/lib/shared/widgets/slider_bottom_sheet.dart
@@ -114,20 +114,22 @@ class _SliderBottomSheetState<T> extends State<SliderBottomSheet<T>> {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      textStyle: platformTextStyle(context, widget.designMode),
-      child: SingleChildScrollView(
-        physics: const ClampingScrollPhysics(),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              _buildHeader(),
-              _buildBody(),
-            ],
+    return SafeArea(
+      child: Material(
+        color: Colors.transparent,
+        textStyle: platformTextStyle(context, widget.designMode),
+        child: SingleChildScrollView(
+          physics: const ClampingScrollPhysics(),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _buildHeader(),
+                _buildBody(),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [x] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [x] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [x] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
I didn't apply safeArea to the showModalBottomSheet, so I found a bug on my latest phone that overlaps with the soft button and fixed it.

Before
![KakaoTalk_20250531_165919122](https://github.com/user-attachments/assets/decde198-a9de-4ce8-ac8e-0812e8a0daca)

BugFix 
After
![KakaoTalk_20250531_180422255](https://github.com/user-attachments/assets/3b4341b0-c7cb-4c61-bd48-8e46c5360c9b)


Issue Number: N/A

## New Behavior
<!-- If the title already explains the change, you can leave this section empty. -->

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
