### PR TITLE
feat(tools): introduce tools API and deprecate old flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+
+## 11.9.0
+- **FEAT**(main-editor): Introduced `tools` in `MainEditorConfigs` to configure available sub-editors and their order, replacing old `enableModeX` flags with a cleaner list-based API.  
+- **FEAT**(paint-editor): Introduced `tools` in `PaintEditorConfigs` to define available paint modes and their order, deprecating individual `enableModeX` flags.  
+- **FEAT**(crop-rotate-editor): Introduced `tools` in `CropRotateEditorConfigs` with a new `CropRotateTool` enum for rotate, flip, aspect ratio, and reset actions, deprecating the old `showXButton` flags.  
+
 ## 11.8.0
 - **FEAT**(callbacks): Add `onEditLayer` to `PaintEditorCallbacks`, allowing custom paint-layer editing logic (e.g., via a side menu). This was requested in [#673](https://github.com/hm21/pro_image_editor/issues/673).
 - **FEAT**(layers): Add `copyWith` method to all layer classes for easier cloning and modification.

--- a/example/lib/features/crop_to_main_editor.dart
+++ b/example/lib/features/crop_to_main_editor.dart
@@ -42,7 +42,11 @@ class _CropToMainEditorExampleState extends State<CropToMainEditorExample>
     cropRotateEditor: const CropRotateEditorConfigs(
       initAspectRatio: 1,
       enableProvideImageInfos: true,
-      showAspectRatioButton: false,
+      tools: [
+        CropRotateTool.rotate,
+        CropRotateTool.flip,
+        CropRotateTool.reset,
+      ],
     ),
   );
 
@@ -90,9 +94,15 @@ class _CropToMainEditorExampleState extends State<CropToMainEditorExample>
                 transformConfigs: transformations,
                 imageInfos: imageInfos,
               ),
-            ),
-            cropRotateEditor: const CropRotateEditorConfigs(
-              enabled: false,
+              tools: [
+                SubEditorMode.paint,
+                SubEditorMode.text,
+                // SubEditorMode.cropRotate,
+                SubEditorMode.tune,
+                SubEditorMode.filter,
+                SubEditorMode.blur,
+                SubEditorMode.emoji,
+              ],
             ),
           ),
         ),

--- a/example/lib/features/design_examples/frosted_glass_example.dart
+++ b/example/lib/features/design_examples/frosted_glass_example.dart
@@ -77,6 +77,16 @@ class _FrostedGlassExampleState extends State<FrostedGlassExample>
               iconTheme:
                   Theme.of(context).iconTheme.copyWith(color: Colors.white)),
           mainEditor: MainEditorConfigs(
+            tools: [
+              SubEditorMode.paint,
+              SubEditorMode.text,
+              SubEditorMode.cropRotate,
+              SubEditorMode.tune,
+              SubEditorMode.filter,
+              SubEditorMode.blur,
+              SubEditorMode.emoji,
+              SubEditorMode.sticker,
+            ],
             widgets: MainEditorWidgets(
               closeWarningDialog: (editor) async {
                 if (!context.mounted) return false;
@@ -235,7 +245,6 @@ class _FrostedGlassExampleState extends State<FrostedGlassExample>
             ),
           ),
           stickerEditor: StickerEditorConfigs(
-            enabled: true,
             builder: (setLayer, scrollController) => DemoBuildStickers(
                 setLayer: setLayer, scrollController: scrollController),
           ),

--- a/example/lib/features/design_examples/grounded_example.dart
+++ b/example/lib/features/design_examples/grounded_example.dart
@@ -75,6 +75,16 @@ class _GroundedDesignExampleState extends State<GroundedDesignExample>
             hideToolbarOnInteraction: false,
           ),
           mainEditor: MainEditorConfigs(
+            tools: [
+              SubEditorMode.paint,
+              SubEditorMode.text,
+              SubEditorMode.cropRotate,
+              SubEditorMode.tune,
+              SubEditorMode.filter,
+              SubEditorMode.blur,
+              SubEditorMode.emoji,
+              SubEditorMode.sticker,
+            ],
             widgets: MainEditorWidgets(
               appBar: (editor, rebuildStream) => null,
               bottomBar: (editor, rebuildStream, key) => ReactiveWidget(
@@ -356,7 +366,6 @@ class _GroundedDesignExampleState extends State<GroundedDesignExample>
             ),
           ),
           stickerEditor: StickerEditorConfigs(
-            enabled: true,
             builder: (setLayer, scrollController) => DemoBuildStickers(
                 categoryColor: const Color(0xFF161616),
                 setLayer: setLayer,

--- a/example/lib/features/design_examples/highly_configurable_example.dart
+++ b/example/lib/features/design_examples/highly_configurable_example.dart
@@ -179,6 +179,16 @@ class _HighlyConfigurableExampleState extends State<HighlyConfigurableExample>
           ),
         ),
         mainEditor: const MainEditorConfigs(
+          tools: [
+            SubEditorMode.paint,
+            SubEditorMode.text,
+            SubEditorMode.cropRotate,
+            SubEditorMode.tune,
+            SubEditorMode.filter,
+            SubEditorMode.blur,
+            SubEditorMode.emoji,
+            SubEditorMode.sticker,
+          ],
           style: MainEditorStyle(
             background: Color.fromARGB(255, 255, 169, 169),
             appBarColor: Color.fromARGB(255, 126, 14, 6),
@@ -203,13 +213,14 @@ class _HighlyConfigurableExampleState extends State<HighlyConfigurableExample>
           ),
         ),
         paintEditor: const PaintEditorConfigs(
-          enabled: true,
-          enableModeFreeStyle: true,
-          enableModeArrow: true,
-          enableModeLine: true,
-          enableModeRect: true,
-          enableModeCircle: true,
-          enableModeDashLine: true,
+          tools: [
+            PaintMode.freeStyle,
+            PaintMode.arrow,
+            PaintMode.line,
+            PaintMode.rect,
+            PaintMode.circle,
+            PaintMode.dashLine,
+          ],
           showToggleFillButton: true,
           showLineWidthAdjustmentButton: true,
           isInitiallyFilled: true,
@@ -239,7 +250,6 @@ class _HighlyConfigurableExampleState extends State<HighlyConfigurableExample>
           ),
         ),
         textEditor: TextEditorConfigs(
-          enabled: true,
           showTextAlignButton: true,
           showBackgroundModeButton: true,
           initFontSize: 24.0,
@@ -274,9 +284,12 @@ class _HighlyConfigurableExampleState extends State<HighlyConfigurableExample>
           ],
         ),
         cropRotateEditor: const CropRotateEditorConfigs(
-          enabled: true,
-          showRotateButton: true,
-          showAspectRatioButton: true,
+          tools: [
+            CropRotateTool.rotate,
+            CropRotateTool.flip,
+            CropRotateTool.aspectRatio,
+            CropRotateTool.reset,
+          ],
           initAspectRatio: 0.0,
           aspectRatios: [
             AspectRatioItem(text: 'Free', value: null),
@@ -311,7 +324,6 @@ class _HighlyConfigurableExampleState extends State<HighlyConfigurableExample>
           ),
         ),
         tuneEditor: TuneEditorConfigs(
-          enabled: true,
           showLayers: true,
           tuneAdjustmentOptions: [
             const TuneAdjustmentItem(
@@ -418,7 +430,6 @@ class _HighlyConfigurableExampleState extends State<HighlyConfigurableExample>
           ),
         ),
         filterEditor: FilterEditorConfigs(
-          enabled: true,
           filterList: presetFiltersList,
           style: const FilterEditorStyle(
             appBarBackground: Color.fromARGB(255, 82, 0, 82),
@@ -431,7 +442,6 @@ class _HighlyConfigurableExampleState extends State<HighlyConfigurableExample>
           ),
         ),
         blurEditor: const BlurEditorConfigs(
-          enabled: true,
           maxBlur: 20.0,
           style: BlurEditorStyle(
             appBarBackgroundColor: Color.fromARGB(255, 56, 0, 0),
@@ -443,7 +453,6 @@ class _HighlyConfigurableExampleState extends State<HighlyConfigurableExample>
           ),
         ),
         emojiEditor: const EmojiEditorConfigs(
-          enabled: true,
           initScale: 2.0,
           checkPlatformCompatibility: true,
           style: EmojiEditorStyle(

--- a/example/lib/features/design_examples/whatsapp_example.dart
+++ b/example/lib/features/design_examples/whatsapp_example.dart
@@ -94,6 +94,16 @@ class _WhatsAppExampleState extends State<WhatsAppExample>
 
   late final _mainEditorConfigs = MainEditorConfigs(
     enableZoom: true,
+    tools: [
+      SubEditorMode.paint,
+      SubEditorMode.text,
+      SubEditorMode.cropRotate,
+      SubEditorMode.tune,
+      SubEditorMode.filter,
+      SubEditorMode.blur,
+      SubEditorMode.emoji,
+      SubEditorMode.sticker,
+    ],
     widgets: MainEditorWidgets(
       appBar: (editor, rebuildStream) => null,
       bottomBar: (editor, rebuildStream, key) => null,
@@ -232,7 +242,6 @@ class _WhatsAppExampleState extends State<WhatsAppExample>
     ),
   );
   late final _stickerEditorConfigs = StickerEditorConfigs(
-    enabled: true,
     builder: (setLayer, scrollController) => DemoBuildStickers(
         setLayer: setLayer, scrollController: scrollController),
   );

--- a/example/lib/features/frame_example.dart
+++ b/example/lib/features/frame_example.dart
@@ -306,6 +306,17 @@ class _FrameExampleState extends State<FrameExample>
             selectable: LayerInteractionSelectable.disabled,
           ),
           mainEditor: MainEditorConfigs(
+            /// Crop-Rotate, Filter, Tune and Blur editors are not supported
+            tools: [
+              SubEditorMode.paint,
+              SubEditorMode.text,
+              // SubEditorMode.cropRotate,
+              // SubEditorMode.tune,
+              // SubEditorMode.filter,
+              // SubEditorMode.blur,
+              SubEditorMode.emoji,
+              // SubEditorMode.sticker,
+            ],
             enableCloseButton: !isDesktopMode(context),
             widgets: MainEditorWidgets(
               bodyItemsRecorded: (editor, rebuildStream) => [
@@ -338,46 +349,36 @@ class _FrameExampleState extends State<FrameExample>
                   SystemUiOverlayStyle(statusBarColor: Colors.black),
             ),
           ),
-
-          /// Crop-Rotate, Filter, Tune and Blur editors are not supported
           cropRotateEditor: const CropRotateEditorConfigs(
-            enabled: false,
 
-            /// widgets: CropRotateEditorWidgets(
-            ///   bodyItems: (editor, rebuildStream) => [
-            ///     _buildFrame(editor.editorBodySize, rebuildStream),
-            ///   ],
-            /// ),
-          ),
+              /// widgets: CropRotateEditorWidgets(
+              ///   bodyItems: (editor, rebuildStream) => [
+              ///     _buildFrame(editor.editorBodySize, rebuildStream),
+              ///   ],
+              /// ),
+              ),
           filterEditor: const FilterEditorConfigs(
-            enabled: false,
-
-            /// widgets: FilterEditorWidgets(
-            ///   bodyItemsRecorded: (editor, rebuildStream) => [
-            ///     _buildFrame(editor.editorBodySize, rebuildStream),
-            ///   ],
-            /// ),
-          ),
+              // widgets: FilterEditorWidgets(
+              //   bodyItemsRecorded: (editor, rebuildStream) => [
+              //     _buildFrame(editor.editorBodySize, rebuildStream),
+              //   ],
+              // ),
+              ),
           blurEditor: const BlurEditorConfigs(
-            enabled: false,
-
-            /// widgets: BlurEditorWidgets(
-            ///   bodyItemsRecorded: (editor, rebuildStream) => [
-            ///     _buildFrame(editor.editorBodySize, rebuildStream),
-            ///   ],
-            /// ),
-          ),
+              // widgets: BlurEditorWidgets(
+              //   bodyItemsRecorded: (editor, rebuildStream) => [
+              //     _buildFrame(editor.editorBodySize, rebuildStream),
+              //   ],
+              // ),
+              ),
           tuneEditor: const TuneEditorConfigs(
-            enabled: false,
-
-            /// widgets: TuneEditorWidgets(
-            ///   bodyItemsRecorded: (editor, rebuildStream) => [
-            ///     _buildFrame(editor.editorBodySize, rebuildStream),
-            ///   ],
-            /// ),
-          ),
+              // widgets: TuneEditorWidgets(
+              //   bodyItemsRecorded: (editor, rebuildStream) => [
+              //     _buildFrame(editor.editorBodySize, rebuildStream),
+              //   ],
+              // ),
+              ),
           stickerEditor: StickerEditorConfigs(
-            enabled: false,
             initWidth: _layerInitWidth / _initScale,
             builder: (setLayer, scrollController) {
               // Optionally your code to pick layers

--- a/example/lib/features/movable_background_image.dart
+++ b/example/lib/features/movable_background_image.dart
@@ -320,6 +320,17 @@ class _MovableBackgroundImageExampleState
                   MediaQuery.devicePixelRatioOf(context)),
             ),
             mainEditor: MainEditorConfigs(
+              /// Crop-Rotate, Filter, Tune and Blur editors are not supported
+              tools: [
+                SubEditorMode.paint,
+                SubEditorMode.text,
+                // SubEditorMode.cropRotate,
+                // SubEditorMode.tune,
+                // SubEditorMode.filter,
+                // SubEditorMode.blur,
+                SubEditorMode.emoji,
+                // SubEditorMode.sticker,
+              ],
               enableCloseButton: !isDesktopMode(context),
               widgets: MainEditorWidgets(
                 bodyItems: (editor, rebuildStream) {
@@ -378,14 +389,7 @@ class _MovableBackgroundImageExampleState
                 background: Colors.transparent,
               ),
             ),
-
-            /// Crop-Rotate, Filter and Blur editors are not supported
-            cropRotateEditor: const CropRotateEditorConfigs(enabled: false),
-            filterEditor: const FilterEditorConfigs(enabled: false),
-            blurEditor: const BlurEditorConfigs(enabled: false),
-
             stickerEditor: StickerEditorConfigs(
-              enabled: false,
               initWidth: (_editorSize.aspectRatio > _imgRatio
                       ? _editorSize.height
                       : _editorSize.width) /

--- a/example/lib/features/signature_drawing_example.dart
+++ b/example/lib/features/signature_drawing_example.dart
@@ -66,15 +66,7 @@ class _SignatureDrawingExampleState extends State<SignatureDrawingExample>
                       configs: ProImageEditorConfigs(
                         designMode: platformDesignMode,
                         paintEditor: PaintEditorConfigs(
-                          enableModeFreeStyle: false,
-                          enableModeArrow: false,
-                          enableModeLine: false,
-                          enableModeRect: false,
-                          enableModeCircle: false,
-                          enableModeDashLine: false,
-                          enableModeEraser: false,
-                          enableModeBlur: false,
-                          enableModePixelate: false,
+                          tools: [],
                           showToggleFillButton: false,
 
                           /// Optional true

--- a/example/lib/features/stickers_example.dart
+++ b/example/lib/features/stickers_example.dart
@@ -65,12 +65,20 @@ class _StickersExampleState extends State<StickersExample>
       ),
       configs: ProImageEditorConfigs(
         designMode: platformDesignMode,
-        blurEditor: const BlurEditorConfigs(enabled: false),
         mainEditor: MainEditorConfigs(
+          tools: [
+            SubEditorMode.paint,
+            SubEditorMode.text,
+            SubEditorMode.cropRotate,
+            SubEditorMode.tune,
+            SubEditorMode.filter,
+            // SubEditorMode.blur,
+            SubEditorMode.emoji,
+            SubEditorMode.sticker,
+          ],
           enableCloseButton: !isDesktopMode(context),
         ),
         stickerEditor: StickerEditorConfigs(
-          enabled: true,
           builder: _buildStickers,
         ),
       ),

--- a/example/lib/features/video_examples/pages/chewie_player_example.dart
+++ b/example/lib/features/video_examples/pages/chewie_player_example.dart
@@ -163,9 +163,19 @@ class _ChewiePlayerExampleState extends State<ChewiePlayerExample>
                   ),
                 ),
                 paintEditor: const PaintEditorConfigs(
-                  /// Blur and pixelate are not supported.
-                  enableModePixelate: false,
-                  enableModeBlur: false,
+                  tools: [
+                    PaintMode.freeStyle,
+                    PaintMode.arrow,
+                    PaintMode.line,
+                    PaintMode.rect,
+                    PaintMode.circle,
+                    PaintMode.dashLine,
+                    PaintMode.polygon,
+                    // Blur and pixelate are not supported.
+                    // PaintMode.pixelate,
+                    // PaintMode.blur,
+                    PaintMode.eraser,
+                  ],
                 ),
                 videoEditor: videoConfigs.copyWith(
                   playTimeSmoothingDuration: const Duration(milliseconds: 600),

--- a/example/lib/features/video_examples/pages/flick_video_player_example.dart
+++ b/example/lib/features/video_examples/pages/flick_video_player_example.dart
@@ -166,9 +166,19 @@ class _FlickVideoPlayerExampleState extends State<FlickVideoPlayerExample>
                   ),
                 ),
                 paintEditor: const PaintEditorConfigs(
-                  /// Blur and pixelate are not supported.
-                  enableModePixelate: false,
-                  enableModeBlur: false,
+                  tools: [
+                    PaintMode.freeStyle,
+                    PaintMode.arrow,
+                    PaintMode.line,
+                    PaintMode.rect,
+                    PaintMode.circle,
+                    PaintMode.dashLine,
+                    PaintMode.polygon,
+                    // Blur and pixelate are not supported.
+                    // PaintMode.pixelate,
+                    // PaintMode.blur,
+                    PaintMode.eraser,
+                  ],
                 ),
                 videoEditor: videoConfigs.copyWith(
                   playTimeSmoothingDuration: const Duration(milliseconds: 600),

--- a/example/lib/features/video_examples/pages/video_media_kit_example.dart
+++ b/example/lib/features/video_examples/pages/video_media_kit_example.dart
@@ -169,9 +169,19 @@ class _VideoMediaKitExampleState extends State<VideoMediaKitExample>
                   ),
                 ),
                 paintEditor: const PaintEditorConfigs(
-                  /// Blur and pixelate are not supported.
-                  enableModePixelate: false,
-                  enableModeBlur: false,
+                  tools: [
+                    PaintMode.freeStyle,
+                    PaintMode.arrow,
+                    PaintMode.line,
+                    PaintMode.rect,
+                    PaintMode.circle,
+                    PaintMode.dashLine,
+                    PaintMode.polygon,
+                    // Blur and pixelate are not supported.
+                    // PaintMode.pixelate,
+                    // PaintMode.blur,
+                    PaintMode.eraser,
+                  ],
                 ),
                 videoEditor: videoConfigs,
               ),

