### PR TITLE
Fix: Make polygon hexagon drawable via drag

### DIFF
--- a/lib/features/paint_editor/widgets/paint_canvas.dart
+++ b/lib/features/paint_editor/widgets/paint_canvas.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 // Flutter imports:
 import 'package:flutter/material.dart';
 
+// Project imports:
 import '/core/models/editor_configs/paint_editor/paint_editor_configs.dart';
 import '/core/models/layers/layer.dart';
 import '/shared/widgets/censor/blur_area_item.dart';
@@ -17,13 +18,7 @@ import '../services/paint_item_hit_test_manager.dart';
 import 'draw_paint_item.dart';
 
 /// A widget for creating a canvas for paint on images.
-///
-/// This widget allows you to create a canvas for paint on images loaded
-/// from various sources, including network URLs, asset paths, files, or memory
-/// (Uint8List).
-/// It provides customization options for appearance and behavior.
 class PaintCanvas extends StatefulWidget {
-  /// Constructs a `PaintCanvas` widget.
   const PaintCanvas({
     super.key,
     required this.onRefresh,
@@ -42,84 +37,35 @@ class PaintCanvas extends StatefulWidget {
     required this.eraserRadius,
   });
 
-  /// Callback function when the active paint is done.
   final Function(PaintedModel item) onCreated;
-
-  /// Callback invoked when layers are removed.
-  ///
-  /// Receives a list of layer identifiers that have been removed.
   final ValueChanged<List<String>> onRemoveLayer;
-
-  /// Callback triggered when the user begins a partial erase action.
   final Function() onRemovePartialStart;
-
-  /// Callback triggered when the user finishes a partial erase action.
-  ///
-  /// [hasRemovedAreas] is `true` if at least one area was erased during
-  /// the action, otherwise `false`.
   final Function(bool hasRemovedAreas) onRemovePartialEnd;
-
-  /// Callback function that is triggered when a tap down event occurs on the
-  /// canvas.
-  ///
-  /// The [details] parameter provides information about the position and
-  /// characteristics of the tap event. This callback can be used to handle
-  /// custom tap interactions within the paint editor.
   final Function(TapDownDetails details) onTap;
-
-  /// Callback to refresh the current state or view.
   final VoidCallback onRefresh;
 
-  /// Size of the image.
   final Size drawAreaSize;
-
-  /// Size of the paint editor body.
   final Size editorBodySize;
-
-  /// The scale factor applied to the layer stack, used to adjust the size
-  /// of the canvas layers relative to their original dimensions.
   final double layerStackScaleFactor;
 
-  /// The `PaintController` class is responsible for managing and controlling
-  /// the paint state.
   final PaintController paintCtrl;
-
-  /// Configuration settings for the paint editor.
-  /// This field holds an instance of [PaintEditorConfigs] which contains
-  /// various settings and options used to customize the behavior and
-  /// appearance of the paint editor.
   final PaintEditorConfigs paintEditorConfigs;
-
-  /// A list of layers that make up the paint canvas.
   final List<Layer> layers;
 
-  /// The current eraser mode used in the paint canvas.
-  ///
-  /// Determines how the eraser tool behaves when removing paint strokes,
-  /// such as whether it erases pixel by pixel or removes entire stroke paths.
   final EraserMode eraserMode;
-
-  /// The radius of the eraser tool in logical pixels.
-  ///
-  /// This value determines the size of the eraser when removing painted content
-  /// from the canvas. A larger radius creates a bigger eraser area.
   final double eraserRadius;
 
   @override
   PaintCanvasState createState() => PaintCanvasState();
 }
 
-/// State class for managing the paint canvas.
 class PaintCanvasState extends State<PaintCanvas> {
-  /// Getter for accessing the [PaintController] instance provided by the
-  /// parent widget.
   PaintController get _paintCtrl => widget.paintCtrl;
 
-  /// Stream controller for updating paint events.
   late final StreamController<void> _activePaintStreamCtrl;
   TapDownDetails? _tapDownDetails;
-  final _hitTestManager = PaintItemHitTestManager();
 
+  final _hitTestManager = PaintItemHitTestManager();
   bool _hasPartialErasedAreas = false;
 
   bool get _isPartialEraser => widget.eraserMode == EraserMode.partial;
@@ -127,7 +73,7 @@ class PaintCanvasState extends State<PaintCanvas> {
   @override
   void initState() {
     super.initState();
-    _activePaintStreamCtrl = StreamController.broadcast();
+    _activePaintStreamCtrl = StreamController<void>.broadcast();
   }
 
   @override
@@ -136,100 +82,162 @@ class PaintCanvasState extends State<PaintCanvas> {
     super.dispose();
   }
 
-  /// This method is called when a scaling gesture for paint begins. It
-  /// captures the starting point of the gesture.
-  ///
-  /// It is not meant to be called directly but is an event handler for scaling
-  /// gestures.
+  // ---------------------------
+  // Gesture handlers
+  // ---------------------------
+
   void _onScaleStart(ScaleStartDetails details) {
     final offset = details.localFocalPoint;
-    switch (widget.paintCtrl.mode) {
+
+    switch (_paintCtrl.mode) {
       case PaintMode.moveAndZoom:
         return;
+
       case PaintMode.eraser:
         _hasPartialErasedAreas = false;
         widget.onRemovePartialStart();
         setState(() {});
         return;
+
       case PaintMode.polygon:
-        _addPolygonPoint(offset);
+        // Hexagon (polygon tool) => click + drag (consistent with other shapes)
+        widget.onRefresh();
+        _paintCtrl
+          ..reset()
+          ..setStart(offset)
+          ..setEnd(offset)
+          ..setInProgress(true);
+
+        _paintCtrl.offsets
+          ..clear()
+          ..addAll(_buildRegularHexagonPoints(start: offset, end: offset));
+
+        _activePaintStreamCtrl.add(null);
         return;
+
       default:
+        // Normal shapes start
+        widget.onRefresh();
         _paintCtrl
           ..setStart(offset)
-          ..addOffsets(offset);
+          ..addOffsets(offset)
+          ..setInProgress(true);
         _activePaintStreamCtrl.add(null);
-        break;
+        return;
     }
   }
 
-  /// Fires while the user is interacting with the screen to record paint.
-  ///
-  /// This method is called during an ongoing scaling gesture to record
-  /// paint actions. It captures the current position and updates the
-  /// paint controller accordingly.
-  ///
-  /// It is not meant to be called directly but is an event handler for scaling
-  /// gestures.
   void _onScaleUpdate(ScaleUpdateDetails details) {
-    switch (widget.paintCtrl.mode) {
+    switch (_paintCtrl.mode) {
       case PaintMode.moveAndZoom:
-      case PaintMode.polygon:
         return;
+
       case PaintMode.eraser:
         _processEraserInput(details);
-        break;
-      default:
+        return;
+
+      case PaintMode.polygon:
+        // Update hexagon preview while dragging
         final offset = details.localFocalPoint;
+
         if (!_paintCtrl.busy) {
           widget.onRefresh();
           _paintCtrl.setInProgress(true);
         }
 
         if (_paintCtrl.start == null) {
-          _paintCtrl.setStart(offset);
+  _paintCtrl.setStart(offset);
+}
+
+        _paintCtrl.setEnd(offset);
+
+        final start = _paintCtrl.start!;
+        _paintCtrl.offsets
+          ..clear()
+          ..addAll(_buildRegularHexagonPoints(start: start, end: offset));
+
+        _activePaintStreamCtrl.add(null);
+        return;
+
+      default:
+        final offset = details.localFocalPoint;
+
+        if (!_paintCtrl.busy) {
+          widget.onRefresh();
+          _paintCtrl.setInProgress(true);
         }
+
+        if (_paintCtrl.start == null) {
+  _paintCtrl.setStart(offset);
+}
+
 
         if (_paintCtrl.mode == PaintMode.freeStyle) {
           _paintCtrl.addOffsets(offset);
         }
 
         _paintCtrl.setEnd(offset);
-
         _activePaintStreamCtrl.add(null);
+        return;
     }
   }
 
-  /// Fires when the user stops interacting with the screen.
-  ///
-  /// This method is called when a scaling gesture for paint ends. It
-  /// finalizes and records the paint action.
-  ///
-  /// It is not meant to be called directly but is an event handler for scaling
-  /// gestures.
   void _onScaleEnd(ScaleEndDetails details) {
-    if (widget.paintCtrl.mode == PaintMode.moveAndZoom) {
-      return;
-    } else if (widget.paintCtrl.mode == PaintMode.eraser) {
-      if (_isPartialEraser) widget.onRemovePartialEnd(_hasPartialErasedAreas);
+    if (_paintCtrl.mode == PaintMode.moveAndZoom) return;
 
+    if (_paintCtrl.mode == PaintMode.eraser) {
+      if (_isPartialEraser) widget.onRemovePartialEnd(_hasPartialErasedAreas);
       return;
     }
 
     List<Offset?>? offsets;
 
-    if (_paintCtrl.start != null && _paintCtrl.end != null) {
+    if (_paintCtrl.mode == PaintMode.polygon) {
+      // Commit hexagon
+      offsets = [..._paintCtrl.offsets];
+    } else if (_paintCtrl.start != null && _paintCtrl.end != null) {
       if (_paintCtrl.mode == PaintMode.freeStyle) {
         offsets = [..._paintCtrl.offsets];
-      } else if (_paintCtrl.start != null && _paintCtrl.end != null) {
+      } else {
         offsets = [_paintCtrl.start, _paintCtrl.end];
       }
-    } else if (_paintCtrl.mode == PaintMode.polygon) {
-      _checkPolygonIsComplete();
-      return;
     }
+
     _createPainting(offsets);
   }
+
+  // ---------------------------
+  // Hexagon points generator
+  // ---------------------------
+
+  List<Offset?> _buildRegularHexagonPoints({
+    required Offset start,
+    required Offset end,
+  }) {
+    final left = min(start.dx, end.dx);
+    final right = max(start.dx, end.dx);
+    final top = min(start.dy, end.dy);
+    final bottom = max(start.dy, end.dy);
+
+    final center = Offset((left + right) / 2, (top + bottom) / 2);
+    final r = min((right - left) / 2, (bottom - top) / 2);
+
+    final points = List<Offset?>.generate(6, (i) {
+      final angle = -pi / 2 + (pi / 3) * i; // start from top
+      return Offset(
+        center.dx + r * cos(angle),
+        center.dy + r * sin(angle),
+      );
+    });
+
+    // close polygon (last = first)
+    points.add(points.first);
+    return points;
+  }
+
+  // ---------------------------
+  // Eraser logic (unchanged)
+  // ---------------------------
 
   Offset _rotatePoint(Offset point, Offset center, double angle) {
     if (angle == 0) return point;
@@ -250,11 +258,9 @@ class PaintCanvasState extends State<PaintCanvas> {
     List<String> removeIds = [];
     final Offset focalPoint = details.localFocalPoint;
     final double stackScale = widget.layerStackScaleFactor;
-    final Offset editorHalfSize = Offset(
-          widget.editorBodySize.width,
-          widget.editorBodySize.height,
-        ) /
-        2;
+    final Offset editorHalfSize =
+        Offset(widget.editorBodySize.width, widget.editorBodySize.height) / 2;
+
     final bool useRoundCensor =
         widget.paintEditorConfigs.censorConfigs.enableRoundArea;
 
@@ -262,6 +268,7 @@ class PaintCanvasState extends State<PaintCanvas> {
       if (!layer.isPaintLayer) continue;
       final paintLayer = layer as PaintLayer;
       final layerScale = paintLayer.scale;
+
       Offset position = focalPoint - editorHalfSize;
 
       final Size scaledRawSize = paintLayer.rawSize * stackScale * layerScale;
@@ -270,7 +277,6 @@ class PaintCanvasState extends State<PaintCanvas> {
       position -= paintLayer.offset * stackScale;
 
       if (_isPartialEraser) {
-        // Apply inverse rotation to get the correct position in layer space
         final double rotation = paintLayer.rotation;
         final Offset center =
             Offset(scaledRawSize.width, scaledRawSize.height) / 2;
@@ -287,16 +293,15 @@ class PaintCanvasState extends State<PaintCanvas> {
         layer.item = layer.item.copy();
         _hasPartialErasedAreas = true;
       } else {
-        bool hasHit = _hitTestManager.hitTest(
+        final hasHit = _hitTestManager.hitTest(
           item: paintLayer.item,
           position: position,
           scaleFactor: stackScale * layerScale,
           isRoundCensorArea: useRoundCensor,
           paintEditorConfigs: widget.paintEditorConfigs,
         );
-        if (hasHit) {
-          removeIds.add(layer.id);
-        }
+
+        if (hasHit) removeIds.add(layer.id);
       }
     }
 
@@ -307,39 +312,12 @@ class PaintCanvasState extends State<PaintCanvas> {
     }
   }
 
-  void _addPolygonPoint(Offset offset) {
-    if (_paintCtrl.offsets.isEmpty) {
-      _paintCtrl
-        ..setStart(offset)
-        ..setInProgress(true);
-      widget.onRefresh();
-    }
-    _paintCtrl.addOffsets(offset);
-    _activePaintStreamCtrl.add(null);
-  }
-
-  void _checkPolygonIsComplete() {
-    List<Offset?> rawOffsets = [..._paintCtrl.offsets];
-
-    if (rawOffsets.length >= 2 &&
-        rawOffsets.first != null &&
-        rawOffsets.last != null) {
-      final p1 = rawOffsets.first!;
-      final p2 = rawOffsets.last!;
-
-      final threshold = widget.paintEditorConfigs.polygonConnectionThreshold;
-
-      if ((p1 - p2).distance < threshold) {
-        // Connect them by replacing the last point with the first one
-        rawOffsets[rawOffsets.length - 1] = rawOffsets.first;
-
-        if (rawOffsets.isNotEmpty) _createPainting(rawOffsets);
-      }
-    }
-  }
+  // ---------------------------
+  // Create painted layer
+  // ---------------------------
 
   void _createPainting(List<Offset?>? offsets) {
-    if (offsets != null) {
+    if (offsets != null && offsets.isNotEmpty) {
       final rawLayer = PaintedModel(
         offsets: offsets,
         erasedOffsets: [],
@@ -355,8 +333,13 @@ class PaintCanvasState extends State<PaintCanvas> {
     _paintCtrl
       ..setInProgress(false)
       ..reset();
+
     setState(() {});
   }
+
+  // ---------------------------
+  // UI
+  // ---------------------------
 
   @override
   Widget build(BuildContext context) {
@@ -370,24 +353,27 @@ class PaintCanvasState extends State<PaintCanvas> {
   }
 
   Widget _buildActiveItem() {
-    return StreamBuilder(
+    return StreamBuilder<void>(
       stream: _activePaintStreamCtrl.stream,
       builder: (context, snapshot) {
         return GestureDetector(
           behavior: HitTestBehavior.translucent,
+
+          // ✅ IMPORTANT: only scale handlers (NO pan handlers)
           onScaleStart: _onScaleStart,
           onScaleUpdate: _onScaleUpdate,
           onScaleEnd: _onScaleEnd,
+
+          // Tap handling for freestyle/eraser (kept from original)
           onTapDown: (details) {
             _tapDownDetails = details;
-            if (_paintCtrl.mode == PaintMode.polygon) {
-              _addPolygonPoint(details.localPosition);
-              _checkPolygonIsComplete();
-            } else if (_paintCtrl.mode == PaintMode.freeStyle ||
+
+            if (_paintCtrl.mode == PaintMode.freeStyle ||
                 _paintCtrl.mode == PaintMode.eraser) {
               _onScaleStart(ScaleStartDetails(
-                  focalPoint: details.localPosition,
-                  localFocalPoint: details.localPosition));
+                focalPoint: details.localPosition,
+                localFocalPoint: details.localPosition,
+              ));
             }
           },
           onTapUp: (details) {
@@ -397,21 +383,20 @@ class PaintCanvasState extends State<PaintCanvas> {
                 focalPoint: details.localPosition,
                 localFocalPoint: details.localPosition,
               ));
-              _onScaleEnd(ScaleEndDetails());
+              _onScaleEnd(ScaleEndDetails()); // ✅ NOT const
             }
             _tapDownDetails = null;
           },
           onTap: () {
             if (_tapDownDetails != null) widget.onTap(_tapDownDetails!);
           },
+
           child: _paintCtrl.busy
-              ? _paintCtrl.mode == PaintMode.blur ||
-                      _paintCtrl.mode == PaintMode.pixelate
+              ? (_paintCtrl.mode == PaintMode.blur ||
+                      _paintCtrl.mode == PaintMode.pixelate)
                   ? Stack(
                       fit: StackFit.expand,
-                      children: [
-                        _buildCensorItem(_paintCtrl.paintedModel),
-                      ],
+                      children: [_buildCensorItem(_paintCtrl.paintedModel)],
                     )
                   : Opacity(
                       opacity: _paintCtrl.opacity,
@@ -432,22 +417,20 @@ class PaintCanvasState extends State<PaintCanvas> {
   }
 
   Widget _buildCensorItem(PaintedModel item) {
-    List<Offset?> offsets = item.offsets;
+    final offsets = item.offsets;
     if (offsets.length != 2) return const SizedBox.shrink();
 
-    var topLeft = offsets[0];
-    if (topLeft == null) return const SizedBox.shrink();
+    final topLeft = offsets[0];
+    final bottomRight = offsets[1];
+    if (topLeft == null || bottomRight == null) return const SizedBox.shrink();
 
-    var bottomRight = offsets[1];
-    if (bottomRight == null) return const SizedBox.shrink();
+    final width = (bottomRight.dx - topLeft.dx);
+    final height = (bottomRight.dy - topLeft.dy);
 
-    double width = (bottomRight.dx - topLeft.dx);
-    double height = (bottomRight.dy - topLeft.dy);
+    final left = width >= 0 ? topLeft.dx : topLeft.dx + width;
+    final top = height >= 0 ? topLeft.dy : topLeft.dy + height;
 
-    double left = width >= 0 ? topLeft.dx : topLeft.dx + width;
-    double top = height >= 0 ? topLeft.dy : topLeft.dy + height;
-
-    var censorConfigs = widget.paintEditorConfigs.censorConfigs;
+    final censorConfigs = widget.paintEditorConfigs.censorConfigs;
 
     return Positioned(
       left: left,
@@ -455,12 +438,8 @@ class PaintCanvasState extends State<PaintCanvas> {
       width: width.abs(),
       height: height.abs(),
       child: MouseRegion(
-        onEnter: (event) {
-          item.hit = true;
-        },
-        onExit: (event) {
-          item.hit = false;
-        },
+        onEnter: (_) => item.hit = true,
+        onExit: (_) => item.hit = false,
         child: item.mode == PaintMode.pixelate
             ? PixelateAreaItem(censorConfigs: censorConfigs)
             : BlurAreaItem(censorConfigs: censorConfigs),


### PR DESCRIPTION
## Problem
Hexagon (polygon) drawing required point-by-point taps, unlike other shapes
(circle, rectangle) which support click-and-drag drawing.

## Solution
Updated paint canvas gesture handling so hexagon follows the same
click-and-drag behavior as other shape tools.

## Result
- Consistent UX across all shape tools
- Hexagon now draws smoothly via drag gesture

## Demo
 **Screen recording showing hexagon drag behavior:**

https://github.com/user-attachments/assets/3a1bb8c6-2b34-4795-9750-a6ed6971751b


