### PR TITLE
feat(text-editor): auto-wrap on layer setting for granular behavior

### DIFF
--- a/lib/core/models/editor_configs/text_editor_configs.dart
+++ b/lib/core/models/editor_configs/text_editor_configs.dart
@@ -56,7 +56,7 @@ class TextEditorConfigs
       this.enableMainEditorZoomFactor = false,
       this.enableTapOutsideToSave = true,
       this.enableAutoOverflow = true,
-      this.enableAutoWrapOnLayer = false,
+      this.enableAutoWrapOnLayer = true,
       this.initFontSize = 24.0,
       this.initialPrimaryColor = const Color(0xFF000000),
       this.initialSecondaryColor,

--- a/lib/core/models/editor_configs/text_editor_configs.dart
+++ b/lib/core/models/editor_configs/text_editor_configs.dart
@@ -56,6 +56,7 @@ class TextEditorConfigs
       this.enableMainEditorZoomFactor = false,
       this.enableTapOutsideToSave = true,
       this.enableAutoOverflow = true,
+      this.enableAutoWrapOnLayer = false,
       this.initFontSize = 24.0,
       this.initialPrimaryColor = const Color(0xFF000000),
       this.initialSecondaryColor,
@@ -168,6 +169,17 @@ class TextEditorConfigs
   /// (e.g., the screen width).
   final bool enableAutoOverflow;
 
+  /// Whether the text should automatically wrap when it reaches the end of
+  /// the screen on the final image.
+  ///
+  /// If set to `true`, the text will wrap to the next line instead of
+  /// overflowing, ensuring it stays within the visible area
+  /// (e.g., the screen width).
+  ///
+  /// If set to `false`, the text will only wrap if the user deliberately
+  /// entered a new line while editing.
+  final bool enableAutoWrapOnLayer;
+
   /// The minimum scale factor from the layer.
   final double minScale;
 
@@ -219,6 +231,7 @@ class TextEditorConfigs
     bool? enableMainEditorZoomFactor,
     bool? enableTapOutsideToSave,
     bool? enableAutoOverflow,
+    bool? enableAutoWrapOnLayer,
     Color? initialPrimaryColor,
     Color? initialSecondaryColor,
     double? initFontSize,
@@ -254,6 +267,8 @@ class TextEditorConfigs
       enableTapOutsideToSave:
           enableTapOutsideToSave ?? this.enableTapOutsideToSave,
       enableAutoOverflow: enableAutoOverflow ?? this.enableAutoOverflow,
+      enableAutoWrapOnLayer:
+          enableAutoWrapOnLayer ?? this.enableAutoWrapOnLayer,
       initialPrimaryColor: initialPrimaryColor ?? this.initialPrimaryColor,
       initialSecondaryColor:
           initialSecondaryColor ?? this.initialSecondaryColor,

--- a/lib/features/text_editor/text_editor.dart
+++ b/lib/features/text_editor/text_editor.dart
@@ -323,7 +323,7 @@ class TextEditorState extends State<TextEditor>
         colorMode: backgroundColorMode,
         textStyle: selectedTextStyle,
         customSecondaryColor: _secondaryColor != null,
-        maxTextWidth: (textEditorConfigs.enableAutoOverflow ||
+        maxTextWidth: (textEditorConfigs.enableAutoWrapOnLayer ||
                 textEditorConfigs.enableImageBoundaryTextWrap)
             ? _maxTextWidth
             : null,


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [X] I have run `dart format .` in the terminal and committed any changes.
- [X] I have run `dart analyze .` in the terminal and addressed any issues.
- [X] I have run `flutter test` in the terminal and addressed any issues.
- [X] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [ ] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [ ] Bugfix
- X] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
Text Auto wrapping is coupled between editor and output. This new setting allows to let the wrap not apply to the output TextLayer.

Issue Number: https://github.com/hm21/pro_image_editor/issues/719

## New Behavior
Setting `enableAutoWrapOnLayer` allows for deciding whether the layer applies the editor's auto wrapping or not, defaults to ~~false~~ true.

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