--- a/example/lib/features/video_examples/pages/video_player_example.dart
+++ b/example/lib/features/video_examples/pages/video_player_example.dart
@@ -160,9 +160,19 @@ class _VideoPlayerExampleState extends State<VideoPlayerExample>
           ),
         ),
         paintEditor: const PaintEditorConfigs(
-          /// Blur and pixelate are not supported.
-          enableModePixelate: false,
-          enableModeBlur: false,
+          tools: [
+            PaintMode.freeStyle,
+            PaintMode.arrow,
+            PaintMode.line,
+            PaintMode.rect,
+            PaintMode.circle,
+            PaintMode.dashLine,
+            PaintMode.polygon,
+            // Blur and pixelate are not supported.
+            // PaintMode.pixelate,
+            // PaintMode.blur,
+            PaintMode.eraser,
+          ],
         ),
         videoEditor: videoConfigs.copyWith(
           playTimeSmoothingDuration: const Duration(milliseconds: 600),

--- a/lib/core/enums/editor_mode.dart
+++ b/lib/core/enums/editor_mode.dart
@@ -27,3 +27,30 @@ enum EditorMode {
   /// The sticker editor.
   sticker,
 }
+
+/// Defines the available sub-editor modes.
+enum SubEditorMode {
+  /// The paint editor.
+  paint,
+
+  /// The text editor.
+  text,
+
+  /// The crop & rotate editor.
+  cropRotate,
+
+  /// The tune editor.
+  tune,
+
+  /// The filter editor.
+  filter,
+
+  /// The blur editor.
+  blur,
+
+  /// The emoji editor.
+  emoji,
+
+  /// The sticker editor.
+  sticker,
+}

--- a/lib/core/mixins/standalone_editor.dart
+++ b/lib/core/mixins/standalone_editor.dart
@@ -15,7 +15,6 @@ import '/shared/factories/editor_mapper.dart';
 import '/shared/services/content_recorder/controllers/content_recorder_controller.dart';
 import '/shared/utils/decode_image.dart';
 import '/shared/widgets/overlays/loading_dialog/loading_dialog.dart';
-import '../enums/editor_mode.dart';
 import '../models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '../models/editor_configs/pro_image_editor_configs.dart';
 import '../models/editor_image.dart';

--- a/lib/core/models/editor_configs/blur_editor_configs.dart
+++ b/lib/core/models/editor_configs/blur_editor_configs.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 import '../custom_widgets/blur_editor_widgets.dart';
 import '../icons/blur_editor_icons.dart';
 import '../styles/blur_editor_style.dart';
@@ -26,6 +29,10 @@ class BlurEditorConfigs implements BaseSubEditorConfigs {
   /// By default, the editor is enabled, and max blur is 5.0.
   const BlurEditorConfigs({
     this.enableGesturePop = true,
+    @Deprecated(
+      'Use tools inside MainEditorConfigs instead, e.g. tools: '
+      '[SubEditorMode.blur]',
+    )
     this.enabled = true,
     this.showLayers = true,
     this.maxBlur = 5.0,
@@ -40,6 +47,10 @@ class BlurEditorConfigs implements BaseSubEditorConfigs {
   final bool enableGesturePop;
 
   /// Indicates whether the blur editor is enabled.
+  @Deprecated(
+    'Use tools inside MainEditorConfigs instead, e.g. tools: '
+    '[SubEditorMode.blur]',
+  )
   final bool enabled;
 
   /// Show also layers in the editor.

--- a/lib/core/models/editor_configs/crop_rotate_editor_configs.dart
+++ b/lib/core/models/editor_configs/crop_rotate_editor_configs.dart
@@ -1,6 +1,10 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 import 'package:flutter/material.dart';
 
 import '/features/crop_rotate_editor/enums/crop_mode.enum.dart';
+import '/features/crop_rotate_editor/enums/crop_tool_enum.dart';
 import '/features/crop_rotate_editor/models/aspect_ratio_item.dart';
 import '/features/crop_rotate_editor/models/rotate_direction.dart';
 import '../custom_widgets/crop_rotate_editor_widgets.dart';
@@ -8,6 +12,8 @@ import '../icons/crop_rotate_editor_icons.dart';
 import '../styles/crop_rotate_editor_style.dart';
 import 'utils/base_sub_editor_configs.dart';
 import 'utils/editor_safe_area.dart';
+
+export '/features/crop_rotate_editor/enums/crop_tool_enum.dart';
 export '/features/crop_rotate_editor/models/rotate_direction.dart';
 export '/features/crop_rotate_editor/models/transform_configs.dart';
 export '../custom_widgets/crop_rotate_editor_widgets.dart';
@@ -39,11 +45,25 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
     this.desktopCornerDragArea = 7,
     this.mobileCornerDragArea = kMinInteractiveDimension,
     this.enableGesturePop = true,
+    @Deprecated(
+      'Use tools inside MainEditorConfigs instead, e.g. tools: '
+      '[SubEditorMode.cropRotate]',
+    )
     this.enabled = true,
+    @Deprecated('Use tools instead, e.g. tools: [CropRotateTool.rotate]')
     this.showRotateButton = true,
+    @Deprecated('Use tools instead, e.g. tools: [CropRotateTool.flip]')
     this.showFlipButton = true,
+    @Deprecated('Use tools instead, e.g. tools: [CropRotateTool.aspectRatio]')
     this.showAspectRatioButton = true,
+    @Deprecated('Use tools instead, e.g. tools: [CropRotateTool.reset]')
     this.showResetButton = true,
+    this.tools = const [
+      CropRotateTool.rotate,
+      CropRotateTool.flip,
+      CropRotateTool.aspectRatio,
+      CropRotateTool.reset,
+    ],
     this.invertMouseScroll = false,
     this.invertDragDirection = false,
     this.initialCropMode = CropMode.rectangular,
@@ -98,18 +118,26 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
   final bool enableGesturePop;
 
   /// Indicates whether the editor is enabled.
+  @Deprecated(
+    'Use tools inside MainEditorConfigs instead, e.g. tools: '
+    '[SubEditorMode.cropRotate]',
+  )
   final bool enabled;
 
   /// Whether to show a button to rotate the image.
+  @Deprecated('Use tools instead, e.g. tools: [CropRotateTool.rotate]')
   final bool showRotateButton;
 
   /// Whether to show a button to flip the image.
+  @Deprecated('Use tools instead, e.g. tools: [CropRotateTool.flip]')
   final bool showFlipButton;
 
   /// Whether to show a button to change the aspect ratio.
+  @Deprecated('Use tools instead, e.g. tools: [CropRotateTool.aspectRatio]')
   final bool showAspectRatioButton;
 
   /// Whether to show a button to reset all transformations.
+  @Deprecated('Use tools instead, e.g. tools: [CropRotateTool.reset]')
   final bool showResetButton;
 
   /// Show the layers from the main-editor.
@@ -135,6 +163,24 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
   /// This determines the default cropping behavior or aspect ratio that will be
   /// presented to the user before any manual adjustments are made.
   final CropMode initialCropMode;
+
+  /// Defines which crop-rotate tools are available in the editor.
+  ///
+  /// The order of the tools in this list determines the order in the UI.
+  /// Simply include the tools you want and leave out the ones you don’t.
+  ///
+  /// Example:
+  /// ```dart
+  /// PaintEditorConfigs(
+  ///   tools: [
+  ///      CropRotateTool.rotate,
+  ///      CropRotateTool.flip,
+  ///      CropRotateTool.aspectRatio,
+  ///      CropRotateTool.reset,
+  ///   ],
+  /// )
+  /// ```
+  final List<CropRotateTool> tools;
 
   /// A boolean flag that determines whether the `imageInfos` parameter
   /// should be included in the `onDone` callback.
@@ -239,10 +285,15 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
   CropRotateEditorConfigs copyWith({
     bool? enableGesturePop,
     bool? enabled,
+    @Deprecated('Use tools instead, e.g. tools: [CropRotateTool.rotate]')
     bool? showRotateButton,
+    @Deprecated('Use tools instead, e.g. tools: [CropRotateTool.flip]')
     bool? showFlipButton,
+    @Deprecated('Use tools instead, e.g. tools: [CropRotateTool.aspectRatio]')
     bool? showAspectRatioButton,
+    @Deprecated('Use tools instead, e.g. tools: [CropRotateTool.reset]')
     bool? showResetButton,
+    List<CropRotateTool>? tools,
     bool? showLayers,
     bool? enableTransformLayers,
     bool? enableDoubleTap,
@@ -282,6 +333,7 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
       showAspectRatioButton:
           showAspectRatioButton ?? this.showAspectRatioButton,
       showResetButton: showResetButton ?? this.showResetButton,
+      tools: tools ?? this.tools,
       showLayers: showLayers ?? this.showLayers,
       enableTransformLayers:
           enableTransformLayers ?? this.enableTransformLayers,

--- a/lib/core/models/editor_configs/emoji_editor_configs.dart
+++ b/lib/core/models/editor_configs/emoji_editor_configs.dart
@@ -1,4 +1,5 @@
-// Project imports:
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
 
 import 'dart:ui';
 
@@ -48,6 +49,10 @@ class EmojiEditorConfigs
   const EmojiEditorConfigs({
     this.layerFractionalOffset = const Offset(-0.5, -0.5),
     this.enableGesturePop = true,
+    @Deprecated(
+      'Use tools inside MainEditorConfigs instead, e.g. tools: '
+      '[SubEditorMode.emoji]',
+    )
     this.enabled = true,
     this.enablePreloadWebFont = true,
     this.initScale = 5.0,
@@ -70,6 +75,10 @@ class EmojiEditorConfigs
   final bool enableGesturePop;
 
   /// Indicates whether the emoji editor is enabled.
+  @Deprecated(
+    'Use tools inside MainEditorConfigs instead, e.g. tools: '
+    '[SubEditorMode.emoji]',
+  )
   final bool enabled;
 
   /// Indicates whether the web font should be preloaded on web platforms.

--- a/lib/core/models/editor_configs/filter_editor_configs.dart
+++ b/lib/core/models/editor_configs/filter_editor_configs.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 // Project imports:
 import '/features/filter_editor/utils/filter_generator/filter_model.dart';
 
@@ -33,6 +36,10 @@ class FilterEditorConfigs implements BaseSubEditorConfigs {
   /// filters.
   const FilterEditorConfigs({
     this.enableGesturePop = true,
+    @Deprecated(
+      'Use tools inside MainEditorConfigs instead, e.g. tools: '
+      '[SubEditorMode.filter]',
+    )
     this.enabled = true,
     this.showLayers = true,
     this.filterList,
@@ -49,6 +56,10 @@ class FilterEditorConfigs implements BaseSubEditorConfigs {
   final bool enableGesturePop;
 
   /// Indicates whether the filter editor is enabled.
+  @Deprecated(
+    'Use tools inside MainEditorConfigs instead, e.g. tools: '
+    '[SubEditorMode.filter]',
+  )
   final bool enabled;
 
   /// Show also layers in the editor.

--- a/lib/core/models/editor_configs/main_editor_configs.dart
+++ b/lib/core/models/editor_configs/main_editor_configs.dart
@@ -2,12 +2,14 @@ import 'package:flutter/widgets.dart';
 
 import '/features/crop_rotate_editor/models/transform_configs.dart';
 import '/shared/utils/decode_image.dart';
+import '../../enums/editor_mode.dart';
 import '../custom_widgets/main_editor_widgets.dart';
 import '../icons/main_editor_icons.dart';
 import '../styles/main_editor_style.dart';
 import 'utils/editor_safe_area.dart';
 import 'utils/zoom_configs.dart';
 
+export '../../enums/editor_mode.dart';
 export '../custom_widgets/main_editor_widgets.dart';
 export '../icons/main_editor_icons.dart';
 export '../styles/main_editor_style.dart';
@@ -30,6 +32,16 @@ class MainEditorConfigs extends ZoomConfigs {
     this.enableEscapeButton = true,
     this.canZoomWhenLayerSelected = true,
     this.mobilePanInteraction = MobilePanInteraction.move,
+    this.tools = const [
+      SubEditorMode.paint,
+      SubEditorMode.text,
+      SubEditorMode.cropRotate,
+      SubEditorMode.tune,
+      SubEditorMode.filter,
+      SubEditorMode.blur,
+      SubEditorMode.emoji,
+      // SubEditorMode.sticker,
+    ],
     this.style = const MainEditorStyle(),
     this.icons = const MainEditorIcons(),
     this.widgets = const MainEditorWidgets(),
@@ -78,6 +90,28 @@ class MainEditorConfigs extends ZoomConfigs {
   /// Defines the safe area configuration for the editor.
   final EditorSafeArea safeArea;
 
+  /// Defines which sub-editors are available in the bottom-bar of the editor.
+  ///
+  /// The order of the tools in this list determines the order in the UI.
+  /// Simply include the tools you want and leave out the ones you don’t.
+  ///
+  /// Example:
+  /// ```dart
+  /// PaintEditorConfigs(
+  ///   tools: [
+  ///      SubEditorMode.paint,
+  ///      SubEditorMode.text,
+  ///      SubEditorMode.cropRotate,
+  ///      SubEditorMode.tune,
+  ///      SubEditorMode.filter,
+  ///      SubEditorMode.blur,
+  ///      SubEditorMode.emoji,
+  ///      SubEditorMode.sticker,
+  ///   ],
+  /// )
+  /// ```
+  final List<SubEditorMode> tools;
+
   /// Creates a copy of this `MainEditorConfigs` object with the given fields
   /// replaced with new values.
   ///
@@ -103,6 +137,7 @@ class MainEditorConfigs extends ZoomConfigs {
     Duration? doubleTapZoomDuration,
     Curve? doubleTapZoomCurve,
     EditorSafeArea? safeArea,
+    List<SubEditorMode>? tools,
   }) {
     return MainEditorConfigs(
       enableCloseButton: enableCloseButton ?? this.enableCloseButton,
@@ -126,6 +161,7 @@ class MainEditorConfigs extends ZoomConfigs {
       doubleTapZoomCurve: doubleTapZoomCurve ?? this.doubleTapZoomCurve,
       boundaryMargin: boundaryMargin ?? this.boundaryMargin,
       safeArea: safeArea ?? this.safeArea,
+      tools: tools ?? this.tools,
     );
   }
 }

--- a/lib/core/models/editor_configs/paint_editor/paint_editor_configs.dart
+++ b/lib/core/models/editor_configs/paint_editor/paint_editor_configs.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
 import 'package:flutter/widgets.dart';
 
 import '/features/paint_editor/enums/paint_editor_enum.dart';
@@ -20,24 +22,6 @@ export 'censor_configs.dart';
 /// `PaintEditorConfigs` allows you to define settings for a paint editor,
 /// including whether the editor is enabled, which drawing tools are available,
 /// initial settings for drawing, and more.
-///
-/// Example usage:
-/// ```dart
-/// PaintEditorConfigs(
-///   enabled: true,
-///   enableModeFreeStyle = true,
-///   enableModeArrow = true,
-///   enableModeLine = true,
-///   enableModeRect = true,
-///   enableModeCircle = true,
-///   enableModeDashLine = true,
-///   enableModeBlur = true,
-///   enableModePixelate = true,
-///   enableModeEraser = true,
-///   isInitiallyFilled: false,
-///   initialPaintMode: PaintMode.freeStyle,
-/// );
-/// ```
 class PaintEditorConfigs extends ZoomConfigs
     implements BaseEditorLayerConfigs, BaseSubEditorConfigs {
   /// Creates an instance of PaintEditorConfigs with optional settings.
@@ -45,6 +29,10 @@ class PaintEditorConfigs extends ZoomConfigs
   /// By default, the editor is enabled, and most drawing tools are enabled.
   /// Other properties are set to reasonable defaults.
   const PaintEditorConfigs({
+    @Deprecated(
+      'Use tools inside MainEditorConfigs instead, e.g. tools: '
+      '[SubEditorMode.paint]',
+    )
     this.enabled = true,
     super.enableZoom,
     super.editorMinScale,
@@ -58,16 +46,39 @@ class PaintEditorConfigs extends ZoomConfigs
     this.layerFractionalOffset = const Offset(-0.5, -0.5),
     this.enableGesturePop = true,
     this.enableEdit = true,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.freeStyle]')
     this.enableModeFreeStyle = true,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.arrow]')
     this.enableModeArrow = true,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.line]')
     this.enableModeLine = true,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.rect]')
     this.enableModeRect = true,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.circle]')
     this.enableModeCircle = true,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.dashLine]')
     this.enableModeDashLine = true,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.polygon]')
     this.enableModePolygon = true,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.blur]')
     this.enableModeBlur = true,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.pixelate]')
     this.enableModePixelate = true,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.eraser]')
     this.enableModeEraser = true,
+    this.tools = const [
+      PaintMode.moveAndZoom,
+      PaintMode.freeStyle,
+      PaintMode.arrow,
+      PaintMode.line,
+      PaintMode.rect,
+      PaintMode.circle,
+      PaintMode.dashLine,
+      PaintMode.polygon,
+      PaintMode.pixelate,
+      PaintMode.blur,
+      PaintMode.eraser,
+    ],
     this.showToggleFillButton = true,
     this.showLineWidthAdjustmentButton = true,
     this.showOpacityAdjustmentButton = true,
@@ -116,33 +127,45 @@ class PaintEditorConfigs extends ZoomConfigs
   final bool enableGesturePop;
 
   /// Indicates whether the paint editor is enabled.
+  @Deprecated(
+    'Use tools inside MainEditorConfigs instead, e.g. tools: '
+    '[SubEditorMode.paint]',
+  )
   final bool enabled;
 
   /// Indicating whether created layers can be edited.
   final bool enableEdit;
 
   /// Indicating whether the free-style drawing option is enabled.
+  @Deprecated('Use tools instead, e.g. tools: [PaintMode.freeStyle]')
   final bool enableModeFreeStyle;
 
   /// Indicating whether the arrow drawing option is enabled.
+  @Deprecated('Use tools instead, e.g. tools: [PaintMode.arrow]')
   final bool enableModeArrow;
 
   /// Indicating whether the line drawing option is enabled.
+  @Deprecated('Use tools instead, e.g. tools: [PaintMode.line]')
   final bool enableModeLine;
 
   /// Indicating whether the rectangle drawing option is enabled.
+  @Deprecated('Use tools instead, e.g. tools: [PaintMode.rect]')
   final bool enableModeRect;
 
   /// Indicating whether the circle drawing option is enabled.
+  @Deprecated('Use tools instead, e.g. tools: [PaintMode.circle]')
   final bool enableModeCircle;
 
   /// Indicating whether the dash line drawing option is enabled.
+  @Deprecated('Use tools instead, e.g. tools: [PaintMode.dashLine]')
   final bool enableModeDashLine;
 
   /// Indicating whether the polygon drawing option is enabled.
+  @Deprecated('Use tools instead, e.g. tools: [PaintMode.polygon]')
   final bool enableModePolygon;
 
   /// Indicating whether the blur drawing option is enabled.
+  @Deprecated('Use tools instead, e.g. tools: [PaintMode.blur]')
   final bool enableModeBlur;
 
   /// Indicating whether the pixelate drawing option is enabled.
@@ -150,10 +173,32 @@ class PaintEditorConfigs extends ZoomConfigs
   /// **IMPORTANT**: This mode is only supported when using the Impeller
   /// rendering engine. On all other platforms, it will automatically be
   /// set to `false`.
+  @Deprecated('Use tools instead, e.g. tools: [PaintMode.pixelate]')
   final bool enableModePixelate;
 
   /// Indicating whether the eraser option is enabled.
+  @Deprecated('Use tools instead, e.g. tools: [PaintMode.eraser]')
   final bool enableModeEraser;
+
+  /// Defines which paint tools are available in the editor.
+  ///
+  /// The order of the tools in this list determines the order in the UI.
+  /// Simply include the tools you want and leave out the ones you don’t.
+  ///
+  /// Example:
+  /// ```dart
+  /// PaintEditorConfigs(
+  ///   tools: [
+  ///     PaintMode.freeStyle,
+  ///     PaintMode.arrow,
+  ///     PaintMode.line,
+  ///     PaintMode.rect,
+  ///     PaintMode.circle,
+  ///     PaintMode.blur,
+  ///   ],
+  /// )
+  /// ```
+  final List<PaintMode> tools;
 
   /// Whether to show a button for toggle the fill state.
   final bool showToggleFillButton;
@@ -245,15 +290,25 @@ class PaintEditorConfigs extends ZoomConfigs
     bool? enableGesturePop,
     bool? enabled,
     bool? enableEdit,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.freeStyle]')
     bool? enableModeFreeStyle,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.arrow]')
     bool? enableModeArrow,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.line]')
     bool? enableModeLine,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.rect]')
     bool? enableModeRect,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.circle]')
     bool? enableModeCircle,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.dashLine]')
     bool? enableModeDashLine,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.polygon]')
     bool? enableModePolygon,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.blur]')
     bool? enableModeBlur,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.pixelate]')
     bool? enableModePixelate,
