### PR TITLE
Add Hexagon shape tool (drag-to-draw) using PathBuilder

### DIFF
--- a/lib/core/models/editor_configs/paint_editor/paint_editor_configs.dart
+++ b/lib/core/models/editor_configs/paint_editor/paint_editor_configs.dart
@@ -75,6 +75,7 @@ class PaintEditorConfigs extends ZoomConfigs
       PaintMode.circle,
       PaintMode.dashLine,
       PaintMode.dashDotLine,
+      PaintMode.hexagon,
       PaintMode.polygon,
       PaintMode.pixelate,
       PaintMode.blur,

--- a/lib/core/models/i18n/i18n_paint_editor.dart
+++ b/lib/core/models/i18n/i18n_paint_editor.dart
@@ -17,6 +17,7 @@ class I18nPaintEditor {
     this.circle = 'Circle',
     this.dashLine = 'Dash line',
     this.dashDotLine = 'Dash-dot line',
+    this.hexagon = 'Hexagon',
     this.polygon = 'Polygon',
     this.blur = 'Blur',
     this.pixelate = 'Pixelate',
@@ -62,6 +63,9 @@ class I18nPaintEditor {
 
   /// Text for the "Dash-dot line" paint mode.
   final String dashDotLine;
+
+  /// Text for the "Hexagon" paint mode.
+  final String hexagon;
 
   /// Text for the "Polygon" paint mode.
   final String polygon;
@@ -130,6 +134,7 @@ class I18nPaintEditor {
     String? circle,
     String? dashLine,
     String? dashDotLine,
+    String? hexagon,
     String? polygon,
     String? blur,
     String? pixelate,
@@ -159,6 +164,7 @@ class I18nPaintEditor {
       circle: circle ?? this.circle,
       dashLine: dashLine ?? this.dashLine,
       dashDotLine: dashDotLine ?? this.dashDotLine,
+      hexagon: hexagon ?? this.hexagon,
       polygon: polygon ?? this.polygon,
       blur: blur ?? this.blur,
       pixelate: pixelate ?? this.pixelate,

--- a/lib/core/models/icons/paint_editor_icons.dart
+++ b/lib/core/models/icons/paint_editor_icons.dart
@@ -22,6 +22,7 @@ class PaintEditorIcons {
     this.circle = Icons.lens_outlined,
     this.dashLine = Icons.power_input,
     this.dashDotLine = Icons.linear_scale,
+    this.hexagon = Icons.hexagon_outlined,
     this.polygon = Icons.pentagon_outlined,
     this.pixelate = Icons.grid_on,
     this.blur = Icons.blur_on_rounded,
@@ -77,6 +78,9 @@ class PaintEditorIcons {
   /// The icon for the dash-dot line drawing tool.
   final IconData dashDotLine;
 
+  /// The icon for the hexagon drawing tool.
+  final IconData hexagon;
+
   /// The icon for the polygon drawing tool.
   final IconData polygon;
 
@@ -117,6 +121,7 @@ class PaintEditorIcons {
     IconData? circle,
     IconData? dashLine,
     IconData? dashDotLine,
+    IconData? hexagon,
     IconData? polygon,
     IconData? blur,
     IconData? pixelate,
@@ -140,6 +145,7 @@ class PaintEditorIcons {
       circle: circle ?? this.circle,
       dashLine: dashLine ?? this.dashLine,
       dashDotLine: dashDotLine ?? this.dashDotLine,
+      hexagon: hexagon ?? this.hexagon,
       polygon: polygon ?? this.polygon,
       blur: blur ?? this.blur,
       pixelate: pixelate ?? this.pixelate,

--- a/lib/features/paint_editor/enums/paint_editor_enum.dart
+++ b/lib/features/paint_editor/enums/paint_editor_enum.dart
@@ -25,6 +25,9 @@ enum PaintMode {
   /// Draws a dash-dot line between two points.
   dashDotLine,
 
+  /// Creates a hexagon shape starting from a point.
+  hexagon,
+
   /// Draws a Polygon with multiple connected lines.
   polygon,
 

--- a/lib/features/paint_editor/models/painted_model.dart
+++ b/lib/features/paint_editor/models/painted_model.dart
@@ -145,7 +145,8 @@ class PaintedModel {
   bool get canBeFilled {
     return mode == PaintMode.circle ||
         mode == PaintMode.rect ||
-        mode == PaintMode.polygon;
+        mode == PaintMode.polygon ||
+        mode == PaintMode.hexagon;
   }
 
   /// Creates a copy of this PaintedModel instance.

--- a/lib/features/paint_editor/models/path_builder/path_builder_base.dart
+++ b/lib/features/paint_editor/models/path_builder/path_builder_base.dart
@@ -9,6 +9,7 @@ import 'path_builder_dash_dot_line.dart';
 import 'path_builder_dash_line.dart';
 import 'path_builder_freestyle.dart';
 import 'path_builder_line.dart';
+import 'path_builder_hexagon.dart';
 import 'path_builder_polygon.dart';
 import 'path_builder_rectangular.dart';
 
@@ -67,6 +68,14 @@ abstract class PathBuilderBase {
           item: item,
           scale: scale,
         );
+
+      case PaintMode.hexagon:
+        return PathBuilderHexagon(
+          paintEditorConfigs: paintEditorConfigs,
+          item: item,
+          scale: scale,
+        );
+
       case PaintMode.polygon:
         return PathBuilderPolygon(
           paintEditorConfigs: paintEditorConfigs,

--- a/lib/features/paint_editor/models/path_builder/path_builder_base.dart
+++ b/lib/features/paint_editor/models/path_builder/path_builder_base.dart
@@ -8,8 +8,8 @@ import 'path_builder_circle.dart';
 import 'path_builder_dash_dot_line.dart';
 import 'path_builder_dash_line.dart';
 import 'path_builder_freestyle.dart';
-import 'path_builder_line.dart';
 import 'path_builder_hexagon.dart';
+import 'path_builder_line.dart';
 import 'path_builder_polygon.dart';
 import 'path_builder_rectangular.dart';
 

--- a/lib/features/paint_editor/models/path_builder/path_builder_hexagon.dart
+++ b/lib/features/paint_editor/models/path_builder/path_builder_hexagon.dart
@@ -1,0 +1,54 @@
+import 'dart:math';
+import 'package:flutter/widgets.dart';
+
+import 'path_builder_base.dart';
+
+/// Builds a regular hexagon inside the rectangle defined by start & end.
+class PathBuilderHexagon extends PathBuilderBase {
+  PathBuilderHexagon({
+    required super.item,
+    required super.scale,
+    required super.paintEditorConfigs,
+  });
+
+  @override
+  Path build() {
+    final rect = Rect.fromPoints(start, end);
+
+    final center = rect.center;
+    final radius = min(rect.width.abs(), rect.height.abs()) / 2;
+
+    // If user didn't drag enough, avoid weird paths.
+    if (radius <= 0.0) {
+      return path;
+    }
+
+    // 6 vertices (flat-top orientation).
+    // Start angle -90 makes one point on top (nice look).
+    const sides = 6;
+    const startAngle = -pi / 2;
+
+    path.reset();
+    for (int i = 0; i < sides; i++) {
+      final angle = startAngle + (2 * pi * i / sides);
+      final p = Offset(
+        center.dx + radius * cos(angle),
+        center.dy + radius * sin(angle),
+      );
+
+      if (i == 0) {
+        path.moveTo(p.dx, p.dy);
+      } else {
+        path.lineTo(p.dx, p.dy);
+      }
+    }
+    path.close();
+
+    return path;
+  }
+
+  @override
+  bool hitTest(Offset position) {
+    return hitTestFillableObject(position);
+  }
+}

--- a/lib/features/paint_editor/models/path_builder/path_builder_hexagon.dart
+++ b/lib/features/paint_editor/models/path_builder/path_builder_hexagon.dart
@@ -5,6 +5,7 @@ import 'path_builder_base.dart';
 
 /// Builds a regular hexagon inside the rectangle defined by start & end.
 class PathBuilderHexagon extends PathBuilderBase {
+  /// Creates a hexagon path builder.
   PathBuilderHexagon({
     required super.item,
     required super.scale,

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -409,6 +409,12 @@ class PaintEditorState extends State<PaintEditor>
             label: i18n.paintEditor.dashDotLine,
           );
 
+        case PaintMode.hexagon:
+          return PaintModeHelper(
+            icon: paintEditorConfigs.icons.hexagon,
+            label: i18n.paintEditor.hexagon,
+          );
+
         case PaintMode.polygon:
           if (!paintEditorConfigs.enableModePolygon) return null;
           return PaintModeHelper(
@@ -747,7 +753,8 @@ class PaintEditorState extends State<PaintEditor>
         rawLayer.mode == PaintMode.arrow ||
         ((rawLayer.mode == PaintMode.polygon ||
                 rawLayer.mode == PaintMode.rect ||
-                rawLayer.mode == PaintMode.circle) &&
+                rawLayer.mode == PaintMode.circle ||
+                rawLayer.mode == PaintMode.hexagon) &&
             !rawLayer.fill);
 
     // Scale and offset the offsets of the paint layer


### PR DESCRIPTION
This PR adds a new Hexagon paint tool implemented via a dedicated PathBuilder, similar to circle and rectangle.

The hexagon uses a two-point (click + drag) interaction and is intentionally kept separate from the existing polygon tool to preserve polygon’s dynamic, multi-point behavior.

Changes include:

New PaintMode.hexagon

Dedicated PathBuilderHexagon

PaintCanvas handling for drag-based drawing

Icon and i18n label integration

Tested locally , a short demo video is attached :)

https://github.com/user-attachments/assets/42e432ae-4e48-4f22-8988-c1566ef9668d

