### PR TITLE
Center paintLayer preview

### DIFF
--- a/lib/features/paint_editor/widgets/paint_editor_layer_editor.dart
+++ b/lib/features/paint_editor/widgets/paint_editor_layer_editor.dart
@@ -82,7 +82,7 @@ class _PaintEditorLayerEditorState extends State<PaintEditorLayerEditor> {
       decoration: const BoxDecoration(),
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
       height: 120,
-      child: FittedBox(
+      child: Center(
         child: SizedBox.fromSize(
           size: _layer.rawSize,
           child: LayerWidgetPaintItem(


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] I have run `dart format .` in the terminal and committed any changes.
- [ ] I have run `dart analyze .` in the terminal and addressed any issues.
- [ ] I have run `flutter test` in the terminal and addressed any issues.
- [ ] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [ ] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [X] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
The preview of the paint layer appears outside its current frame, particularly noticeable in smaller devices or mobile screens. The Center() widget replacing the FittedBox() behaves better to make sure the preview of the layer is centered and fit in the available space.