### PR TITLE
Standard layer padding

### DIFF
--- a/lib/shared/widgets/layer/widgets/layer_widget_paint_item.dart
+++ b/lib/shared/widgets/layer/widgets/layer_widget_paint_item.dart
@@ -47,23 +47,20 @@ class LayerWidgetPaintItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.zero,
-      child: RepaintBoundary(
-        child: Opacity(
-          opacity: layer.opacity,
-          child: CustomPaint(
-            size: layer.size,
-            willChange: willChange,
-            isComplex: layer.item.mode == PaintMode.freeStyle,
-            painter: DrawPaintItem(
-              item: layer.item,
-              scale: scale,
-              selected: isSelected,
-              enabledHitDetection: enableHitDetection,
-              freeStyleHighPerformance: isHighPerformanceMode,
-              onHitChanged: onHitChanged,
-            ),
+    return RepaintBoundary(
+      child: Opacity(
+        opacity: layer.opacity,
+        child: CustomPaint(
+          size: layer.size,
+          willChange: willChange,
+          isComplex: layer.item.mode == PaintMode.freeStyle,
+          painter: DrawPaintItem(
+            item: layer.item,
+            scale: scale,
+            selected: isSelected,
+            enabledHitDetection: enableHitDetection,
+            freeStyleHighPerformance: isHighPerformanceMode,
+            onHitChanged: onHitChanged,
           ),
         ),
       ),

--- a/lib/shared/widgets/layer/widgets/layer_widget_paint_item.dart
+++ b/lib/shared/widgets/layer/widgets/layer_widget_paint_item.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import '/core/models/layers/paint_layer.dart';
 import '/features/paint_editor/enums/paint_editor_enum.dart';
 import '/features/paint_editor/widgets/draw_paint_item.dart';
-import '/shared/utils/platform_info.dart';
 
 /// A widget representing a paint layer in the sticker editor.
 class LayerWidgetPaintItem extends StatelessWidget {
@@ -49,8 +48,7 @@ class LayerWidgetPaintItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      // Improves hit detection for mobile devices by adding padding.
-      padding: EdgeInsets.all(isDesktop ? 0 : 15),
+      padding: EdgeInsets.zero,
       child: RepaintBoundary(
         child: Opacity(
           opacity: layer.opacity,


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] I have run `dart format .` in the terminal and committed any changes.
- [ ] I have run `dart analyze .` in the terminal and addressed any issues.
- [ ] I have run `flutter test` in the terminal and addressed any issues.
- [ ] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [ ] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [ ] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
Selection area is way too big in Mobile, makes it quite uncomfortable and easy to make mistakes.
I have only spotted specific padding for paint widgets, but this issue seems more general
https://github.com/hm21/pro_image_editor/issues/591

## New Behavior
This lowers the extra padding in paint layers which might not be necessary since v10+

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
