### PR TITLE
feat: added enableImageBoundaryTextWrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## X.X.X
+- **FEAT**(text-editor): Add `enableImageBoundaryTextWrap` property to `TextEditorConfigs` to automatically wrap text at the actual image boundaries instead of screen boundaries.
+
 ## 11.12.2
 - **FEAT**(main-editor): Make scaling actions done through desktop interactions (mouse scroll or keyboard) consistent between layer types and proportional to the current size of the layer.
 

--- a/lib/core/models/editor_configs/text_editor_configs.dart
+++ b/lib/core/models/editor_configs/text_editor_configs.dart
@@ -38,42 +38,43 @@ class TextEditorConfigs
   ///
   /// By default, the text editor is enabled, and most text formatting options
   /// are enabled. The initial font size is set to 24.0.
-  const TextEditorConfigs({
-    this.layerFractionalOffset = const Offset(-0.5, -0.5),
-    this.enableGesturePop = true,
-    this.enableSuggestions = true,
-    @Deprecated(
-      'Use tools inside MainEditorConfigs instead, e.g. tools: '
-      '[SubEditorMode.text]',
-    )
-    this.enabled = true,
-    this.enableEdit = true,
-    this.enableAutocorrect = true,
-    this.showSelectFontStyleBottomBar = false,
-    this.showTextAlignButton = true,
-    this.showFontScaleButton = true,
-    this.showBackgroundModeButton = true,
-    this.enableMainEditorZoomFactor = false,
-    this.enableTapOutsideToSave = true,
-    this.enableAutoOverflow = true,
-    this.initFontSize = 24.0,
-    this.initialPrimaryColor = const Color(0xFF000000),
-    this.initialSecondaryColor,
-    this.initialTextAlign = TextAlign.center,
-    this.inputTextFieldAlign = Alignment.center,
-    this.initFontScale = 1.0,
-    this.maxFontScale = 3.0,
-    this.minFontScale = 0.3,
-    this.minScale = double.negativeInfinity,
-    this.maxScale = double.infinity,
-    this.customTextStyles,
-    this.defaultTextStyle = const TextStyle(),
-    this.initialBackgroundColorMode = LayerBackgroundMode.backgroundAndColor,
-    this.safeArea = const EditorSafeArea(),
-    this.style = const TextEditorStyle(),
-    this.icons = const TextEditorIcons(),
-    this.widgets = const TextEditorWidgets(),
-  })  : assert(initFontSize > 0, 'initFontSize must be positive'),
+  const TextEditorConfigs(
+      {this.layerFractionalOffset = const Offset(-0.5, -0.5),
+      this.enableGesturePop = true,
+      this.enableSuggestions = true,
+      @Deprecated(
+        'Use tools inside MainEditorConfigs instead, e.g. tools: '
+        '[SubEditorMode.text]',
+      )
+      this.enabled = true,
+      this.enableEdit = true,
+      this.enableAutocorrect = true,
+      this.showSelectFontStyleBottomBar = false,
+      this.showTextAlignButton = true,
+      this.showFontScaleButton = true,
+      this.showBackgroundModeButton = true,
+      this.enableMainEditorZoomFactor = false,
+      this.enableTapOutsideToSave = true,
+      this.enableAutoOverflow = true,
+      this.initFontSize = 24.0,
+      this.initialPrimaryColor = const Color(0xFF000000),
+      this.initialSecondaryColor,
+      this.initialTextAlign = TextAlign.center,
+      this.inputTextFieldAlign = Alignment.center,
+      this.initFontScale = 1.0,
+      this.maxFontScale = 3.0,
+      this.minFontScale = 0.3,
+      this.minScale = double.negativeInfinity,
+      this.maxScale = double.infinity,
+      this.customTextStyles,
+      this.defaultTextStyle = const TextStyle(),
+      this.initialBackgroundColorMode = LayerBackgroundMode.backgroundAndColor,
+      this.safeArea = const EditorSafeArea(),
+      this.style = const TextEditorStyle(),
+      this.icons = const TextEditorIcons(),
+      this.widgets = const TextEditorWidgets(),
+      this.enableImageBoundaryTextWrap = false})
+      : assert(initFontSize > 0, 'initFontSize must be positive'),
         assert(maxScale >= minScale,
             'maxScale must be greater than or equal to minScale');
 
@@ -200,6 +201,9 @@ class TextEditorConfigs
   /// Widgets associated with the text editor.
   final TextEditorWidgets widgets;
 
+  /// Enable automatic text wrapping when text reach the image boundaries
+  final bool enableImageBoundaryTextWrap;
+
   /// Creates a copy of this `TextEditorConfigs` object with the given fields
   /// replaced with new values.
   ///