+    @Deprecated('Use tools instead, e.g. tools: [PaintMode.eraser]')
     bool? enableModeEraser,
     bool? showToggleFillButton,
     bool? showLineWidthAdjustmentButton,
@@ -287,6 +342,7 @@ class PaintEditorConfigs extends ZoomConfigs
     double? minOpacity,
     double? maxOpacity,
     int? divisionsOpacity,
+    List<PaintMode>? tools,
   }) {
     return PaintEditorConfigs(
       layerFractionalOffset:
@@ -304,6 +360,7 @@ class PaintEditorConfigs extends ZoomConfigs
       enableModeBlur: enableModeBlur ?? this.enableModeBlur,
       enableModePixelate: enableModePixelate ?? this.enableModePixelate,
       enableModeEraser: enableModeEraser ?? this.enableModeEraser,
+      tools: tools ?? this.tools,
       showToggleFillButton: showToggleFillButton ?? this.showToggleFillButton,
       showLineWidthAdjustmentButton:
           showLineWidthAdjustmentButton ?? this.showLineWidthAdjustmentButton,

--- a/lib/core/models/editor_configs/sticker_editor_configs.dart
+++ b/lib/core/models/editor_configs/sticker_editor_configs.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 import 'package:flutter/widgets.dart';
 
 import '/core/models/layers/layer.dart';
@@ -37,7 +40,11 @@ class StickerEditorConfigs
     this.initWidth = 100,
     this.minScale = double.negativeInfinity,
     this.maxScale = double.infinity,
-    this.enabled = false,
+    @Deprecated(
+      'Use tools inside MainEditorConfigs instead, e.g. tools: '
+      '[SubEditorMode.sticker]',
+    )
+    this.enabled = true,
     this.style = const StickerEditorStyle(),
     this.icons = const StickerEditorIcons(),
   })  : assert(initWidth > 0, 'initWidth must be positive'),
