### PR TITLE
fix(editor): do not reset the rotation after changing ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## X.X.X
+- **FIX** Do not reset the rotation after Aspect Ratio is selected
+
 ## 10.2.8
 - **FIX**(helper-lines): Resolve issue where layers wouldn't release when sharing the same axis.
 - **FIX**(helper-lines): Resolve issue where helperLine configs had no effect.

--- a/lib/features/crop_rotate_editor/crop_rotate_editor.dart
+++ b/lib/features/crop_rotate_editor/crop_rotate_editor.dart
@@ -1126,7 +1126,7 @@ class CropRotateEditorState extends State<CropRotateEditor>
     calcCropRect();
     calcFitToScreen();
     _setOffsetLimits();
-    addHistory(scaleRotation: oldScaleFactor, angle: 0);
+    addHistory(scaleRotation: oldScaleFactor);
     _updateAllStates();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 10.3.0
+version: 10.3.1
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.

```
00:21 +301: All tests passed!  
```

- [x] I have pulled from the stable branch before committing.
- [X] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [X] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [X] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [X] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [X] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
<!-- 
Please describe the behavior that is being modified, or link to a relevant issue. 
If the issue is already covered in the title, feel free to leave this section empty. 
-->

The CropRotate editor would reset all rotation to 0, when new aspect ratio is selected.

### Steps to reproduce
- Go to the CropsRotatePage
- Rotate the image
- Set Aspect Ratio to anything
- Apply the change and go back to MainEditor
- The rotation done in the previous step was reset

Issue Number: N/A

## New Behavior
<!-- If the title already explains the change, you can leave this section empty. -->

Do not reset the new aspect ratio to 0 when selecting new aspect ratio

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
I'm not very sure if there's a side effect to this. But seems like this wasn't updated for 10.0.0 where the ratio no longer reset all rotate/flip history? I have done a bit of minor rotation, flip, crops testing and the change seem to functions.