### PR TITLE
fix(main-editor): apple pencil tap detection for text layer editing

### DIFF
--- a/lib/shared/widgets/layer/layer_widget.dart
+++ b/lib/shared/widgets/layer/layer_widget.dart
@@ -236,17 +236,26 @@ class _LayerWidgetState extends State<LayerWidget>
       if (timeElapsed > tapTimeElapsed) return;
 
       // Fire onTap only if selection/edit is enabled and pointer is inside hit box
-      if ((interaction.enableSelection || interaction.enableEdit) &&
-          !_isOutsideHitBox()) {
+      final bool canSelect = interaction.enableSelection;
+      final bool canEdit = interaction.enableEdit;
+      final bool insideHitBox = !_isOutsideHitBox();
+      final bool isStylus = event.kind == PointerDeviceKind.stylus;
+
+      // For stylus input, bypass hit box check since it has precision issues
+      // If tap passed distance/time validation, it's a valid tap
+      if ((canSelect || canEdit) && (insideHitBox || isStylus)) {
         _layersService?.handleLayerTap(_layer, _lastDownEvent!);
       }
     });
   }
 
   bool _isOutsideHitBox() {
-    return ((_isHitOutsideInCanvas() || _isHitOutsideInText()) &&
-            _layerType != LayerWidgetType.censor) &&
-        !_isSelected;
+    final bool hitOutsideCanvas = _isHitOutsideInCanvas();
+    final bool hitOutsideText = _isHitOutsideInText();
+    final bool isCensor = _layerType == LayerWidgetType.censor;
+    final bool isSelected = _isSelected;
+
+    return ((hitOutsideCanvas || hitOutsideText) && !isCensor) && !isSelected;
   }
 
   /// Checks if the hit is outside the canvas for certain types of layers.


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [ ] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [x] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
Apple Pencil taps on existing text layers fail to open the text editor, while finger taps work correctly. This prevents users from editing text when using an Apple Pencil, significantly impacting the user experience on iPad devices.

- Apple Pencil taps are ignored - text editor does not open
- Finger taps work correctly and open the text editor
- Dragging with Apple Pencil works for moving layers

## Expected Behavior
Apple Pencil tap on existing text layer should open the text editor for editing
Should behave identically to finger taps

Issue Number: N/A

## Root cause
The issue occurs in the layer widget's hit box detection logic ([layer_widget.dart](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)). Apple Pencil input has slightly different precision characteristics that cause the TextLayer.hit property to be set to false, making the system think the tap is "outside" the text area even when it's a valid tap.

## New Behavior
Bypass hit box validation for stylus input when the tap has already passed distance/time validation, since stylus taps that meet the tap criteria should be considered valid regardless of minor precision differences in hit detection.

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Additional Information
