### PR TITLE
feat: add enableTapOutsideToSave prop to text editor configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## X.X.X
+- **FEAT**(text-editor): Added `enableTapOutsideToSave` configuration to `TextEditorConfigs` to control whether tapping outside the text field saves the text annotation. When set to `false`, users must use the done button or other explicit save actions. Defaults to `true` for backward compatibility.
+
 ## 11.11.0
 - **FEAT**(dashDotLine): Added new paint-mode "dashDotLine".
 

--- a/lib/core/models/editor_configs/text_editor_configs.dart
+++ b/lib/core/models/editor_configs/text_editor_configs.dart
@@ -54,6 +54,7 @@ class TextEditorConfigs
     this.showFontScaleButton = true,
     this.showBackgroundModeButton = true,
     this.enableMainEditorZoomFactor = false,
+    this.enableTapOutsideToSave = true,
     this.enableAutoOverflow = true,
     this.initFontSize = 24.0,
     this.initialPrimaryColor = const Color(0xFF000000),
@@ -110,6 +111,14 @@ class TextEditorConfigs
   /// A flag to enable or disable scaling of the text field in sync with the
   /// editor's zoom level.
   final bool enableMainEditorZoomFactor;
+
+  /// Whether tapping outside the text field saves the text annotation.
+  ///
+  /// When `true` (default), tapping outside the text input area will save
+  /// the current text and close the editor. When `false`, tapping outside
+  /// will not trigger the save action, requiring users to use the done
+  /// button or other explicit save actions.
+  final bool enableTapOutsideToSave;
 
   /// The initial font size for text.
   final double initFontSize;
@@ -204,6 +213,7 @@ class TextEditorConfigs
     bool? enableEdit,
     bool? showSelectFontStyleBottomBar,
     bool? enableMainEditorZoomFactor,
+    bool? enableTapOutsideToSave,
     bool? enableAutoOverflow,
     Color? initialPrimaryColor,
     Color? initialSecondaryColor,
@@ -236,6 +246,8 @@ class TextEditorConfigs
           showSelectFontStyleBottomBar ?? this.showSelectFontStyleBottomBar,
       enableMainEditorZoomFactor:
           enableMainEditorZoomFactor ?? this.enableMainEditorZoomFactor,
+      enableTapOutsideToSave:
+          enableTapOutsideToSave ?? this.enableTapOutsideToSave,
       enableAutoOverflow: enableAutoOverflow ?? this.enableAutoOverflow,
       initialPrimaryColor: initialPrimaryColor ?? this.initialPrimaryColor,
       initialSecondaryColor:

--- a/lib/features/text_editor/text_editor.dart
+++ b/lib/features/text_editor/text_editor.dart
@@ -396,7 +396,7 @@ class TextEditorState extends State<TextEditor>
 
       return GestureDetector(
         behavior: HitTestBehavior.translucent,
-        onTap: done,
+        onTap: textEditorConfigs.enableTapOutsideToSave ? done : null,
         child: Stack(
           children: [
             if (textEditorConfigs.widgets.bodyItems != null)


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [ ] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [ ] Bugfix
- [x] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
Currently, when you tap outside the text box in the text editor, the editor closes and saves the changes. This is ok for most cases, but for our specific scenario, where users most of the time uses an apple pencil, this might cause early closes of the editor when using normal pencil writting gestures. We want to manually trigger the done call in a separate button.

Issue Number: N/A

## New Behavior
I added enableTapOutsideToSave to text editor configs to have the option to disable this behavior.

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Additional Information
Im working on a way to also have a larger text area so apple pencil can be used smoothly, as an improvement for our use case.