### PR TITLE
Feat/network image headers

### DIFF
--- a/lib/core/models/editor_image.dart
+++ b/lib/core/models/editor_image.dart
@@ -88,6 +88,7 @@ class EditorImage {
   EditorImage({
     this.byteArray,
     this.networkUrl,
+    this.networkHeaders,
     this.assetPath,
     dynamic file,
   })  : file = file == null ? null : ensureFileInstance(file),
@@ -108,6 +109,9 @@ class EditorImage {
 
   /// A URL string pointing to an image on the internet.
   final String? networkUrl;
+
+  /// Optional HTTP headers to use when fetching the network image.
+  final Map<String, String>? networkHeaders;
 
   /// A string representing the asset path of an image.
   final String? assetPath;
@@ -143,7 +147,7 @@ class EditorImage {
       case EditorImageType.file:
         return FileImage(file! as dynamic);
       case EditorImageType.network:
-        return NetworkImage(networkUrl!);
+        return NetworkImage(networkUrl!, headers: networkHeaders);
     }
   }
 
@@ -161,7 +165,10 @@ class EditorImage {
         bytes = await readFileAsUint8List(file!);
         break;
       case EditorImageType.network:
-        bytes = await fetchImageAsUint8List(networkUrl!);
+        bytes = await fetchImageAsUint8List(
+          networkUrl!,
+          headers: networkHeaders,
+        );
         break;
     }
 
@@ -203,6 +210,7 @@ class EditorImage {
         _areUint8ListsEqual(byteArray, other.byteArray) &&
         file?.path == other.file?.path &&
         networkUrl == other.networkUrl &&
+        _areHeadersEqual(networkHeaders, other.networkHeaders) &&
         assetPath == other.assetPath;
   }
 
@@ -212,6 +220,7 @@ class EditorImage {
       _hashUint8List(byteArray),
       file?.path,
       networkUrl,
+      networkHeaders,
       assetPath,
     );
   }
