### PR TITLE
fix: return custom edit widgets

### DIFF
--- a/lib/features/paint_editor/widgets/paint_editor_layer_editor.dart
+++ b/lib/features/paint_editor/widgets/paint_editor_layer_editor.dart
@@ -74,7 +74,7 @@ class _PaintEditorLayerEditorState extends State<PaintEditorLayerEditor> {
 
   Widget _buildPainting() {
     if (_customWidgets.editPreview != null) {
-      _customWidgets.editPreview!(_layer);
+      return _customWidgets.editPreview!(_layer);
     }
 
     return Container(
@@ -96,7 +96,7 @@ class _PaintEditorLayerEditorState extends State<PaintEditorLayerEditor> {
 
   Widget _buildBarColorPicker() {
     if (_customWidgets.editColorSlider != null) {
-      _customWidgets.editColorSlider!(_layer, _setColor);
+      return _customWidgets.editColorSlider!(_layer, _setColor);
     }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -132,7 +132,7 @@ class _PaintEditorLayerEditorState extends State<PaintEditorLayerEditor> {
 
   Widget _buildOpacity() {
     if (_customWidgets.editOpacitySlider != null) {
-      _customWidgets.editOpacitySlider!(_layer, _setOpacity);
+      return _customWidgets.editOpacitySlider!(_layer, _setOpacity);
     }
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -156,7 +156,7 @@ class _PaintEditorLayerEditorState extends State<PaintEditorLayerEditor> {
 
   Widget _buildStrokeWidthSlider() {
     if (_customWidgets.editStrokeWidthSlider != null) {
-      _customWidgets.editStrokeWidthSlider!(_layer, _setStrokeWidth);
+      return _customWidgets.editStrokeWidthSlider!(_layer, _setStrokeWidth);
     }
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -182,7 +182,7 @@ class _PaintEditorLayerEditorState extends State<PaintEditorLayerEditor> {
 
   Widget _buildFillItem() {
     if (_customWidgets.editFillSwitch != null) {
-      _customWidgets.editFillSwitch!(_layer, _setFillState);
+      return _customWidgets.editFillSwitch!(_layer, _setFillState);
     }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -198,7 +198,7 @@ class _PaintEditorLayerEditorState extends State<PaintEditorLayerEditor> {
 
   Widget _buildAction() {
     if (_customWidgets.editActionButtons != null) {
-      _customWidgets.editActionButtons!(_layer);
+      return _customWidgets.editActionButtons!(_layer);
     }
     return Padding(
       padding: const EdgeInsetsGeometry.fromLTRB(16, 16, 16, 0),


### PR DESCRIPTION
## PR Checklist (Required)
- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] I have run `dart format .` in the terminal and committed any changes.
- [ ] I have run `dart analyze .` in the terminal and addressed any issues.
- [ ] I have run `flutter test` in the terminal and addressed any issues.
- [ ] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [ ] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [X] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
Fixes Paint Editor edit widgets to take the user overwritten widgets