### PR TITLE
fix(text-editor): Fix theme change during hero flight.

### DIFF
--- a/lib/features/text_editor/widgets/text_editor_input.dart
+++ b/lib/features/text_editor/widgets/text_editor_input.dart
@@ -116,6 +116,10 @@ class _TextEditorInputState extends State<TextEditorInput> {
 
       animation.addStatusListener(animationStatusListener);
     }
+
+    final shuttleChild =
+        InheritedTheme.captureAll(fromHeroContext, toHero.child);
+
     return isOpening
         ? SingleChildScrollView(
             clipBehavior: Clip.none,
@@ -123,11 +127,11 @@ class _TextEditorInputState extends State<TextEditorInput> {
             child: IntrinsicWidth(
               child: ConstrainedBox(
                 constraints: BoxConstraints(maxWidth: widget.maxWidth),
-                child: toHero.child,
+                child: shuttleChild,
               ),
             ),
           )
-        : toHero.child;
+        : shuttleChild;
   }
 
   @override


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [x] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
When the application contains a globally modified inputDecorationTheme (e.g., an added border), the InputField in TextEditor also receives this border. This can be mitigated by setting the theme prop in ProImageEditorConfigs, however the global theme was still visible in Hero during flight, causing a visible style shift.

Issue Number: N/A

## New Behavior
Hero during flight receives the same theme as the widget.

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Additional Information