@@ -221,6 +230,16 @@ class EditorImage {
     if (a.length != b.length) return false;
     for (int i = 0; i < a.length; i++) {
       if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+
+  bool _areHeadersEqual(
+      Map<String, String>? a, Map<String, String>? b) {
+    if (a == null || b == null) return a == b;
+    if (a.length != b.length) return false;
+    for (final key in a.keys) {
+      if (a[key] != b[key]) return false;
     }
     return true;
   }
@@ -247,6 +266,7 @@ class EditorImage {
     Uint8List? byteArray,
     File? file,
     String? networkUrl,
+    Map<String, String>? networkHeaders,
     String? assetPath,
   }) {
     final bytes = byteArray ?? this.byteArray;
@@ -255,6 +275,7 @@ class EditorImage {
       byteArray: bytes != null ? Uint8List.fromList(bytes) : null,
       file: fileHelper != null ? File(fileHelper.path) : null,
       networkUrl: networkUrl ?? this.networkUrl,
+      networkHeaders: networkHeaders ?? this.networkHeaders,
       assetPath: assetPath ?? this.assetPath,
     );
   }

--- a/lib/core/models/editor_image.dart
+++ b/lib/core/models/editor_image.dart
@@ -1,7 +1,5 @@
-// Dart imports:
-import 'dart:typed_data';
-
 // Flutter imports:
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '/core/platform/io/io_helper.dart';
@@ -210,7 +208,7 @@ class EditorImage {
         _areUint8ListsEqual(byteArray, other.byteArray) &&
         file?.path == other.file?.path &&
         networkUrl == other.networkUrl &&
-        _areHeadersEqual(networkHeaders, other.networkHeaders) &&
+        mapEquals(networkHeaders, other.networkHeaders) &&
         assetPath == other.assetPath;
   }
 
@@ -230,16 +228,6 @@ class EditorImage {
     if (a.length != b.length) return false;
     for (int i = 0; i < a.length; i++) {
       if (a[i] != b[i]) return false;
-    }
-    return true;
-  }
-
-  bool _areHeadersEqual(
-      Map<String, String>? a, Map<String, String>? b) {
-    if (a == null || b == null) return a == b;
-    if (a.length != b.length) return false;
-    for (final key in a.keys) {
-      if (a[key] != b[key]) return false;
     }
     return true;
   }

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -221,12 +221,16 @@ class ProImageEditor extends StatefulWidget
   factory ProImageEditor.network(
     String networkUrl, {
     Key? key,
+    Map<String, String>? networkHeaders,
     ProImageEditorConfigs configs = const ProImageEditorConfigs(),
     required ProImageEditorCallbacks callbacks,
   }) {
     return ProImageEditor._(
       key: key,
-      editorImage: EditorImage(networkUrl: networkUrl),
+      editorImage: EditorImage(
+        networkUrl: networkUrl,
+        networkHeaders: networkHeaders,
+      ),
       configs: configs,
       callbacks: callbacks,
     );
@@ -289,6 +293,7 @@ class ProImageEditor extends StatefulWidget
     dynamic file,
     String? assetPath,
     String? networkUrl,
+    Map<String, String>? networkHeaders,
     EditorImage? editorImage,
     ProVideoController? videoController,
     ProImageEditorConfigs configs = const ProImageEditorConfigs(),
@@ -301,6 +306,7 @@ class ProImageEditor extends StatefulWidget
             byteArray: byteArray,
             file: file,
             networkUrl: networkUrl,
+            networkHeaders: networkHeaders,
             assetPath: assetPath,
           ),
       videoController: videoController,

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -210,6 +210,8 @@ class ProImageEditor extends StatefulWidget
   /// {@macro mainEditorConfigs}
   /// - `networkUrl` *(required)*: The URL from which the image should be
   /// loaded.
+  /// - `networkHeaders` *(optional)*: HTTP headers to include when fetching
+  /// the image (e.g., for authentication).
   ///
   /// Example usage:
   /// ```dart

--- a/lib/shared/utils/converters.dart
+++ b/lib/shared/utils/converters.dart
@@ -48,8 +48,11 @@ Future<Uint8List> loadAssetImageAsUint8List(String assetPath) async {
 /// ```dart
 /// final Uint8List imageBytes = await fetchImageAsUint8List('https://example.com/image.jpg');
 /// ```
-Future<Uint8List> fetchImageAsUint8List(String imageUrl) async {
-  final response = await http.get(Uri.parse(imageUrl));
+Future<Uint8List> fetchImageAsUint8List(
+  String imageUrl, {
+  Map<String, String>? headers,
+}) async {
+  final response = await http.get(Uri.parse(imageUrl), headers: headers);
 
   if (response.statusCode == 200) {
     // Convert the response body to a Uint8List


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:
- [x] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [x] I have run `dart format .` in the terminal and committed any changes.
- [x] I have run `dart analyze .` in the terminal and addressed any issues.
- [x] I have run `flutter test` in the terminal and addressed any issues.
- [x] I have pulled from the stable branch before committing.
- [x] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [x] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [x] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:
- [ ] Bugfix
- [x] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [x] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior

Currently, when loading images from network URLs using `ProImageEditor.network()` or `EditorImage(networkUrl: ...)`, there is no way to pass custom HTTP headers. This limitation prevents users from:
- Adding authorization tokens for authenticated image requests
- Passing API keys required by image hosting services
- Including custom headers needed for specific server configurations

Issue Number: N/A

## New Behavior

Users can now provide optional HTTP headers when loading images from network sources:

```dart
// Using ProImageEditor.network constructor
ProImageEditor.network(
  'https://example.com/image.jpg',
  networkHeaders: {
    'Authorization': 'Bearer token123',
    'Custom-Header': 'value',
  },
  callbacks: ProImageEditorCallbacks(...),
);

// Using EditorImage directly
EditorImage(
  networkUrl: 'https://example.com/image.jpg',
  networkHeaders: {
    'Authorization': 'Bearer token123',
  },
);
```

The headers are properly passed through all image loading operations including:
- Initial image display via `NetworkImage`
- Byte conversion via `http.get` requests
- Image equality checks and hash calculations

## Breaking Changes?
Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

This is a backwards-compatible addition. The `networkHeaders` parameter is optional, and existing code will continue to work without any modifications.

## Additional Information

**Implementation details:**
- Added `networkHeaders` field to `EditorImage` class
- Updated `safeImageProvider` to pass headers to `NetworkImage`
- Updated `safeLoadImageBytes` to pass headers to `fetchImageAsUint8List`
- Added header equality check in `operator ==` for proper comparison
- Included headers in `hashCode` calculation
- Updated `copyWith` method to support header copying
- Added documentation to `ProImageEditor.network` factory constructor
- Updated `fetchImageAsUint8List` utility function to accept optional headers

**Testing:**
This change has been manually tested with authenticated image URLs and works as expected. The existing test suite continues to pass.