@@ -234,6 +238,7 @@ class TextEditorConfigs
     TextEditorStyle? style,
     TextEditorIcons? icons,
     TextEditorWidgets? widgets,
+    bool? enableImageBoundaryTextWrap,
   }) {
     return TextEditorConfigs(
       layerFractionalOffset:
@@ -269,6 +274,8 @@ class TextEditorConfigs
       style: style ?? this.style,
       icons: icons ?? this.icons,
       widgets: widgets ?? this.widgets,
+      enableImageBoundaryTextWrap:
+          enableImageBoundaryTextWrap ?? this.enableImageBoundaryTextWrap,
     );
   }
 }

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -1347,6 +1347,7 @@ class ProImageEditorState extends State<ProImageEditor>
         scaleFactor: textEditorConfigs.enableMainEditorZoomFactor
             ? interactiveViewer.currentState?.scaleFactor ?? 1.0
             : 1.0,
+        imageSize: sizesManager.decodedImageSize,
       ),
 
       /// Small Duration is important for a smooth hero animation
@@ -1646,6 +1647,7 @@ class ProImageEditorState extends State<ProImageEditor>
         scaleFactor: textEditorConfigs.enableMainEditorZoomFactor
             ? interactiveViewer.currentState?.scaleFactor ?? 1.0
             : 1.0,
+        imageSize: sizesManager.decodedImageSize,
       ),
       duration: duration,
     );

--- a/lib/features/text_editor/text_editor.dart
+++ b/lib/features/text_editor/text_editor.dart
@@ -29,6 +29,7 @@ class TextEditor extends StatefulWidget with SimpleConfigsAccess {
     this.callbacks = const ProImageEditorCallbacks(),
     this.configs = const ProImageEditorConfigs(),
     this.scaleFactor = 1.0,
+    this.imageSize = Size.zero,
     required this.theme,
   });
   @override
@@ -45,6 +46,9 @@ class TextEditor extends StatefulWidget with SimpleConfigsAccess {
 
   /// The text layer data to be edited, if any.
   final TextLayer? layer;
+
+  /// The size of the image being edited, used for boundary text wrapping.
+  final Size imageSize;
 
   /// A factor by which the textfield is scaled.
   ///
@@ -86,9 +90,15 @@ class TextEditorState extends State<TextEditor>
   late double _fontScale;
   final double _cursorWidth = 2.0;
 
-  double? get _maxTextWidth => textEditorConfigs.enableAutoOverflow
-      ? editorBodySize.width - 32 - _cursorWidth
-      : null;
+  double? get _maxTextWidth {
+    if (textEditorConfigs.enableImageBoundaryTextWrap &&
+        widget.imageSize != Size.zero) {
+      return widget.imageSize.width - 32 - _cursorWidth;
+    }
+    return textEditorConfigs.enableAutoOverflow
+        ? editorBodySize.width - 32 - _cursorWidth
+        : null;
+  }
 
   /// Gets the primary color.
   Color get primaryColor => _primaryColor;
@@ -313,8 +323,10 @@ class TextEditorState extends State<TextEditor>
         colorMode: backgroundColorMode,
         textStyle: selectedTextStyle,
         customSecondaryColor: _secondaryColor != null,
-        maxTextWidth:
-            textEditorConfigs.enableAutoOverflow ? _maxTextWidth : null,
+        maxTextWidth: (textEditorConfigs.enableAutoOverflow ||
+                textEditorConfigs.enableImageBoundaryTextWrap)
+            ? _maxTextWidth
+            : null,
       );
 
       Navigator.of(context).pop(layer);
@@ -466,6 +478,7 @@ class TextEditorState extends State<TextEditor>
       ..add(StringProperty('heroTag', widget.heroTag))
       ..add(DoubleProperty('scaleFactor', widget.scaleFactor))
       ..add(DiagnosticsProperty<TextLayer?>('layer', widget.layer))
+      ..add(DiagnosticsProperty<Size>('imageSize', widget.imageSize))
       ..add(DiagnosticsProperty<ThemeData>('theme', widget.theme))
       ..add(DiagnosticsProperty<TextAlign>('align', align))
       ..add(DiagnosticsProperty<TextStyle>(


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [x] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [x] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [ ] Bugfix
- [x] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
Currently exists `enableAutoOverflow` to wrap automatically when texts reaches editor constraints but no way to wrap when text reaches the image width boundaries. This PR adds that config.

Issue Number: N/A

## New Behavior
This implementation adds support for `enableImageBoundaryTextWrap` configuration in the TextEditor, allowing text to wrap at the actual image boundaries instead of the screen/editor boundaries.

[untitled.webm](https://github.com/user-attachments/assets/941e726e-e624-4dd6-9a72-91965444ffc4)


## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Additional Information
This PR closes #664 
