### PR TITLE
feat(text-editor): allow background and borders

### DIFF
--- a/lib/core/models/styles/text_editor_style.dart
+++ b/lib/core/models/styles/text_editor_style.dart
@@ -63,6 +63,10 @@ class TextEditorStyle {
     this.inputHintColor = const Color(0xFFBDBDBD),
     this.inputCursorColor = kImageEditorPrimaryColor,
     this.fontScaleBottomSheetBackground = const Color(0xFF252728),
+    this.inputTextFieldBackground = Colors.transparent,
+    this.inputTextFieldBorderColor = Colors.transparent,
+    this.inputTextFieldBorderRadius = const BorderRadius.all(Radius.circular(4)),
+    this.inputTextFieldPadding = EdgeInsets.zero,
   });
 
   /// Background color of the app bar in the text editor.
@@ -95,6 +99,18 @@ class TextEditorStyle {
   /// Background color for the font scale bottom sheet.
   final Color fontScaleBottomSheetBackground;
 
+  /// Background color of the input text field.
+  final Color inputTextFieldBackground;
+
+  /// Border color of the input text field.
+  final Color inputTextFieldBorderColor;
+
+  /// Border radius of the input text field.
+  final BorderRadius inputTextFieldBorderRadius;
+
+  /// Padding of the input text field.
+  final EdgeInsets inputTextFieldPadding;
+
   /// Creates a copy of this `TextEditorStyle` object with the given fields
   /// replaced with new values.
   ///
@@ -109,6 +125,10 @@ class TextEditorStyle {
     Color? inputHintColor,
     Color? inputCursorColor,
     Color? fontScaleBottomSheetBackground,
+    Color? inputTextFieldBackground,
+    Color? inputTextFieldBorderColor,
+    BorderRadius? inputTextFieldBorderRadius,
+    EdgeInsets? inputTextFieldPadding,
     MainAxisAlignment? bottomBarMainAxisAlignment,
     EdgeInsets? textFieldMargin,
     TextStyle? fontSizeBottomSheetTitle,
@@ -122,6 +142,14 @@ class TextEditorStyle {
       background: background ?? this.background,
       inputHintColor: inputHintColor ?? this.inputHintColor,
       inputCursorColor: inputCursorColor ?? this.inputCursorColor,
+      inputTextFieldBackground:
+          inputTextFieldBackground ?? this.inputTextFieldBackground,
+      inputTextFieldBorderColor:
+          inputTextFieldBorderColor ?? this.inputTextFieldBorderColor,
+      inputTextFieldBorderRadius:
+          inputTextFieldBorderRadius ?? this.inputTextFieldBorderRadius,
+      inputTextFieldPadding:
+          inputTextFieldPadding ?? this.inputTextFieldPadding,
       bottomBarMainAxisAlignment:
           bottomBarMainAxisAlignment ?? this.bottomBarMainAxisAlignment,
       textFieldMargin: textFieldMargin ?? this.textFieldMargin,

--- a/lib/core/models/styles/text_editor_style.dart
+++ b/lib/core/models/styles/text_editor_style.dart
@@ -65,7 +65,8 @@ class TextEditorStyle {
     this.fontScaleBottomSheetBackground = const Color(0xFF252728),
     this.inputTextFieldBackground = Colors.transparent,
     this.inputTextFieldBorderColor = Colors.transparent,
-    this.inputTextFieldBorderRadius = const BorderRadius.all(Radius.circular(4)),
+    this.inputTextFieldBorderRadius =
+        const BorderRadius.all(Radius.circular(4)),
     this.inputTextFieldPadding = EdgeInsets.zero,
   });
 

--- a/lib/features/text_editor/widgets/text_editor_input.dart
+++ b/lib/features/text_editor/widgets/text_editor_input.dart
@@ -163,40 +163,51 @@ class _TextEditorInputState extends State<TextEditorInput> {
       child: Hero(
         flightShuttleBuilder: _flightShuttleBuilder,
         tag: widget.heroTag ?? 'Text-Image-Editor-Empty-Hero',
-        child: RoundedBackgroundTextField(
-          key: const ValueKey('rounded-background-text-editor-field'),
-          maxTextWidth: widget.maxWidth,
-          controller: widget.textCtrl,
-          focusNode: widget.focusNode,
-          onChanged: (value) {
-            widget.callbacks?.handleChanged(value);
-            setState(() {});
-          },
-          onEditingComplete: widget.callbacks?.handleEditingComplete,
-          onSubmitted: widget.callbacks?.handleSubmitted,
-          textAlign:
-              widget.textCtrl.text.isEmpty ? TextAlign.center : widget.align,
-          configs: widget.configs,
-          cursorHeight: widget.textFontSize,
-          cursorWidth: widget.cursorWidth,
-          hint: widget.i18n.inputHintText,
-          hintStyle: widget.selectedTextStyle.copyWith(
-            color: widget.configs.style.inputHintColor,
-            fontSize: widget.textFontSize,
-            shadows: [],
+        child: Container(
+          padding: widget.configs.style.inputTextFieldPadding,
+          decoration: BoxDecoration(
+            color: widget.configs.style.inputTextFieldBackground,
+            border: Border.all(
+              color: widget.configs.style.inputTextFieldBorderColor,
+              width: 1,
+            ),
+            borderRadius: widget.configs.style.inputTextFieldBorderRadius,
           ),
-          backgroundColor: widget.backgroundColor,
-          style: widget.selectedTextStyle.copyWith(
-            color: widget.textColor,
-            fontSize: widget.textFontSize,
-            letterSpacing: 0,
-            decoration: TextDecoration.none,
-            shadows: [],
-          ),
+          child: RoundedBackgroundTextField(
+            key: const ValueKey('rounded-background-text-editor-field'),
+            maxTextWidth: widget.maxWidth,
+            controller: widget.textCtrl,
+            focusNode: widget.focusNode,
+            onChanged: (value) {
+              widget.callbacks?.handleChanged(value);
+              setState(() {});
+            },
+            onEditingComplete: widget.callbacks?.handleEditingComplete,
+            onSubmitted: widget.callbacks?.handleSubmitted,
+            textAlign:
+                widget.textCtrl.text.isEmpty ? TextAlign.center : widget.align,
+            configs: widget.configs,
+            cursorHeight: widget.textFontSize,
+            cursorWidth: widget.cursorWidth,
+            hint: widget.i18n.inputHintText,
+            hintStyle: widget.selectedTextStyle.copyWith(
+              color: widget.configs.style.inputHintColor,
+              fontSize: widget.textFontSize,
+              shadows: [],
+            ),
+            backgroundColor: widget.backgroundColor,
+            style: widget.selectedTextStyle.copyWith(
+              color: widget.textColor,
+              fontSize: widget.textFontSize,
+              letterSpacing: 0,
+              decoration: TextDecoration.none,
+              shadows: [],
+            ),
 
-          /// If we edit an layer we focus to the textfield after the
-          /// hero animation is done
-          autofocus: widget.layer == null,
+            /// If we edit an layer we focus to the textfield after the
+            /// hero animation is done
+            autofocus: widget.layer == null,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] I have run `dart format .` in the terminal and committed any changes.
- [ ] I have run `dart analyze .` in the terminal and addressed any issues.
- [ ] I have run `flutter test` in the terminal and addressed any issues.
- [ ] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [ ] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [ ] Bugfix
- [X] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
It is hard to read black on black or non-contrasting colors while editing text.

Issue Number: N/A

## New Behavior

Allow `TextEditorStyle` contain inputTextField properties to be set on app side!

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
