### PR TITLE
fix(main-editor): fix problem where `onLayerTapUp` is never called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## X.X.X
+- **FIX**(main-editor): fix problem where `onLayerTapUp` is never called
+
 ## 11.14.1
 - **FIX**(main-editor): Prevent dual editor opening (paint and text) when a text layer that is inside a paint layer is tapped with Apple pencil.
 

--- a/lib/features/main_editor/services/main_editor_layers_service.dart
+++ b/lib/features/main_editor/services/main_editor_layers_service.dart
@@ -170,7 +170,7 @@ class MainEditorLayersService {
       layerInteraction.clearSelectedLayers();
       _deselectGroup(layer);
     }
-    if (_isScaleInteractionActive || state.isLayerBeingTransformed) return;
+    if (_isScaleInteractionActive) return;
     if (layerInteraction.hoverRemoveBtn) {
       state.removeLayer(layer);
     }


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [x] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [x] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [x] Bugfix
- [ ] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
<!-- 
Please describe the behavior that is being modified, or link to a relevant issue. 
If the issue is already covered in the title, feel free to leave this section empty. 
-->
When the user finish action with a layer (drag or scale, etc), `onLayerTapUp` callback should be called, but currently isn't because  [handleTapUp](https://github.com/panuavakul/pro_image_editor/blob/stable/lib/features/main_editor/services/main_editor_layers_service.dart#L173) checks for `isLayerBeingTransformed`. Please refer to `Additional Information` for my reasoning.

Issue Number: N/A

## New Behavior
<!-- If the title already explains the change, you can leave this section empty. -->

Remove `isLayerBeingTransformed` check, which seems to be unnecessary?

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information

I did a bit of looking and found that [handleTapUp](https://github.com/panuavakul/pro_image_editor/blob/stable/lib/features/main_editor/services/main_editor_layers_service.dart#L173) has the `isLayerBeingTransformed` check. As of right now the only place where `isLayerBeingTransformed` becomes `false` is at [_onScaleEnd](https://github.com/panuavakul/pro_image_editor/blob/fix/onLayerTapUp-never-called/lib/features/main_editor/main_editor.dart#L1323). One problem is that `_onScaleEnd` is always called after `handleTapUp`, which means that currently there's no case that `isLayerBeingTransformed` would be `true` by the time the check takes place, which leads to `onLayerTapUp` never being called.

What lead me to think that this check is unnecessary is that the check also check for `_isScaleInteractionActive` and that `isLayerBeingTransformed` is only trigger on/off in the scale operation.

However, I'm not very confident that this is the fix so if this doesn't make sense, please feel free to close this PR