@@ -57,6 +64,10 @@ class StickerEditorConfigs
   /// When set to `true`, the sticker editor is active and users can interact
   /// with it.
   /// If `false`, the editor is disabled and does not respond to user inputs.
+  @Deprecated(
+    'Use tools inside MainEditorConfigs instead, e.g. tools: '
+    '[SubEditorMode.sticker]',
+  )
   final bool enabled;
 
   /// The initial width of the stickers in the editor.

--- a/lib/core/models/editor_configs/text_editor_configs.dart
+++ b/lib/core/models/editor_configs/text_editor_configs.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 // Flutter imports:
 import 'package:flutter/widgets.dart';
 
@@ -39,6 +42,10 @@ class TextEditorConfigs
     this.layerFractionalOffset = const Offset(-0.5, -0.5),
     this.enableGesturePop = true,
     this.enableSuggestions = true,
+    @Deprecated(
+      'Use tools inside MainEditorConfigs instead, e.g. tools: '
+      '[SubEditorMode.text]',
+    )
     this.enabled = true,
     this.enableEdit = true,
     this.enableAutocorrect = true,
@@ -78,6 +85,10 @@ class TextEditorConfigs
   final bool enableGesturePop;
 
   /// Indicates whether the text editor is enabled.
+  @Deprecated(
+    'Use tools inside MainEditorConfigs instead, e.g. tools: '
+    '[SubEditorMode.text]',
+  )
   final bool enabled;
 
   /// Indicating whether created layers can be edited.

--- a/lib/core/models/editor_configs/tune_editor_configs.dart
+++ b/lib/core/models/editor_configs/tune_editor_configs.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 import '/features/tune_editor/models/tune_adjustment_item.dart';
 import '../custom_widgets/tune_editor_widgets.dart';
 import '../icons/tune_editor_icons.dart';
@@ -24,6 +27,10 @@ class TuneEditorConfigs implements BaseSubEditorConfigs {
   /// - [safeArea] defines the safe area configuration for the editor interface.
   const TuneEditorConfigs({
     this.enableGesturePop = true,
+    @Deprecated(
+      'Use tools inside MainEditorConfigs instead, e.g. tools: '
+      '[SubEditorMode.tune]',
+    )
     this.enabled = true,
     this.showLayers = true,
     this.tuneAdjustmentOptions,
@@ -40,6 +47,10 @@ class TuneEditorConfigs implements BaseSubEditorConfigs {
   /// Indicates whether the tune editor is enabled.
   ///
   /// When this is `false`, the tune editor features will be disabled.
+  @Deprecated(
+    'Use tools inside MainEditorConfigs instead, e.g. tools: '
+    '[SubEditorMode.tune]',
+  )
   final bool enabled;
 
   /// Specifies whether the layers should be visible in the editor.

--- a/lib/designs/frosted_glass/widgets/appbar/frosted_glass_appbar.dart
+++ b/lib/designs/frosted_glass/widgets/appbar/frosted_glass_appbar.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 // Flutter imports:
 import 'package:flutter/material.dart';
 
@@ -151,96 +154,100 @@ class _FrostedGlassActionBarState extends State<FrostedGlassActionBar> {
                       spacing: 12,
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        if (widget.editor.configs.paintEditor.enabled)
-                          IconButton(
-                            tooltip: widget.editor.configs.i18n.paintEditor
-                                .bottomNavigationBarText,
-                            onPressed: widget.editor.openPaintEditor,
-                            icon: Icon(widget
-                                .editor.paintEditorConfigs.icons.bottomNavBar),
-                          ),
-                        if (widget.editor.configs.textEditor.enabled)
-                          IconButton(
-                            tooltip: widget.editor.configs.i18n.textEditor
-                                .bottomNavigationBarText,
-                            onPressed: () => widget.editor.openTextEditor(
-                              duration: const Duration(milliseconds: 150),
-                            ),
-                            icon: Icon(widget
-                                .editor.textEditorConfigs.icons.bottomNavBar),
-                          ),
-                        if (widget.editor.configs.cropRotateEditor.enabled)
-                          IconButton(
-                            tooltip: widget.editor.configs.i18n.cropRotateEditor
-                                .bottomNavigationBarText,
-                            onPressed: widget.editor.openCropRotateEditor,
-                            icon: Icon(widget.editor.cropRotateEditorConfigs
-                                .icons.bottomNavBar),
-                          ),
-                        if (widget.editor.configs.tuneEditor.enabled)
-                          IconButton(
-                            tooltip: widget.editor.configs.i18n.tuneEditor
-                                .bottomNavigationBarText,
-                            onPressed: () =>
-                                widget.editor.openTuneEditor(enableHero: false),
-                            icon: Icon(widget
-                                .editor.tuneEditorConfigs.icons.bottomNavBar),
-                          ),
-                        if (widget.editor.configs.filterEditor.enabled)
-                          IconButton(
-                            tooltip: widget.editor.configs.i18n.filterEditor
-                                .bottomNavigationBarText,
-                            onPressed: widget.editor.openFilterEditor,
-                            icon: Icon(widget
-                                .editor.filterEditorConfigs.icons.bottomNavBar),
-                          ),
-                        if (widget.editor.configs.blurEditor.enabled)
-                          IconButton(
-                            tooltip: widget.editor.configs.i18n.blurEditor
-                                .bottomNavigationBarText,
-                            onPressed: widget.editor.openBlurEditor,
-                            icon: Icon(widget
-                                .editor.blurEditorConfigs.icons.bottomNavBar),
-                          ),
-                        if (widget.editor.configs.stickerEditor.enabled ||
-                            widget.editor.configs.emojiEditor.enabled)
-                          IconButton(
-                            key: const ValueKey(
-                                'whatsapp-open-sticker-editor-btn'),
-                            tooltip: widget.editor.configs.i18n.stickerEditor
-                                .bottomNavigationBarText,
-                            onPressed: widget.openStickerEditor,
-                            icon: Icon(widget.editor.stickerEditorConfigs.icons
-                                .bottomNavBar),
-                          ),
-                      ],
+                      children: _buildItemList(),
                     ),
                   ),
                 ),
               ),
             )
-          /*  AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 150),
-                  transitionBuilder: (child, animation) => ScaleTransition(
-                    scale: animation,
-                    child: FadeTransition(
-                      opacity: animation,
-                      child: child,
-                    ),
-                  ),
-                  child: widget.editor.canUndo
-                      ?IconButton(
-                          tooltip: widget.editor.configs.i18n.undo,
-                          onPressed: widget.editor.undoAction,
-                          icon: Icon(widget.editor.configs.icons.undoAction),
-                         
-                        )
-                      : const SizedBox.shrink(),
-                ),
-             */
         ],
       ),
     );
+  }
+
+  List<Widget> _buildItemList() {
+    final tools = widget.editor.configs.mainEditor.tools;
+
+    return tools
+        .map((tool) {
+          switch (tool) {
+            case SubEditorMode.paint:
+              if (!widget.editor.configs.paintEditor.enabled) return null;
+              return IconButton(
+                tooltip: widget
+                    .editor.configs.i18n.paintEditor.bottomNavigationBarText,
+                onPressed: widget.editor.openPaintEditor,
+                icon: Icon(widget.editor.paintEditorConfigs.icons.bottomNavBar),
+              );
+
+            case SubEditorMode.text:
+              if (!widget.editor.configs.textEditor.enabled) return null;
+              return IconButton(
+                tooltip: widget
+                    .editor.configs.i18n.textEditor.bottomNavigationBarText,
+                onPressed: () => widget.editor.openTextEditor(
+                  duration: const Duration(milliseconds: 150),
+                ),
+                icon: Icon(widget.editor.textEditorConfigs.icons.bottomNavBar),
+              );
+
+            case SubEditorMode.cropRotate:
+              if (!widget.editor.configs.cropRotateEditor.enabled) return null;
+              return IconButton(
+                tooltip: widget.editor.configs.i18n.cropRotateEditor
+                    .bottomNavigationBarText,
+                onPressed: widget.editor.openCropRotateEditor,
+                icon: Icon(
+                    widget.editor.cropRotateEditorConfigs.icons.bottomNavBar),
+              );
+
+            case SubEditorMode.tune:
+              if (!widget.editor.configs.tuneEditor.enabled) return null;
+              return IconButton(
+                tooltip: widget
+                    .editor.configs.i18n.tuneEditor.bottomNavigationBarText,
+                onPressed: () =>
+                    widget.editor.openTuneEditor(enableHero: false),
+                icon: Icon(widget.editor.tuneEditorConfigs.icons.bottomNavBar),
+              );
+
+            case SubEditorMode.filter:
+              if (!widget.editor.configs.filterEditor.enabled) return null;
+              return IconButton(
+                tooltip: widget
+                    .editor.configs.i18n.filterEditor.bottomNavigationBarText,
+                onPressed: widget.editor.openFilterEditor,
+                icon:
+                    Icon(widget.editor.filterEditorConfigs.icons.bottomNavBar),
+              );
+
+            case SubEditorMode.blur:
+              if (!widget.editor.configs.blurEditor.enabled) return null;
+              return IconButton(
+                tooltip: widget
+                    .editor.configs.i18n.blurEditor.bottomNavigationBarText,
+                onPressed: widget.editor.openBlurEditor,
+                icon: Icon(widget.editor.blurEditorConfigs.icons.bottomNavBar),
+              );
+
+            case SubEditorMode.emoji:
+              if (!(widget.editor.configs.stickerEditor.enabled ||
+                  widget.editor.configs.emojiEditor.enabled)) {
+                return null;
+              }
+              return IconButton(
+                key: const ValueKey('whatsapp-open-sticker-editor-btn'),
+                tooltip: widget
+                    .editor.configs.i18n.stickerEditor.bottomNavigationBarText,
+                onPressed: widget.openStickerEditor,
+                icon:
+                    Icon(widget.editor.stickerEditorConfigs.icons.bottomNavBar),
+              );
+            case SubEditorMode.sticker:
+              return null;
+          }
+        })
+        .whereType<Widget>()
+        .toList();
   }
 }

--- a/lib/designs/frosted_glass/widgets/bottombar/frosted_glass_paint_bottombar.dart
+++ b/lib/designs/frosted_glass/widgets/bottombar/frosted_glass_paint_bottombar.dart
@@ -185,8 +185,8 @@ class _FrostedGlassPaintBottomBarState
           alignment: WrapAlignment.start,
           runAlignment: WrapAlignment.center,
           spacing: 10,
