### PR TITLE
fix(main-editor): prevent dual editor opening with Apple pencil tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## XX.XX.X
+- **FIX**(main-editor): Prevent dual editor opening (paint and text) when a text layer that is inside a paint layer is tapped with Apple pencil.
+
 ## 11.14.0
 - **FEAT**(crop-editor): Add `cropOverlayOpacity` and `cropOverlayInteractionOpacity` to control the opacity outside the crop area when editing an image.
 

--- a/lib/shared/widgets/layer/layer_widget.dart
+++ b/lib/shared/widgets/layer/layer_widget.dart
@@ -240,10 +240,19 @@ class _LayerWidgetState extends State<LayerWidget>
       final bool canEdit = interaction.enableEdit;
       final bool insideHitBox = !_isOutsideHitBox();
       final bool isStylus = event.kind == PointerDeviceKind.stylus;
+      final bool isTextLayer = _layerType == LayerWidgetType.text;
 
-      // For stylus input, bypass hit box check since it has precision issues
-      // If tap passed distance/time validation, it's a valid tap
-      if ((canSelect || canEdit) && (insideHitBox || isStylus)) {
+      if (!(canSelect || canEdit)) {
+        return;
+      }
+
+      // For stylus on TEXT layers only, bypass hit box check since it has
+      // precision issues with stylus input
+      // For paint layers: always use hit box validation (no bypass)
+      // to ensure taps on empty space inside shapes don't trigger edit.
+      final bool stylusTextBypass = isStylus && isTextLayer;
+
+      if (insideHitBox || stylusTextBypass) {
         _layersService?.handleLayerTap(_layer, _lastDownEvent!);
       }
     });


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [x] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [x] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
When tapping with Apple pencil on a text layer that is positioned inside a paint/drawing layer, both editor would open simultaneously - the text editor and the paint editor modal.

Issue Number: N/A

## New Behavior
Removed the stylus bypass that was applying to all layer types. Now the bypass only applies to text layers, while paint layers use standard hit detection. This prevents paint layers from incorrectly capturing stylus taps that should only affect the text layer above them.


## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Additional Information

TODO: Paint/drawing layers don't support stylus tap selection - only drag. Implementing this would require a more sophisticated exclusivity mechanism to prevent multiple overlapping layers from responding to the same tap.
