### PR TITLE
fix(layer-selection): rtl layer selection location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 11.12.0
 - **FEAT**(text-editor): Added `enableTapOutsideToSave` configuration to `TextEditorConfigs` to control whether tapping outside the text field saves the text annotation. 
+- **FEAT**(example-app): Added localization support to the example app to switch between rtl/ltr locales.
 - **FIX**(paint-editor): Resolve draw delay in the freestyle mode. Resolves issue [#696](https://github.com/hm21/pro_image_editor/issues/696).
+- **FIX**(rtl-layer-selection): Correct layer selection position in RTL layout. Resolves issue [#698](https://github.com/hm21/pro_image_editor/issues/698).
+- **FIX**(rtl-loading-dialog): Add directional padding to the loading dialog.
 
 ## 11.11.0
 - **FEAT**(dashDotLine): Added new paint-mode "dashDotLine".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## 11.12.0
-- **FEAT**(text-editor): Added `enableTapOutsideToSave` configuration to `TextEditorConfigs` to control whether tapping outside the text field saves the text annotation. 
+## X.X.X
 - **FEAT**(example-app): Added localization support to the example app to switch between rtl/ltr locales.
-- **FIX**(paint-editor): Resolve draw delay in the freestyle mode. Resolves issue [#696](https://github.com/hm21/pro_image_editor/issues/696).
 - **FIX**(rtl-layer-selection): Correct layer selection position in RTL layout. Resolves issue [#698](https://github.com/hm21/pro_image_editor/issues/698).
 - **FIX**(rtl-loading-dialog): Add directional padding to the loading dialog.
+
+## 11.12.0
+- **FEAT**(text-editor): Added `enableTapOutsideToSave` configuration to `TextEditorConfigs` to control whether tapping outside the text field saves the text annotation. 
+- **FIX**(paint-editor): Resolve draw delay in the freestyle mode. Resolves issue [#696](https://github.com/hm21/pro_image_editor/issues/696).
 
 ## 11.11.0
 - **FEAT**(dashDotLine): Added new paint-mode "dashDotLine".

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:example/shared/widgets/not_found_example.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_localization/flutter_localization.dart';
 import 'package:media_kit/media_kit.dart';
 
 import 'package:pro_image_editor/pro_image_editor.dart';
@@ -14,7 +15,7 @@ import 'core/constants/example_list_constant.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-
+  await FlutterLocalization.instance.ensureInitialized();
   // Necessary initialization for package:media_kit.
   MediaKit.ensureInitialized();
 
@@ -35,6 +36,11 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    const langCode = 'ar';
+    FlutterLocalization.instance.init(
+      mapLocales: [const MapLocale(langCode, {})],
+      initLanguageCode: langCode,
+    );
     return MaterialApp(
       title: 'Pro-Image-Editor',
       theme: ThemeData(
@@ -45,6 +51,10 @@ class MyApp extends StatelessWidget {
         useMaterial3: true,
       ),
       builder: BotToastInit(),
+      locale: const Locale(langCode),
+      localizationsDelegates:
+          FlutterLocalization.instance.localizationsDelegates,
+      supportedLocales: [const Locale(langCode)],
       navigatorObservers: [BotToastNavigatorObserver()],
       debugShowCheckedModeBanner: false,
       onGenerateRoute: (settings) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   intl: ^0.20.1
   
   bot_toast: ^4.1.0
+  flutter_localization: ^0.3.3
   cupertino_icons: ^1.0.8
   file_picker: ^10.2.1
   gal: ^2.3.2

--- a/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
+++ b/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
@@ -301,9 +301,14 @@ class _LayerInteractionHelperWidgetState
         final paddedWidth = childWidth;
         final paddedHeight = childHeight;
 
+        final targetRenderBox = context.findRenderObject() as RenderBox;
+        final position = targetRenderBox.localToGlobal(Offset.zero);
+
         return Positioned(
           width: paddedWidth,
           height: paddedHeight,
+          top: position.dy,
+          left: position.dx,
           child: ValueListenableBuilder(
               valueListenable: _isOverlayVisibleNotifier,
               builder: (_, isVisible, __) {

--- a/lib/shared/widgets/overlays/loading_dialog/loading_dialog.dart
+++ b/lib/shared/widgets/overlays/loading_dialog/loading_dialog.dart
@@ -219,7 +219,7 @@ class LoadingDialog extends ChangeNotifier {
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
             Padding(
-              padding: const EdgeInsets.only(right: 20.0),
+              padding: const EdgeInsetsDirectional.only(end: 20.0),
               child: SizedBox(
                 height: 40,
                 width: 40,


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [x] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [x] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
<!-- 
When selecting a layer in an RTL layout, the layer selection overlay box location is offset to the right and is incorrect location.
-->

Issue Number: 698

## New Behavior
Selecting a layer in RTL layout correctly displays location of this layer selection above the layer box.
- correct position of layer selection in RTL layout
- add directional padding to the loading dialog
- add localization support to the example app to switch between rtl/ltr locales

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->