-          children: List.generate(widget.paintEditor.paintModes.length, (i) {
-            PaintModeBottomBarItem item = widget.paintEditor.paintModes[i];
+          children: List.generate(widget.paintEditor.tools.length, (i) {
+            PaintModeBottomBarItem item = widget.paintEditor.tools[i];
             bool isSelected = widget.paintEditor.paintMode == item.mode;
             return IconButton(
               onPressed: () {

--- a/lib/designs/frosted_glass/widgets/frosted_glass_crop_rotate_toolbar.dart
+++ b/lib/designs/frosted_glass/widgets/frosted_glass_crop_rotate_toolbar.dart
@@ -50,11 +50,12 @@ class _FrostedGlassCropRotateToolbar
     extends State<FrostedGlassCropRotateToolbar> {
   @override
   Widget build(BuildContext context) {
-    var padding = const EdgeInsets.symmetric(vertical: 8, horizontal: 16);
-    var style = TextStyle(
+    const padding = EdgeInsets.symmetric(vertical: 8, horizontal: 16);
+    final style = TextStyle(
       color: widget.configs.cropRotateEditor.style.appBarColor,
       fontSize: 16,
     );
+    final tools = widget.configs.cropRotateEditor.tools;
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.end,
@@ -67,7 +68,7 @@ class _FrostedGlassCropRotateToolbar
             crossAxisAlignment: CrossAxisAlignment.center,
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              if (widget.configs.cropRotateEditor.showRotateButton)
+              if (tools.contains(CropRotateTool.rotate))
                 IconButton(
                   onPressed: widget.onRotate,
                   tooltip: widget.configs.i18n.cropRotateEditor.rotate,
@@ -76,7 +77,7 @@ class _FrostedGlassCropRotateToolbar
                 )
               else
                 const SizedBox.shrink(),
-              if (widget.configs.cropRotateEditor.showResetButton)
+              if (tools.contains(CropRotateTool.reset))
                 CupertinoButton(
                   onPressed: widget.onReset,
                   padding: padding,
@@ -85,7 +86,7 @@ class _FrostedGlassCropRotateToolbar
                     style: style,
                   ),
                 ),
-              if (widget.configs.cropRotateEditor.showAspectRatioButton)
+              if (tools.contains(CropRotateTool.aspectRatio))
                 IconButton(
                   onPressed: widget.openAspectRatios,
                   tooltip: widget.configs.i18n.cropRotateEditor.ratio,

--- a/lib/designs/frosted_glass/widgets/frosted_glass_sticker_editor.dart
+++ b/lib/designs/frosted_glass/widgets/frosted_glass_sticker_editor.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 // Flutter imports:
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -55,12 +58,16 @@ class _FrostedGlassStickerPageState extends State<FrostedGlassStickerPage> {
   late TextEditingController _searchCtrl;
   late FocusNode _searchFocus;
 
+  late final bool _isStickerEditorEnabled =
+      widget.configs.stickerEditor.enabled &&
+          widget.configs.mainEditor.tools.contains(SubEditorMode.sticker);
+
   @override
   void initState() {
     super.initState();
     _searchCtrl = TextEditingController();
     _searchFocus = FocusNode();
-    if (!widget.configs.emojiEditor.enabled) {
+    if (!_isStickerEditorEnabled) {
       temporaryStickerMode = FrostedGlassStickerMode.sticker;
     }
   }
@@ -95,7 +102,7 @@ class _FrostedGlassStickerPageState extends State<FrostedGlassStickerPage> {
                         configs: widget.configs,
                       ),
                     ),
-                    if (widget.configs.stickerEditor.enabled)
+                    if (_isStickerEditorEnabled)
                       Offstage(
                         offstage: temporaryStickerMode !=
                             FrostedGlassStickerMode.sticker,
@@ -180,7 +187,7 @@ class _FrostedGlassStickerPageState extends State<FrostedGlassStickerPage> {
                         color: Colors.white,
                       ),
                     ),
-                    if (widget.configs.stickerEditor.enabled)
+                    if (_isStickerEditorEnabled)
                       Align(
                         alignment: Alignment.center,
                         child: SegmentedButton(

--- a/lib/designs/grounded/widgets/bottombar/grounded_crop_rotate_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_crop_rotate_bar.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 import 'package:flutter/material.dart';
 
 import '/core/mixins/converted_configs.dart';
@@ -109,7 +112,9 @@ class _GroundedCropRotateBarState extends State<GroundedCropRotateBar>
               children: <Widget>[
                 ..._buildConfigs(),
                 if (cropRotateEditorConfigs.aspectRatios.isNotEmpty &&
-                    cropRotateEditorConfigs.showAspectRatioButton) ...[
+                    cropRotateEditorConfigs.showAspectRatioButton &&
+                    cropRotateEditorConfigs.tools
+                        .contains(CropRotateTool.aspectRatio)) ...[
                   const SizedBox(width: 5),
                   _buildDivider(),
                   ...List.generate(

--- a/lib/designs/grounded/widgets/bottombar/grounded_main_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_main_bar.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -174,114 +177,151 @@ class GroundedMainBarState extends State<GroundedMainBar>
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       mainAxisSize: MainAxisSize.min,
-                      children: <Widget>[
-                        if (paintEditorConfigs.enabled)
-                          FlatIconTextButton(
-                            spacing: 7,
-                            label: Text(
-                                i18n.paintEditor.bottomNavigationBarText,
-                                style: _bottomTextStyle),
-                            icon: Icon(
-                              paintEditorConfigs.icons.bottomNavBar,
-                              size: _bottomIconSize,
-                              color: _foreGroundColor,
-                            ),
-                            onPressed: widget.editor.openPaintEditor,
-                          ),
-                        if (textEditorConfigs.enabled)
-                          FlatIconTextButton(
-                            spacing: 7,
-                            label: Text(i18n.textEditor.bottomNavigationBarText,
-                                style: _bottomTextStyle),
-                            icon: Icon(
-                              textEditorConfigs.icons.bottomNavBar,
-                              size: _bottomIconSize,
-                              color: _foreGroundColor,
-                            ),
-                            onPressed: widget.editor.openTextEditor,
-                          ),
-                        if (cropRotateEditorConfigs.enabled)
-                          FlatIconTextButton(
-                            spacing: 7,
-                            label: Text(
-                                i18n.cropRotateEditor.bottomNavigationBarText,
-                                style: _bottomTextStyle),
-                            icon: Icon(
-                              cropRotateEditorConfigs.icons.bottomNavBar,
-                              size: _bottomIconSize,
-                              color: _foreGroundColor,
-                            ),
-                            onPressed: widget.editor.openCropRotateEditor,
-                          ),
-                        if (tuneEditorConfigs.enabled)
-                          FlatIconTextButton(
-                            spacing: 7,
-                            label: Text(i18n.tuneEditor.bottomNavigationBarText,
-                                style: _bottomTextStyle),
-                            icon: Icon(
-                              tuneEditorConfigs.icons.bottomNavBar,
-                              size: _bottomIconSize,
-                              color: _foreGroundColor,
-                            ),
-                            onPressed: widget.editor.openTuneEditor,
-                          ),
-                        if (filterEditorConfigs.enabled)
-                          FlatIconTextButton(
-                            spacing: 7,
-                            label: Text(
-                                i18n.filterEditor.bottomNavigationBarText,
-                                style: _bottomTextStyle),
-                            icon: Icon(
-                              filterEditorConfigs.icons.bottomNavBar,
-                              size: _bottomIconSize,
-                              color: _foreGroundColor,
-                            ),
-                            onPressed: widget.editor.openFilterEditor,
-                          ),
-                        if (blurEditorConfigs.enabled)
-                          FlatIconTextButton(
-                            spacing: 7,
-                            label: Text(i18n.blurEditor.bottomNavigationBarText,
-                                style: _bottomTextStyle),
-                            icon: Icon(
-                              blurEditorConfigs.icons.bottomNavBar,
-                              size: _bottomIconSize,
-                              color: _foreGroundColor,
-                            ),
-                            onPressed: widget.editor.openBlurEditor,
-                          ),
-                        if (emojiEditorConfigs.enabled)
-                          FlatIconTextButton(
-                            spacing: 7,
-                            label: Text(
-                                i18n.emojiEditor.bottomNavigationBarText,
-                                style: _bottomTextStyle),
-                            icon: Icon(
-                              emojiEditorConfigs.icons.bottomNavBar,
-                              size: _bottomIconSize,
-                              color: _foreGroundColor,
-                            ),
-                            onPressed: _openEmojiEditor,
-                          ),
-                        if (stickerEditorConfigs.enabled)
-                          FlatIconTextButton(
-                            spacing: 7,
-                            label: Text(
-                                i18n.stickerEditor.bottomNavigationBarText,
-                                style: _bottomTextStyle),
-                            icon: Icon(
-                              stickerEditorConfigs.icons.bottomNavBar,
-                              size: _bottomIconSize,
-                              color: _foreGroundColor,
-                            ),
-                            onPressed: _openStickerEditor,
-                          ),
-                      ],
+                      children: _buildToolList(),
                     ),
                   ),
           ),
         ),
       ),
     );
+  }
+
+  List<Widget> _buildToolList() {
+    final tools = widget.editor.configs.mainEditor.tools;
+
+    return tools
+        .map((tool) {
+          switch (tool) {
+            case SubEditorMode.paint:
+              if (!paintEditorConfigs.enabled) return null;
+              return FlatIconTextButton(
+                spacing: 7,
+                label: Text(
+                  i18n.paintEditor.bottomNavigationBarText,
+                  style: _bottomTextStyle,
+                ),
+                icon: Icon(
+                  paintEditorConfigs.icons.bottomNavBar,
+                  size: _bottomIconSize,
+                  color: _foreGroundColor,
+                ),
+                onPressed: widget.editor.openPaintEditor,
+              );
+
+            case SubEditorMode.text:
+              if (!textEditorConfigs.enabled) return null;
+              return FlatIconTextButton(
+                spacing: 7,
+                label: Text(
+                  i18n.textEditor.bottomNavigationBarText,
+                  style: _bottomTextStyle,
+                ),
+                icon: Icon(
+                  textEditorConfigs.icons.bottomNavBar,
+                  size: _bottomIconSize,
+                  color: _foreGroundColor,
+                ),
+                onPressed: widget.editor.openTextEditor,
+              );
+
+            case SubEditorMode.cropRotate:
+              if (!cropRotateEditorConfigs.enabled) return null;
+              return FlatIconTextButton(
+                spacing: 7,
+                label: Text(
+                  i18n.cropRotateEditor.bottomNavigationBarText,
+                  style: _bottomTextStyle,
+                ),
+                icon: Icon(
+                  cropRotateEditorConfigs.icons.bottomNavBar,
+                  size: _bottomIconSize,
+                  color: _foreGroundColor,
+                ),
+                onPressed: widget.editor.openCropRotateEditor,
+              );
+
+            case SubEditorMode.tune:
+              if (!tuneEditorConfigs.enabled) return null;
+              return FlatIconTextButton(
+                spacing: 7,
+                label: Text(
+                  i18n.tuneEditor.bottomNavigationBarText,
+                  style: _bottomTextStyle,
+                ),
+                icon: Icon(
+                  tuneEditorConfigs.icons.bottomNavBar,
+                  size: _bottomIconSize,
+                  color: _foreGroundColor,
+                ),
+                onPressed: widget.editor.openTuneEditor,
+              );
+
+            case SubEditorMode.filter:
+              if (!filterEditorConfigs.enabled) return null;
+              return FlatIconTextButton(
+                spacing: 7,
+                label: Text(
+                  i18n.filterEditor.bottomNavigationBarText,
+                  style: _bottomTextStyle,
+                ),
+                icon: Icon(
+                  filterEditorConfigs.icons.bottomNavBar,
+                  size: _bottomIconSize,
+                  color: _foreGroundColor,
+                ),
+                onPressed: widget.editor.openFilterEditor,
+              );
+
+            case SubEditorMode.blur:
+              if (!blurEditorConfigs.enabled) return null;
+              return FlatIconTextButton(
+                spacing: 7,
+                label: Text(
+                  i18n.blurEditor.bottomNavigationBarText,
+                  style: _bottomTextStyle,
+                ),
+                icon: Icon(
+                  blurEditorConfigs.icons.bottomNavBar,
+                  size: _bottomIconSize,
+                  color: _foreGroundColor,
+                ),
+                onPressed: widget.editor.openBlurEditor,
+              );
+
+            case SubEditorMode.emoji:
+              if (!emojiEditorConfigs.enabled) return null;
+              return FlatIconTextButton(
+                spacing: 7,
+                label: Text(
+                  i18n.emojiEditor.bottomNavigationBarText,
+                  style: _bottomTextStyle,
+                ),
+                icon: Icon(
+                  emojiEditorConfigs.icons.bottomNavBar,
+                  size: _bottomIconSize,
+                  color: _foreGroundColor,
+                ),
+                onPressed: _openEmojiEditor,
+              );
+
+            case SubEditorMode.sticker:
+              if (!stickerEditorConfigs.enabled) return null;
+              return FlatIconTextButton(
+                spacing: 7,
+                label: Text(
+                  i18n.stickerEditor.bottomNavigationBarText,
+                  style: _bottomTextStyle,
+                ),
+                icon: Icon(
+                  stickerEditorConfigs.icons.bottomNavBar,
+                  size: _bottomIconSize,
+                  color: _foreGroundColor,
+                ),
+                onPressed: _openStickerEditor,
+              );
+          }
+        })
+        .whereType<Widget>()
+        .toList();
   }
 }

--- a/lib/designs/grounded/widgets/bottombar/grounded_paint_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_paint_bar.dart
@@ -137,10 +137,9 @@ class _GroundedPaintBarState extends State<GroundedPaintBar>
                   _buildDivider(),
                 ],
                 ...List.generate(
-                  widget.editor.paintModes.length,
+                  widget.editor.tools.length,
                   (index) {
-                    PaintModeBottomBarItem item =
-                        widget.editor.paintModes[index];
+                    PaintModeBottomBarItem item = widget.editor.tools[index];
                     Color color = getColor(item.mode);
                     return FadeInUp(
                       duration: kGroundedFadeInDuration * 1.5,

--- a/lib/designs/whatsapp/whatsapp_sticker_editor.dart
+++ b/lib/designs/whatsapp/whatsapp_sticker_editor.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 // Dart imports:
 import 'dart:ui';
 
@@ -43,12 +46,16 @@ class _WhatsAppStickerPageState extends State<WhatsAppStickerPage> {
   late TextEditingController _searchCtrl;
   late FocusNode _searchFocus;
 
+  late final bool _isStickerEditorEnabled =
+      widget.configs.stickerEditor.enabled &&
+          widget.configs.mainEditor.tools.contains(SubEditorMode.sticker);
+
   @override
   void initState() {
     super.initState();
     _searchCtrl = TextEditingController();
     _searchFocus = FocusNode();
-    if (!widget.configs.stickerEditor.enabled) {
+    if (!_isStickerEditorEnabled) {
       whatsAppTemporaryStickerMode = WhatsAppStickerMode.emoji;
     }
   }
@@ -86,7 +93,7 @@ class _WhatsAppStickerPageState extends State<WhatsAppStickerPage> {
                         configs: widget.configs,
                       ),
                     ),
-                    if (widget.configs.stickerEditor.enabled)
+                    if (_isStickerEditorEnabled)
                       Offstage(
                         offstage: whatsAppTemporaryStickerMode !=
                             WhatsAppStickerMode.sticker,
@@ -171,7 +178,7 @@ class _WhatsAppStickerPageState extends State<WhatsAppStickerPage> {
                         color: Colors.white,
                       ),
                     ),
-                    if (widget.configs.stickerEditor.enabled)
+                    if (_isStickerEditorEnabled)
                       Align(
                         alignment: Alignment.center,
                         child: SegmentedButton(
@@ -235,12 +242,11 @@ class _WhatsAppStickerPageState extends State<WhatsAppStickerPage> {
       ),
       AnimatedSwitcher(
         duration: const Duration(milliseconds: 180),
-        reverseDuration:
-            widget.configs.stickerEditor.enabled ? null : const Duration(),
+        reverseDuration: _isStickerEditorEnabled ? null : const Duration(),
         switchInCurve: Curves.easeInOut,
         transitionBuilder: (child, animation) => FadeTransition(
           opacity: animation,
-          child: widget.configs.stickerEditor.enabled
+          child: _isStickerEditorEnabled
               ? SizeTransition(
                   sizeFactor: animation,
                   axisAlignment: -1,
@@ -257,15 +263,14 @@ class _WhatsAppStickerPageState extends State<WhatsAppStickerPage> {
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
         child: AnimatedSwitcher(
-          duration: Duration(
-              milliseconds: widget.configs.stickerEditor.enabled ? 160 : 0),
+          duration: Duration(milliseconds: _isStickerEditorEnabled ? 160 : 0),
           switchInCurve: Curves.easeInOut,
           transitionBuilder: (child, animation) => FadeTransition(
             opacity: animation,
             child: child,
           ),
           child: _activeSearch
-              ? (widget.configs.stickerEditor.enabled
+              ? (_isStickerEditorEnabled
                   ? Row(
                       children: [
                         Expanded(
@@ -288,8 +293,7 @@ class _WhatsAppStickerPageState extends State<WhatsAppStickerPage> {
                         icon: const Icon(Icons.search),
                         color: Colors.white,
                       ),
-                      if (widget.configs.stickerEditor.enabled)
-                        _buildCupertinoSegments(),
+                      if (_isStickerEditorEnabled) _buildCupertinoSegments(),
                       IconButton(
                         onPressed: null,
                         icon: Icon(

--- a/lib/designs/whatsapp/widgets/appbar/whatsapp_appbar.dart
+++ b/lib/designs/whatsapp/widgets/appbar/whatsapp_appbar.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 // Flutter imports:
 import 'package:flutter/material.dart';
 
@@ -60,101 +63,130 @@ class _WhatsAppAppBarState extends State<WhatsAppAppBar> {
       left: 10,
       right: 10,
       child: LayoutBuilder(builder: (context, constraints) {
-        double screenW = constraints.maxWidth;
-        final double space = screenW < 300 ? 5 : 10;
-        var gap = SizedBox(width: space);
         return widget.openEditor
             ? const SizedBox.shrink()
             : Row(
-                children: [
-                  GestureInterceptor(
-                    child: IconButton(
-                      tooltip: widget.configs.i18n.cancel,
-                      onPressed: widget.onClose,
-                      icon: Icon(widget.configs.mainEditor.icons.closeEditor),
-                      style: whatsAppButtonStyle,
-                    ),
-                  ),
-                  const Spacer(),
-                  gap,
-                  AnimatedSwitcher(
-                    duration: const Duration(milliseconds: 150),
-                    transitionBuilder: (child, animation) => ScaleTransition(
-                      scale: animation,
-                      child: FadeTransition(
-                        opacity: animation,
-                        child: child,
-                      ),
-                    ),
-                    child: widget.canUndo
-                        ? GestureInterceptor(
-                            child: IconButton(
-                              tooltip: widget.configs.i18n.undo,
-                              onPressed: widget.onTapUndo,
-                              icon: Icon(
-                                  widget.configs.mainEditor.icons.undoAction),
-                              style: whatsAppButtonStyle,
-                            ),
-                          )
-                        : const SizedBox.shrink(),
-                  ),
-                  if (widget.configs.cropRotateEditor.enabled) ...[
-                    gap,
-                    GestureInterceptor(
-                      child: IconButton(
-                        tooltip: widget.configs.i18n.cropRotateEditor
-                            .bottomNavigationBarText,
-                        onPressed: widget.onTapCropRotateEditor,
-                        icon: Icon(
-                            widget.configs.cropRotateEditor.icons.bottomNavBar),
-                        style: whatsAppButtonStyle,
-                      ),
-                    ),
-                  ],
-                  if (widget.configs.stickerEditor.enabled ||
-                      widget.configs.emojiEditor.enabled) ...[
-                    gap,
-                    GestureInterceptor(
-                      child: IconButton(
-                        key: const ValueKey('whatsapp-open-sticker-editor-btn'),
-                        tooltip: widget
-                            .configs.i18n.stickerEditor.bottomNavigationBarText,
-                        onPressed: widget.onTapStickerEditor,
-                        icon: Icon(
-                            widget.configs.stickerEditor.icons.bottomNavBar),
-                        style: whatsAppButtonStyle,
-                      ),
-                    ),
-                  ],
-                  if (widget.configs.textEditor.enabled) ...[
-                    gap,
-                    GestureInterceptor(
-                      child: IconButton(
-                        tooltip: widget
-                            .configs.i18n.textEditor.bottomNavigationBarText,
-                        onPressed: widget.onTapTextEditor,
-                        icon:
-                            Icon(widget.configs.textEditor.icons.bottomNavBar),
-                        style: whatsAppButtonStyle,
-                      ),
-                    ),
-                  ],
-                  if (widget.configs.paintEditor.enabled) ...[
-                    gap,
-                    GestureInterceptor(
-                      child: IconButton(
-                        tooltip: widget
-                            .configs.i18n.paintEditor.bottomNavigationBarText,
-                        onPressed: widget.onTapPaintEditor,
-                        icon:
-                            Icon(widget.configs.paintEditor.icons.bottomNavBar),
-                        style: whatsAppButtonStyle,
-                      ),
-                    ),
-                  ],
-                ],
+                children: _buildToolList(constraints.maxWidth),
               );
       }),
     );
+  }
+
+  List<Widget> _buildToolList(double screenWidth) {
+    final double space = screenWidth < 300 ? 5 : 10;
+    final gap = SizedBox(width: space);
+
+    final tools = widget.configs.mainEditor.tools;
+
+    final items = <Widget>[
+      // Close button (always visible)
+      GestureInterceptor(
+        child: IconButton(
+          tooltip: widget.configs.i18n.cancel,
+          onPressed: widget.onClose,
+          icon: Icon(widget.configs.mainEditor.icons.closeEditor),
+          style: whatsAppButtonStyle,
+        ),
+      ),
+      const Spacer(),
+      gap,
+
+      // Undo button
+      AnimatedSwitcher(
+        duration: const Duration(milliseconds: 150),
+        transitionBuilder: (child, animation) => ScaleTransition(
+          scale: animation,
+          child: FadeTransition(opacity: animation, child: child),
+        ),
+        child: widget.canUndo
+            ? GestureInterceptor(
+                child: IconButton(
+                  tooltip: widget.configs.i18n.undo,
+                  onPressed: widget.onTapUndo,
+                  icon: Icon(widget.configs.mainEditor.icons.undoAction),
+                  style: whatsAppButtonStyle,
+                ),
+              )
+            : const SizedBox.shrink(),
+      ),
+    ];
+
+    // Dynamic tools
+    for (final tool in tools) {
+      switch (tool) {
+        case SubEditorMode.cropRotate:
+          if (!widget.configs.cropRotateEditor.enabled) continue;
+          items.addAll([
+            gap,
+            GestureInterceptor(
+              child: IconButton(
+                tooltip: widget
+                    .configs.i18n.cropRotateEditor.bottomNavigationBarText,
+                onPressed: widget.onTapCropRotateEditor,
+                icon: Icon(widget.configs.cropRotateEditor.icons.bottomNavBar),
+                style: whatsAppButtonStyle,
+              ),
+            ),
+          ]);
+          break;
+
+        case SubEditorMode.emoji:
+          if (!(widget.configs.stickerEditor.enabled ||
+              widget.configs.emojiEditor.enabled)) {
+            continue;
+          }
+          items.addAll([
+            gap,
+            GestureInterceptor(
+              child: IconButton(
+                key: const ValueKey('whatsapp-open-sticker-editor-btn'),
+                tooltip:
+                    widget.configs.i18n.stickerEditor.bottomNavigationBarText,
+                onPressed: widget.onTapStickerEditor,
+                icon: Icon(widget.configs.stickerEditor.icons.bottomNavBar),
+                style: whatsAppButtonStyle,
+              ),
+            ),
+          ]);
+          break;
+
+        case SubEditorMode.text:
+          if (!widget.configs.textEditor.enabled) continue;
+          items.addAll([
+            gap,
+            GestureInterceptor(
+              child: IconButton(
+                tooltip: widget.configs.i18n.textEditor.bottomNavigationBarText,
+                onPressed: widget.onTapTextEditor,
+                icon: Icon(widget.configs.textEditor.icons.bottomNavBar),
+                style: whatsAppButtonStyle,
+              ),
+            ),
+          ]);
+          break;
+
+        case SubEditorMode.paint:
+          if (!widget.configs.paintEditor.enabled) continue;
+          items.addAll([
+            gap,
+            GestureInterceptor(
+              child: IconButton(
+                tooltip:
+                    widget.configs.i18n.paintEditor.bottomNavigationBarText,
+                onPressed: widget.onTapPaintEditor,
+                icon: Icon(widget.configs.paintEditor.icons.bottomNavBar),
+                style: whatsAppButtonStyle,
+              ),
+            ),
+          ]);
+          break;
+
+        // ignore tools that aren't relevant for this WhatsApp-like toolbar
+        default:
+          continue;
+      }
+    }
+
+    return items;
   }
 }

--- a/lib/features/crop_rotate_editor/crop_rotate_editor.dart
+++ b/lib/features/crop_rotate_editor/crop_rotate_editor.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 // Dart imports:
 import 'dart:math';
 import 'dart:ui' as ui;
@@ -378,6 +381,9 @@ class CropRotateEditorState extends State<CropRotateEditor>
 
   bool _isVideoPlayerReady = true;
 
+  /// Defines which crop-rotate tools are available in the editor.
+  late List<CropRotateTool> tools = [...cropRotateEditorConfigs.tools];
+
   @override
   void initState() {
     super.initState();
@@ -460,6 +466,21 @@ class CropRotateEditorState extends State<CropRotateEditor>
 
     // Perform post-frame initialization
     cropRotateEditorCallbacks?.onInit?.call();
+
+    // TODO: Remove when releasing version 12.0.0.
+    tools.removeWhere((el) {
+      switch (el) {
+        case CropRotateTool.rotate:
+          return !cropRotateEditorConfigs.showRotateButton;
+        case CropRotateTool.flip:
+          return !cropRotateEditorConfigs.showFlipButton;
+        case CropRotateTool.aspectRatio:
+          return !cropRotateEditorConfigs.showAspectRatioButton;
+        case CropRotateTool.reset:
+          return !cropRotateEditorConfigs.showResetButton;
+      }
+    });
+
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       cropRotateEditorCallbacks?.onAfterViewInit?.call();
       initialized = true;
@@ -2183,15 +2204,13 @@ class CropRotateEditorState extends State<CropRotateEditor>
           .call(this, rebuildController.stream);
     }
 
-    return cropRotateEditorConfigs.showRotateButton ||
-            cropRotateEditorConfigs.showFlipButton ||
-            cropRotateEditorConfigs.showAspectRatioButton ||
-            cropRotateEditorConfigs.showResetButton
+    return tools.isNotEmpty
         ? CropEditorBottombar(
             bottomBarScrollCtrl: _bottomBarScrollCtrl,
             i18n: i18n.cropRotateEditor,
             configs: cropRotateEditorConfigs,
             theme: theme,
+            tools: tools,
             onRotate: rotate,
             onFlip: flip,
             onOpenAspectRatioOptions: openAspectRatioOptions,

--- a/lib/features/crop_rotate_editor/enums/crop_tool_enum.dart
+++ b/lib/features/crop_rotate_editor/enums/crop_tool_enum.dart
@@ -1,0 +1,14 @@
+/// Defines the available tools in the crop & rotate editor.
+enum CropRotateTool {
+  /// A tool to rotate the image by 90° steps.
+  rotate,
+
+  /// A tool to flip the image horizontally or vertically.
+  flip,
+
+  /// A tool to change the aspect ratio of the image.
+  aspectRatio,
+
+  /// A tool to reset all transformations to their original state.
+  reset,
+}

--- a/lib/features/crop_rotate_editor/widgets/crop_editor_bottombar.dart
+++ b/lib/features/crop_rotate_editor/widgets/crop_editor_bottombar.dart
@@ -27,6 +27,7 @@ class CropEditorBottombar extends StatelessWidget {
     required this.i18n,
     required this.configs,
     required this.theme,
+    required this.tools,
     required this.onRotate,
     required this.onFlip,
     required this.onOpenAspectRatioOptions,
@@ -45,6 +46,9 @@ class CropEditorBottombar extends StatelessWidget {
   /// Theme data for styling the bottom bar.
   final ThemeData theme;
 
+  /// Defines which paint tools are available in the editor.
+  final List<CropRotateTool> tools;
+
   /// Callback for the rotate option.
   final Function() onRotate;
 
@@ -56,6 +60,39 @@ class CropEditorBottombar extends StatelessWidget {
 
   /// Callback for resetting the editor.
   final Function() onReset;
+
+  _ToolItem _getItem(CropRotateTool tool) {
+    switch (tool) {
+      case CropRotateTool.rotate:
+        return _ToolItem(
+          key: const ValueKey('crop-rotate-editor-rotate-btn'),
+          label: i18n.rotate,
+          icon: configs.icons.rotate,
+          onTap: onRotate,
+        );
+      case CropRotateTool.flip:
+        return _ToolItem(
+          key: const ValueKey('crop-rotate-editor-flip-btn'),
+          label: i18n.flip,
+          icon: configs.icons.flip,
+          onTap: onFlip,
+        );
+      case CropRotateTool.aspectRatio:
+        return _ToolItem(
+          key: const ValueKey('crop-rotate-editor-ratio-btn'),
+          label: i18n.ratio,
+          icon: configs.icons.aspectRatio,
+          onTap: onOpenAspectRatioOptions,
+        );
+      case CropRotateTool.reset:
+        return _ToolItem(
+          key: const ValueKey('crop-rotate-editor-reset-btn'),
+          label: i18n.reset,
+          icon: configs.icons.reset,
+          onTap: onReset,
+        );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -76,63 +113,12 @@ class CropEditorBottombar extends StatelessWidget {
                   minWidth: min(MediaQuery.sizeOf(context).width, 500),
                   maxWidth: 500,
                 ),
-                child: Builder(builder: (context) {
-                  Color foregroundColor = configs.style.appBarColor;
-                  return Wrap(
+                child: Wrap(
                     direction: Axis.horizontal,
                     alignment: WrapAlignment.spaceAround,
-                    children: <Widget>[
-                      if (configs.showRotateButton)
-                        FlatIconTextButton(
-                          key: const ValueKey('crop-rotate-editor-rotate-btn'),
-                          label: Text(
-                            i18n.rotate,
-                            style: TextStyle(
-                                fontSize: 10.0, color: foregroundColor),
-                          ),
-                          icon: Icon(configs.icons.rotate,
-                              color: foregroundColor),
-                          onPressed: onRotate,
-                        ),
-                      if (configs.showFlipButton)
-                        FlatIconTextButton(
-                          key: const ValueKey('crop-rotate-editor-flip-btn'),
-                          label: Text(
-                            i18n.flip,
-                            style: TextStyle(
-                                fontSize: 10.0, color: foregroundColor),
-                          ),
-                          icon:
-                              Icon(configs.icons.flip, color: foregroundColor),
-                          onPressed: onFlip,
-                        ),
-                      if (configs.showAspectRatioButton)
-                        FlatIconTextButton(
-                          key: const ValueKey('crop-rotate-editor-ratio-btn'),
-                          label: Text(
-                            i18n.ratio,
-                            style: TextStyle(
-                                fontSize: 10.0, color: foregroundColor),
-                          ),
-                          icon: Icon(configs.icons.aspectRatio,
-                              color: foregroundColor),
-                          onPressed: onOpenAspectRatioOptions,
-                        ),
-                      if (configs.showResetButton)
-                        FlatIconTextButton(
-                          key: const ValueKey('crop-rotate-editor-reset-btn'),
-                          label: Text(
-                            i18n.reset,
-                            style: TextStyle(
-                                fontSize: 10.0, color: foregroundColor),
-                          ),
-                          icon:
-                              Icon(configs.icons.reset, color: foregroundColor),
-                          onPressed: onReset,
-                        ),
-                    ],
-                  );
-                }),
+                    children: tools
+                        .map((tool) => _buildTool(_getItem(tool)))
+                        .toList()),
               ),
             ),
           ),
@@ -140,4 +126,31 @@ class CropEditorBottombar extends StatelessWidget {
       ),
     );
   }
+
+  Widget _buildTool(_ToolItem item) {
+    Color foregroundColor = configs.style.appBarColor;
+    return FlatIconTextButton(
+      key: item.key,
+      label: Text(
+        item.label,
+        style: TextStyle(fontSize: 10.0, color: foregroundColor),
+      ),
+      icon: Icon(item.icon, color: foregroundColor),
+      onPressed: item.onTap,
+    );
+  }
+}
+
+class _ToolItem {
+  const _ToolItem({
+    required this.key,
+    required this.label,
+    required this.icon,
+    required this.onTap,
+  });
+
+  final Key key;
+  final String label;
+  final IconData icon;
+  final Function() onTap;
 }

--- a/lib/features/main_editor/widgets/main_editor_bottombar.dart
+++ b/lib/features/main_editor/widgets/main_editor_bottombar.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -137,64 +140,84 @@ class MainEditorBottombar extends StatelessWidget {
 
   /// Builds a list of editor action buttons dynamically
   List<Widget> _buildEditorButtons() {
-    return [
-      if (configs.paintEditor.enabled)
-        _buildActionButton(
-          key: const ValueKey('open-paint-editor-btn'),
-          label: configs.i18n.paintEditor.bottomNavigationBarText,
-          icon: configs.paintEditor.icons.bottomNavBar,
-          onPressed: openPaintEditor,
-        ),
-      if (configs.textEditor.enabled)
-        _buildActionButton(
-          key: const ValueKey('open-text-editor-btn'),
-          label: configs.i18n.textEditor.bottomNavigationBarText,
-          icon: configs.textEditor.icons.bottomNavBar,
-          onPressed: openTextEditor,
-        ),
-      if (configs.cropRotateEditor.enabled)
-        _buildActionButton(
-          key: const ValueKey('open-crop-rotate-editor-btn'),
-          label: configs.i18n.cropRotateEditor.bottomNavigationBarText,
-          icon: configs.cropRotateEditor.icons.bottomNavBar,
-          onPressed: openCropRotateEditor,
-        ),
-      if (configs.tuneEditor.enabled)
-        _buildActionButton(
-          key: const ValueKey('open-tune-editor-btn'),
-          label: configs.i18n.tuneEditor.bottomNavigationBarText,
-          icon: configs.tuneEditor.icons.bottomNavBar,
-          onPressed: openTuneEditor,
-        ),
-      if (configs.filterEditor.enabled)
-        _buildActionButton(
-          key: const ValueKey('open-filter-editor-btn'),
-          label: configs.i18n.filterEditor.bottomNavigationBarText,
-          icon: configs.filterEditor.icons.bottomNavBar,
-          onPressed: openFilterEditor,
-        ),
-      if (configs.blurEditor.enabled)
-        _buildActionButton(
-          key: const ValueKey('open-blur-editor-btn'),
-          label: configs.i18n.blurEditor.bottomNavigationBarText,
-          icon: configs.blurEditor.icons.bottomNavBar,
-          onPressed: openBlurEditor,
-        ),
-      if (configs.emojiEditor.enabled)
-        _buildActionButton(
-          key: const ValueKey('open-emoji-editor-btn'),
-          label: configs.i18n.emojiEditor.bottomNavigationBarText,
-          icon: configs.emojiEditor.icons.bottomNavBar,
-          onPressed: openEmojiEditor,
-        ),
-      if (configs.stickerEditor.enabled)
-        _buildActionButton(
-          key: const ValueKey('open-sticker-editor-btn'),
-          label: configs.i18n.stickerEditor.bottomNavigationBarText,
-          icon: configs.stickerEditor.icons.bottomNavBar,
-          onPressed: openStickerEditor,
-        ),
-    ];
+    return configs.mainEditor.tools
+        .map((tool) {
+          switch (tool) {
+            case SubEditorMode.paint:
+              if (!configs.paintEditor.enabled) return null;
+              return _buildActionButton(
+                key: const ValueKey('open-paint-editor-btn'),
+                label: configs.i18n.paintEditor.bottomNavigationBarText,
+                icon: configs.paintEditor.icons.bottomNavBar,
+                onPressed: openPaintEditor,
+              );
+
+            case SubEditorMode.text:
+              if (!configs.textEditor.enabled) return null;
+              return _buildActionButton(
+                key: const ValueKey('open-text-editor-btn'),
+                label: configs.i18n.textEditor.bottomNavigationBarText,
+                icon: configs.textEditor.icons.bottomNavBar,
+                onPressed: openTextEditor,
+              );
+
+            case SubEditorMode.cropRotate:
+              if (!configs.cropRotateEditor.enabled) return null;
+              return _buildActionButton(
+                key: const ValueKey('open-crop-rotate-editor-btn'),
+                label: configs.i18n.cropRotateEditor.bottomNavigationBarText,
+                icon: configs.cropRotateEditor.icons.bottomNavBar,
+                onPressed: openCropRotateEditor,
+              );
+
+            case SubEditorMode.tune:
+              if (!configs.tuneEditor.enabled) return null;
+              return _buildActionButton(
+                key: const ValueKey('open-tune-editor-btn'),
+                label: configs.i18n.tuneEditor.bottomNavigationBarText,
+                icon: configs.tuneEditor.icons.bottomNavBar,
+                onPressed: openTuneEditor,
+              );
+
+            case SubEditorMode.filter:
+              if (!configs.filterEditor.enabled) return null;
+              return _buildActionButton(
+                key: const ValueKey('open-filter-editor-btn'),
+                label: configs.i18n.filterEditor.bottomNavigationBarText,
+                icon: configs.filterEditor.icons.bottomNavBar,
+                onPressed: openFilterEditor,
+              );
+
+            case SubEditorMode.blur:
+              if (!configs.blurEditor.enabled) return null;
+              return _buildActionButton(
+                key: const ValueKey('open-blur-editor-btn'),
+                label: configs.i18n.blurEditor.bottomNavigationBarText,
+                icon: configs.blurEditor.icons.bottomNavBar,
+                onPressed: openBlurEditor,
+              );
+
+            case SubEditorMode.emoji:
+              if (!configs.emojiEditor.enabled) return null;
+              return _buildActionButton(
+                key: const ValueKey('open-emoji-editor-btn'),
+                label: configs.i18n.emojiEditor.bottomNavigationBarText,
+                icon: configs.emojiEditor.icons.bottomNavBar,
+                onPressed: openEmojiEditor,
+              );
+
+            case SubEditorMode.sticker:
+              if (!configs.stickerEditor.enabled) return null;
+              return _buildActionButton(
+                key: const ValueKey('open-sticker-editor-btn'),
+                label: configs.i18n.stickerEditor.bottomNavigationBarText,
+                icon: configs.stickerEditor.icons.bottomNavBar,
+                onPressed: openStickerEditor,
+              );
+          }
+        })
+        .whereType<Widget>()
+        .toList();
   }
 
   /// Helper to build a single action button

--- a/lib/features/paint_editor/models/paint_mode_helper_model.dart
+++ b/lib/features/paint_editor/models/paint_mode_helper_model.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/widgets.dart';
+
+/// Helper class for defining a paint mode's UI representation.
+///
+/// Contains the [icon] and [label] used in the editor's toolbars.
+class PaintModeHelper {
+  /// Creates a [PaintModeHelper] with the given [icon] and [label].
+  const PaintModeHelper({
+    required this.icon,
+    required this.label,
+  });
+
+  /// The icon that represents the paint mode.
+  final IconData icon;
+
+  /// The label text shown for the paint mode.
+  final String label;
+}

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// TODO: Remove the deprecated values when releasing version 12.0.0.
+
 import 'dart:async';
 import 'dart:math';
 
@@ -30,6 +33,7 @@ import '../filter_editor/widgets/filtered_widget.dart';
 import '../main_editor/services/layer_copy_manager.dart';
 import 'controllers/paint_controller.dart';
 import 'models/paint_editor_response_model.dart';
+import 'models/paint_mode_helper_model.dart';
 import 'services/paint_desktop_interaction_manager.dart';
 import 'widgets/paint_canvas.dart';
 
@@ -254,69 +258,7 @@ class PaintEditorState extends State<PaintEditor>
   /// modes in the paint editor.
   /// The list is dynamically generated based on the configuration settings in
   /// the [PaintEditorConfigs] object.
-  List<PaintModeBottomBarItem> get paintModes => [
-        if (paintEditorConfigs.enableModeFreeStyle)
-          PaintModeBottomBarItem(
-            mode: PaintMode.freeStyle,
-            icon: paintEditorConfigs.icons.freeStyle,
-            label: i18n.paintEditor.freestyle,
-          ),
-        if (paintEditorConfigs.enableModeArrow)
-          PaintModeBottomBarItem(
-            mode: PaintMode.arrow,
-            icon: paintEditorConfigs.icons.arrow,
-            label: i18n.paintEditor.arrow,
-          ),
-        if (paintEditorConfigs.enableModeLine)
-          PaintModeBottomBarItem(
-            mode: PaintMode.line,
-            icon: paintEditorConfigs.icons.line,
-            label: i18n.paintEditor.line,
-          ),
-        if (paintEditorConfigs.enableModeRect)
-          PaintModeBottomBarItem(
-            mode: PaintMode.rect,
-            icon: paintEditorConfigs.icons.rectangle,
-            label: i18n.paintEditor.rectangle,
-          ),
-        if (paintEditorConfigs.enableModeCircle)
-          PaintModeBottomBarItem(
-            mode: PaintMode.circle,
-            icon: paintEditorConfigs.icons.circle,
-            label: i18n.paintEditor.circle,
-          ),
-        if (paintEditorConfigs.enableModeDashLine)
-          PaintModeBottomBarItem(
-            mode: PaintMode.dashLine,
-            icon: paintEditorConfigs.icons.dashLine,
-            label: i18n.paintEditor.dashLine,
-          ),
-        if (paintEditorConfigs.enableModePolygon)
-          PaintModeBottomBarItem(
-            mode: PaintMode.polygon,
-            icon: paintEditorConfigs.icons.polygon,
-            label: i18n.paintEditor.polygon,
-          ),
-        if (paintEditorConfigs.enableModePixelate &&
-            ShaderManager.instance.isShaderFilterSupported)
-          PaintModeBottomBarItem(
-            mode: PaintMode.pixelate,
-            icon: paintEditorConfigs.icons.pixelate,
-            label: i18n.paintEditor.pixelate,
-          ),
-        if (paintEditorConfigs.enableModeBlur)
-          PaintModeBottomBarItem(
-            mode: PaintMode.blur,
-            icon: paintEditorConfigs.icons.blur,
-            label: i18n.paintEditor.blur,
-          ),
-        if (paintEditorConfigs.enableModeEraser)
-          PaintModeBottomBarItem(
-            mode: PaintMode.eraser,
-            icon: paintEditorConfigs.icons.eraser,
-            label: i18n.paintEditor.eraser,
-          ),
-      ];
+  final List<PaintModeBottomBarItem> tools = [];
 
   /// The Uint8List from the fake hero image, which is drawn when finish
   /// editing.
@@ -371,6 +313,7 @@ class PaintEditorState extends State<PaintEditor>
     _isFillMode = paintEditorConfigs.isInitiallyFilled;
 
     initStreamControllers();
+    setTools(paintEditorConfigs.tools);
 
     _bottomBarScrollCtrl = ScrollController();
     _desktopInteractionManager =
@@ -408,6 +351,112 @@ class PaintEditorState extends State<PaintEditor>
   void setState(void Function() fn) {
     rebuildController.add(null);
     super.setState(fn);
+  }
+
+  /// Sets the available painting tools for the paint editor.
+  ///
+  /// This method configures the available painting modes based on the provided
+  /// [tools] list and the current paint editor configuration settings. Only
+  /// tools that are both included in the [tools] parameter and enabled in
+  /// [paintEditorConfigs] will be added to the tool list.
+  void setTools(List<PaintMode> tools) {
+    PaintModeHelper? buildPaintModeHelper(PaintMode mode) {
+      switch (mode) {
+        case PaintMode.freeStyle:
+          if (!paintEditorConfigs.enableModeFreeStyle) return null;
+          return PaintModeHelper(
+            icon: paintEditorConfigs.icons.freeStyle,
+            label: i18n.paintEditor.freestyle,
+          );
+
+        case PaintMode.arrow:
+          if (!paintEditorConfigs.enableModeArrow) return null;
+          return PaintModeHelper(
+            icon: paintEditorConfigs.icons.arrow,
+            label: i18n.paintEditor.arrow,
+          );
+
+        case PaintMode.line:
+          if (!paintEditorConfigs.enableModeLine) return null;
+          return PaintModeHelper(
+            icon: paintEditorConfigs.icons.line,
+            label: i18n.paintEditor.line,
+          );
+
+        case PaintMode.rect:
+          if (!paintEditorConfigs.enableModeRect) return null;
+          return PaintModeHelper(
+            icon: paintEditorConfigs.icons.rectangle,
+            label: i18n.paintEditor.rectangle,
+          );
+
+        case PaintMode.circle:
+          if (!paintEditorConfigs.enableModeCircle) return null;
+          return PaintModeHelper(
+            icon: paintEditorConfigs.icons.circle,
+            label: i18n.paintEditor.circle,
+          );
+
+        case PaintMode.dashLine:
+          if (!paintEditorConfigs.enableModeDashLine) return null;
+          return PaintModeHelper(
+            icon: paintEditorConfigs.icons.dashLine,
+            label: i18n.paintEditor.dashLine,
+          );
+
+        case PaintMode.polygon:
+          if (!paintEditorConfigs.enableModePolygon) return null;
+          return PaintModeHelper(
+            icon: paintEditorConfigs.icons.polygon,
+            label: i18n.paintEditor.polygon,
+          );
+
+        case PaintMode.pixelate:
+          if (!paintEditorConfigs.enableModePixelate ||
+              !ShaderManager.instance.isShaderFilterSupported) {
+            return null;
+          }
+          return PaintModeHelper(
+            icon: paintEditorConfigs.icons.pixelate,
+            label: i18n.paintEditor.pixelate,
+          );
+
+        case PaintMode.blur:
+          if (!paintEditorConfigs.enableModeBlur) return null;
+          return PaintModeHelper(
+            icon: paintEditorConfigs.icons.blur,
+            label: i18n.paintEditor.blur,
+          );
+
+        case PaintMode.eraser:
+          if (!paintEditorConfigs.enableModeEraser) return null;
+          return PaintModeHelper(
+            icon: paintEditorConfigs.icons.eraser,
+            label: i18n.paintEditor.eraser,
+          );
+        case PaintMode.moveAndZoom:
+          if (!paintEditorConfigs.enableZoom) return null;
+          return PaintModeHelper(
+            icon: paintEditorConfigs.icons.moveAndZoom,
+            label: i18n.paintEditor.moveAndZoom,
+          );
+      }
+    }
+
+    this.tools.clear();
+    for (final tool in tools) {
+      final element = buildPaintModeHelper(tool);
+
+      if (element == null) continue;
+
+      this.tools.add(
+            PaintModeBottomBarItem(
+              mode: tool,
+              icon: element.icon,
+              label: element.label,
+            ),
+          );
+    }
   }
 
   /// Initializes stream controllers for managing UI updates.
@@ -993,7 +1042,7 @@ class PaintEditorState extends State<PaintEditor>
           .call(this, rebuildController.stream);
     }
 
-    if (paintModes.length <= 1) return const SizedBox.shrink();
+    if (tools.length <= 1) return const SizedBox.shrink();
 
     return PaintEditorBottombar(
       configs: configs.paintEditor,
@@ -1001,7 +1050,7 @@ class PaintEditorState extends State<PaintEditor>
       i18n: i18n.paintEditor,
       theme: theme,
       enableZoom: _enableZoom,
-      paintModes: paintModes,
+      tools: tools,
       setMode: setMode,
       bottomBarScrollCtrl: _bottomBarScrollCtrl,
     );

--- a/lib/features/paint_editor/widgets/paint_editor_bottombar.dart
+++ b/lib/features/paint_editor/widgets/paint_editor_bottombar.dart
@@ -20,7 +20,7 @@ class PaintEditorBottombar extends StatelessWidget {
   /// - [bottomBarScrollCtrl]: Controls the scroll behavior of the bottom bar.
   /// - [theme]: Theme data for styling the bottom bar.
   /// - [enableZoom]: Whether zoom functionality is enabled.
-  /// - [paintModes]: A list of available paint modes displayed in the bottom
+  /// - [tools]: A list of available paint modes displayed in the bottom
   ///   bar.
   /// - [setMode]: Callback triggered when a new paint mode is selected.
   const PaintEditorBottombar({
@@ -30,7 +30,7 @@ class PaintEditorBottombar extends StatelessWidget {
     required this.i18n,
     required this.theme,
     required this.enableZoom,
-    required this.paintModes,
+    required this.tools,
     required this.setMode,
     required this.bottomBarScrollCtrl,
   });
@@ -54,7 +54,7 @@ class PaintEditorBottombar extends StatelessWidget {
   final bool enableZoom;
 
   /// A list of available paint modes displayed in the bottom bar.
-  final List<PaintModeBottomBarItem> paintModes;
+  final List<PaintModeBottomBarItem> tools;
 
   /// Callback triggered when a new paint mode is selected.
   final Function(PaintMode mode) setMode;
@@ -68,8 +68,7 @@ class PaintEditorBottombar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     double minWidth = min(MediaQuery.sizeOf(context).width, 600);
-    double maxWidth =
-        max((paintModes.length + (enableZoom ? 1 : 0)) * 80, minWidth);
+    double maxWidth = max((tools.length + (enableZoom ? 1 : 0)) * 80, minWidth);
 
     return Theme(
       data: theme,
@@ -91,57 +90,23 @@ class PaintEditorBottombar extends StatelessWidget {
                       : double.infinity,
                 ),
                 child: Wrap(
-                  direction: Axis.horizontal,
-                  alignment: WrapAlignment.spaceAround,
-                  runAlignment: WrapAlignment.spaceAround,
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  children: <Widget>[
-                    if (enableZoom) ...[
-                      FlatIconTextButton(
+                    direction: Axis.horizontal,
+                    alignment: WrapAlignment.spaceAround,
+                    runAlignment: WrapAlignment.spaceAround,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: tools.map((item) {
+                      Color color = _getColor(item.mode);
+                      return FlatIconTextButton(
                         label: Text(
-                          i18n.moveAndZoom,
-                          style: TextStyle(
-                            fontSize: 10.0,
-                            color: _getColor(PaintMode.moveAndZoom),
-                          ),
+                          item.label,
+                          style: TextStyle(fontSize: 10.0, color: color),
                         ),
-                        icon: Icon(
-                          configs.icons.moveAndZoom,
-                          color: _getColor(PaintMode.moveAndZoom),
-                        ),
+                        icon: Icon(item.icon, color: color),
                         onPressed: () {
-                          setMode(PaintMode.moveAndZoom);
+                          setMode(item.mode);
                         },
-                      ),
-                      Container(
-                        margin: const EdgeInsets.symmetric(horizontal: 4),
-                        height: kBottomNavigationBarHeight - 14,
-                        width: 1,
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(2),
-                          color: configs.style.bottomBarInactiveItemColor,
-                        ),
-                      )
-                    ],
-                    ...List.generate(
-                      paintModes.length,
-                      (index) {
-                        PaintModeBottomBarItem item = paintModes[index];
-                        Color color = _getColor(item.mode);
-                        return FlatIconTextButton(
-                          label: Text(
-                            item.label,
-                            style: TextStyle(fontSize: 10.0, color: color),
-                          ),
-                          icon: Icon(item.icon, color: color),
-                          onPressed: () {
-                            setMode(item.mode);
-                          },
-                        );
-                      },
-                    ),
-                  ],
-                ),
+                      );
+                    }).toList()),
               ),
             ),
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 11.8.0
+version: 11.9.0
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/features/main_editor_test.dart
+++ b/test/features/main_editor_test.dart
@@ -309,14 +309,12 @@ void main() {
               onImageEditingComplete: (Uint8List bytes) async {},
             ),
             configs: ProImageEditorConfigs(
-              paintEditor: const PaintEditorConfigs(enabled: false),
-              textEditor: const TextEditorConfigs(enabled: false),
-              cropRotateEditor: const CropRotateEditorConfigs(enabled: false),
-              emojiEditor: const EmojiEditorConfigs(
-                enabled: false,
+              mainEditor: const MainEditorConfigs(
+                tools: [
+                  SubEditorMode.sticker,
+                ],
               ),
               stickerEditor: StickerEditorConfigs(
-                enabled: true,
                 builder: (setLayer, scrollController) =>
                     Container(key: widgetKey),
                 style: StickerEditorStyle(

--- a/test/features/sticker_editor_test.dart
+++ b/test/features/sticker_editor_test.dart
@@ -14,8 +14,12 @@ void main() {
         home: StickerEditor(
           scrollController: ScrollController(),
           configs: ProImageEditorConfigs(
+            mainEditor: const MainEditorConfigs(
+              tools: [
+                SubEditorMode.sticker,
+              ],
+            ),
             stickerEditor: StickerEditorConfigs(
-              enabled: true,
               builder: (setLayer, scrollController) {
                 return Container();
               },


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [x] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [x] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [ ] Bugfix
- [x] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
<!-- 
Please describe the behavior that is being modified, or link to a relevant issue. 
If the issue is already covered in the title, feel free to leave this section empty. 
-->

Issue Number: #672

## New Behavior
- main-editor: added `mainEditor.tools` to configure available sub-editors and their order, replacing multiple `enableModeX` flags and hardcoded if-chains with a dynamic toolbar.
- paint-editor: added `paintEditor.tools` to define available paint modes and their order, deprecated individual `enableModeX` flags, and introduced a helper function with switch for cleaner mapping.
- crop-rotate-editor: added `cropRotateEditor.tools` with new `CropRotateTool` enum (`rotate`, `flip`, `aspectRatio`, `reset`) and deprecated `showRotateButton`, `showFlipButton`, `showAspectRatioButton`, and `showResetButton`.

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
