### PR TITLE
fix(main-editor): Skip mouse wheel scaling if disabled

### DIFF
--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -2490,15 +2490,12 @@ class ProImageEditorState extends State<ProImageEditor>
                         return;
                       }
 
-                      if (selectedLayers.any((layer) => !layer.interaction.enableScale)) {
-                        return;
-                      }
-
                       /// Otherwise, handle scroll as a layer scaling
                       /// interaction.
                       _desktopInteractionManager.mouseScroll(
                         event,
                         selectedLayers: selectedLayers,
+                        interactiveViewer: interactiveViewer.currentState
                       );
                     }
                   : null,

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -2490,6 +2490,10 @@ class ProImageEditorState extends State<ProImageEditor>
                         return;
                       }
 
+                      if (selectedLayers.any((layer) => !layer.interaction.enableScale)) {
+                        return;
+                      }
+
                       /// Otherwise, handle scroll as a layer scaling
                       /// interaction.
                       _desktopInteractionManager.mouseScroll(

--- a/lib/features/main_editor/services/desktop_interaction_manager.dart
+++ b/lib/features/main_editor/services/desktop_interaction_manager.dart
@@ -11,6 +11,8 @@ import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/layers/layer.dart';
 import '/core/services/keyboard_service.dart';
 
+import '/shared/widgets/extended/interactive_viewer/extended_interactive_viewer.dart';
+
 /// A manager class responsible for handling desktop interactions in the image
 /// editor.
 ///
@@ -176,6 +178,7 @@ class DesktopInteractionManager {
   void mouseScroll(
     PointerSignalEvent event, {
     required List<Layer> selectedLayers,
+    required ExtendedInteractiveViewerState? interactiveViewer,
   }) {
     if (event is! PointerScrollEvent || selectedLayers.isEmpty) return;
 
@@ -192,12 +195,15 @@ class DesktopInteractionManager {
             : layer.isTextLayer
                 ? 0.15
                 : configs.textEditor.initFontSize / 50;
-        if (event.scrollDelta.dy > 0) {
-          layer
-            ..scale -= factor
-            ..scale = max(0.1, layer.scale);
-        } else if (event.scrollDelta.dy < 0) {
-          layer.scale += factor;
+        if (interactiveViewer?.isInteractionEnabled == true) {
+          // only scale if interaction is enabled (that means we might zoom in/out)
+          if (event.scrollDelta.dy > 0) {
+            layer
+              ..scale -= factor
+              ..scale = max(0.1, layer.scale);
+          } else if (event.scrollDelta.dy < 0) {
+            layer.scale += factor;
+          }
         }
       }
     }


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] I have run `dart format .` in the terminal and committed any changes.
- [ ] I have run `dart analyze .` in the terminal and addressed any issues.
- [ ] I have run `flutter test` in the terminal and addressed any issues.
- [ ] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [ ] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [X] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
I have a bit of a specific situation where I disable the zoom in/out temporarily. I am noticing my layers scale in and out when they shouldn't.

## New Behavior
This fix ignores scaling layers if we are not really zooming in and out in the viewer.

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
