### PR TITLE
feat(main-editor): make scale actions proportional in desktop interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## X.X.X
+- **FEAT**(main-editor): Make scaling actions done through desktop interactions (mouse scroll or keyboard) consistent between layer types and proportional to the current size of the layer.
+
 ## 11.12.1
 - **FIX**(RTL): Resolve incorrect layer selection box location. Resolves issue [#698](https://github.com/hm21/pro_image_editor/issues/698). 
 

--- a/lib/features/main_editor/services/desktop_interaction_manager.dart
+++ b/lib/features/main_editor/services/desktop_interaction_manager.dart
@@ -156,17 +156,13 @@ class DesktopInteractionManager {
     if (selectedLayers.isEmpty) return;
 
     for (Layer layer in selectedLayers) {
-      double factor = layer is PaintLayer
-          ? 0.1
-          : layer is TextLayer
-              ? 0.15
-              : configs.textEditor.initFontSize / 50;
+      double factor = 1.1;
       if (isZoomIn) {
         layer
-          ..scale -= factor
+          ..scale /= factor
           ..scale = max(0.1, layer.scale);
       } else {
-        layer.scale += factor;
+        layer.scale *= factor;
       }
     }
 
@@ -190,19 +186,15 @@ class DesktopInteractionManager {
           layer.rotation += 0.087266;
         }
       } else {
-        double factor = layer.isPaintLayer
-            ? 0.1
-            : layer.isTextLayer
-                ? 0.15
-                : configs.textEditor.initFontSize / 50;
+        double factor = 1.1;
         if (interactiveViewer?.isInteractionEnabled == true) {
           // only scale if interaction is enabled (that means we might zoom in/out)
           if (event.scrollDelta.dy > 0) {
             layer
-              ..scale -= factor
+              ..scale /= factor
               ..scale = max(0.1, layer.scale);
           } else if (event.scrollDelta.dy < 0) {
-            layer.scale += factor;
+            layer.scale *= factor;
           }
         }
       }


### PR DESCRIPTION






## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [x] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [ ] Bugfix
- [x] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
The scale factor is changed by a constant. The problem is that the layer is small, the change is relatively large. For example: If a paint layer has a scale of 0.2, a single scale action can change the scale to 0.1, which results in a 75% reduction in area of the object. In the demonstration below, notice the 'huge' steps when layer is small and 'tiny' steps when layer is large:

[Screencast from 2025-11-11 14-10-42.webm](https://github.com/user-attachments/assets/350449aa-83e2-4055-8a3a-b36a9aea9028)

Issue Number: N/A

## New Behavior
Scale changes from desktop interactions are proportional to the current size of the layer. It also makes the scaling behavior the same for all types of layers. In the demonstration, notice that scaling changes appear the same, regardless of layer size.

[Screencast from 2025-11-11 14-13-34.webm](https://github.com/user-attachments/assets/ff52e73a-2990-4005-b68e-f7c42b0a7193)

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Additional Information
I haven't searched for similar scaling behaviors in other parts of the software. If they exist, they might still be improvable in the same way.