### PR TITLE
feat(paint-editor): add editLayer callback for customizable PaintLayer edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 11.7.1
+- **FEAT**(paint-editor): Add support for custom paint layer editing via `widgets.editLayer` callback in `PaintEditorWidgets`.
+
 ## 11.7.0
 - **FEAT**(sub-editors): Add `enableGesturePop` config to all sub-editors to control whether user back navigation (hardware back button, predictive back swipe) is allowed.
 

--- a/lib/core/models/custom_widgets/paint_editor_widgets.dart
+++ b/lib/core/models/custom_widgets/paint_editor_widgets.dart
@@ -37,6 +37,7 @@ class PaintEditorWidgets
     this.editFillSwitch,
     this.editActionButtons,
     this.editBottomSheet,
+    this.editLayer,
   });
 
   /// Custom close button in the paint-editor to close the line-width bottom
@@ -117,6 +118,9 @@ class PaintEditorWidgets
 
   /// A callback function that returns a widget for editing a [PaintLayer].
   final Widget Function(PaintLayer layer)? editBottomSheet;
+
+  /// A callback function that allows the user to edit a [PaintLayer].
+  final Future<PaintLayer> Function(PaintLayer layer)? editLayer;
 
   @override
   PaintEditorWidgets copyWith({

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -1358,22 +1358,27 @@ class ProImageEditorState extends State<ProImageEditor>
   void _editPaintLayer(PaintLayer layer) async {
     if (layer.isPaintLayer && layer.item.isCensorArea) return;
 
-    PaintLayer? result = await showModalBottomSheet<PaintLayer>(
-      context: context,
-      backgroundColor: paintEditorConfigs.style.editSheetBackgroundColor,
-      showDragHandle: paintEditorConfigs.style.editSheetShowDragHandle,
-      isScrollControlled: true,
-      useSafeArea: true,
-      builder: (context) =>
-          paintEditorConfigs.widgets.editBottomSheet?.call(layer) ??
-          SafeArea(
-            child: PaintEditorLayerEditor(
-              layer: _layerCopyManager.duplicateLayer(layer,
-                  offset: Offset.zero) as PaintLayer,
-              configs: configs,
+    PaintLayer? result;
+    if (paintEditorConfigs.widgets.editLayer != null) {
+      result = await paintEditorConfigs.widgets.editLayer!(layer);
+    } else {
+      result = await showModalBottomSheet<PaintLayer>(
+        context: context,
+        backgroundColor: paintEditorConfigs.style.editSheetBackgroundColor,
+        showDragHandle: paintEditorConfigs.style.editSheetShowDragHandle,
+        isScrollControlled: true,
+        useSafeArea: true,
+        builder: (context) =>
+            paintEditorConfigs.widgets.editBottomSheet?.call(layer) ??
+            SafeArea(
+              child: PaintEditorLayerEditor(
+                layer: _layerCopyManager.duplicateLayer(layer,
+                    offset: Offset.zero) as PaintLayer,
+                configs: configs,
+              ),
             ),
-          ),
-    );
+      );
+    }
 
     if (result == null) return;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 11.7.0
+version: 11.7.1
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
 related to https://github.com/hm21/pro_image_editor/issues/673

## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [x] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [x] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [x] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [ ] Bugfix
- [x] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
The Edit Layer is forced to be a bottom sheet dialog

Issue Number: #673

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
