### PR TITLE
feat(main_editor): enableSubEditorPage

### DIFF
--- a/lib/core/models/editor_configs/main_editor_configs.dart
+++ b/lib/core/models/editor_configs/main_editor_configs.dart
@@ -42,6 +42,7 @@ class MainEditorConfigs extends ZoomConfigs {
       SubEditorMode.emoji,
       // SubEditorMode.sticker,
     ],
+    this.enableSubEditorPage = false,
     this.style = const MainEditorStyle(),
     this.icons = const MainEditorIcons(),
     this.widgets = const MainEditorWidgets(),
@@ -89,6 +90,9 @@ class MainEditorConfigs extends ZoomConfigs {
 
   /// Defines the safe area configuration for the editor.
   final EditorSafeArea safeArea;
+
+  /// Whether to use the sub-editor page without pushing a new route.
+  final bool enableSubEditorPage;
 
   /// Defines which sub-editors are available in the bottom-bar of the editor.
   ///
@@ -138,8 +142,10 @@ class MainEditorConfigs extends ZoomConfigs {
     Curve? doubleTapZoomCurve,
     EditorSafeArea? safeArea,
     List<SubEditorMode>? tools,
+    bool? enableSubEditorPage,
   }) {
     return MainEditorConfigs(
+      enableSubEditorPage: enableSubEditorPage ?? this.enableSubEditorPage,
       enableCloseButton: enableCloseButton ?? this.enableCloseButton,
       enableEscapeButton: enableEscapeButton ?? this.enableEscapeButton,
       transformSetup: transformSetup ?? this.transformSetup,

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -405,6 +405,7 @@ class ProImageEditorState extends State<ProImageEditor>
         EditorZoomMixin {
   final _bottomBarKey = GlobalKey();
   final _removeAreaKey = GlobalKey();
+  final _navigatorKey = GlobalKey<NavigatorState>();
   final _backgroundImageColorFilterKey = GlobalKey<ColorFilterGeneratorState>();
   @override
   final interactiveViewer = GlobalKey<ExtendedInteractiveViewerState>();
@@ -1475,87 +1476,91 @@ class ProImageEditorState extends State<ProImageEditor>
     _pageOpenCompleter = Completer();
 
     final subEditorStyle = mainEditorConfigs.style.subEditorPage;
-    return Navigator.push<T?>(
-      context,
-      PageRouteBuilder(
-        opaque: false,
-        barrierColor: subEditorStyle.barrierColor,
-        barrierDismissible: subEditorStyle.barrierDismissible,
-        transitionDuration: duration,
-        reverseTransitionDuration: duration,
-        transitionsBuilder: subEditorStyle.transitionsBuilder ??
-            (context, animation, secondaryAnimation, child) {
-              return FadeTransition(opacity: animation, child: child);
-            },
-        pageBuilder: (context, animation, secondaryAnimation) {
-          void animationStatusListener(AnimationStatus status) {
-            switch (status) {
-              case AnimationStatus.completed:
-                if (cropRotateEditor.currentState != null) {
-                  cropRotateEditor.currentState!.hideFakeHero();
+    var route = PageRouteBuilder<T?>(
+      opaque: false,
+      barrierColor: subEditorStyle.barrierColor,
+      barrierDismissible: subEditorStyle.barrierDismissible,
+      transitionDuration: duration,
+      reverseTransitionDuration: duration,
+      transitionsBuilder: subEditorStyle.transitionsBuilder ??
+          (context, animation, secondaryAnimation, child) {
+            return FadeTransition(opacity: animation, child: child);
+          },
+      pageBuilder: (context, animation, secondaryAnimation) {
+        void animationStatusListener(AnimationStatus status) {
+          switch (status) {
+            case AnimationStatus.completed:
+              if (cropRotateEditor.currentState != null) {
+                cropRotateEditor.currentState!.hideFakeHero();
+              }
+              break;
+            case AnimationStatus.dismissed:
+              setState(() {
+                isSubEditorOpen = false;
+                isSubEditorClosing = false;
+                if (!_pageOpenCompleter.isCompleted) {
+                  _pageOpenCompleter.complete(true);
                 }
-                break;
-              case AnimationStatus.dismissed:
-                setState(() {
-                  isSubEditorOpen = false;
-                  isSubEditorClosing = false;
-                  if (!_pageOpenCompleter.isCompleted) {
-                    _pageOpenCompleter.complete(true);
-                  }
 
-                  if (stateManager.heroScreenshotRequired) {
-                    stateManager.heroScreenshotRequired = false;
-                    _takeScreenshot();
-                  }
-                });
+                if (stateManager.heroScreenshotRequired) {
+                  stateManager.heroScreenshotRequired = false;
+                  _takeScreenshot();
+                }
+              });
 
-                animation.removeStatusListener(animationStatusListener);
-                mainEditorCallbacks?.handleEndCloseSubEditor(editorName);
-                break;
-              case AnimationStatus.reverse:
-                isSubEditorClosing = true;
-                mainEditorCallbacks?.handleStartCloseSubEditor(editorName);
+              animation.removeStatusListener(animationStatusListener);
+              mainEditorCallbacks?.handleEndCloseSubEditor(editorName);
+              break;
+            case AnimationStatus.reverse:
+              isSubEditorClosing = true;
+              mainEditorCallbacks?.handleStartCloseSubEditor(editorName);
 
-                break;
-              case AnimationStatus.forward:
-                break;
-            }
+              break;
+            case AnimationStatus.forward:
+              break;
           }
+        }
 
-          animation.addStatusListener(animationStatusListener);
+        animation.addStatusListener(animationStatusListener);
 
-          if (!subEditorStyle.requireReposition) return page;
+        if (!subEditorStyle.requireReposition) return page;
 
-          return SafeArea(
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                Positioned(
-                  top: subEditorStyle.positionTop,
-                  left: subEditorStyle.positionLeft,
-                  right: subEditorStyle.positionRight,
-                  bottom: subEditorStyle.positionBottom,
-                  child: Center(
-                    child: Container(
-                      width: subEditorStyle.enforceSizeFromMainEditor
-                          ? sizesManager.editorSize.width
-                          : null,
-                      height: subEditorStyle.enforceSizeFromMainEditor
-                          ? sizesManager.editorSize.height
-                          : null,
-                      clipBehavior: Clip.hardEdge,
-                      decoration: BoxDecoration(
-                        borderRadius: subEditorStyle.borderRadius,
-                      ),
-                      child: page,
+        return SafeArea(
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              Positioned(
+                top: subEditorStyle.positionTop,
+                left: subEditorStyle.positionLeft,
+                right: subEditorStyle.positionRight,
+                bottom: subEditorStyle.positionBottom,
+                child: Center(
+                  child: Container(
+                    width: subEditorStyle.enforceSizeFromMainEditor
+                        ? sizesManager.editorSize.width
+                        : null,
+                    height: subEditorStyle.enforceSizeFromMainEditor
+                        ? sizesManager.editorSize.height
+                        : null,
+                    clipBehavior: Clip.hardEdge,
+                    decoration: BoxDecoration(
+                      borderRadius: subEditorStyle.borderRadius,
                     ),
+                    child: page,
                   ),
                 ),
-              ],
-            ),
-          );
-        },
-      ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+    if (mainEditorConfigs.enableSubEditorPage) {
+      return _navigatorKey.currentState!.push<T?>(route);
+    }
+    return Navigator.push<T?>(
+      context,
+      route,
     );
   }
 
@@ -2493,10 +2498,17 @@ class ProImageEditorState extends State<ProImageEditor>
     return RecordInvisibleWidget(
       controller: _controllers.screenshot,
       child: ExtendedPopScope(
-        canPop: isPopScopeDisabled ||
-            !stateManager.canUndo ||
-            _isProcessingFinalImage,
+        canPop: (isPopScopeDisabled ||
+                !stateManager.canUndo ||
+                _isProcessingFinalImage) &&
+            (!mainEditorConfigs.enableSubEditorPage || !isSubEditorOpen),
         onPopInvokedWithResult: (didPop, result) {
+          if (mainEditorConfigs.enableSubEditorPage && isSubEditorOpen) {
+            if (_navigatorKey.currentState?.canPop() == true) {
+              _navigatorKey.currentState?.pop();
+              return;
+            }
+          }
           if (!didPop &&
               !isPopScopeDisabled &&
               stateManager.canUndo &&
@@ -2545,13 +2557,37 @@ class ProImageEditorState extends State<ProImageEditor>
                   child: LayoutBuilder(
                     builder: (context, constraints) {
                       sizesManager.editorSize = constraints.biggest;
-                      return Scaffold(
+                      var scaffold = Scaffold(
                         backgroundColor: mainEditorConfigs.style.background,
                         resizeToAvoidBottomInset: false,
                         appBar: _buildAppBar(),
                         body: _buildBody(),
                         bottomNavigationBar: _buildBottomNavBar(),
                       );
+
+                      if (mainEditorConfigs.enableSubEditorPage) {
+                        return Stack(
+                          children: [
+                            scaffold,
+                            Positioned.fill(
+                              child: IgnorePointer(
+                                ignoring: !isSubEditorOpen,
+                                child: Navigator(
+                                  key: _navigatorKey,
+                                  onGenerateRoute: (settings) =>
+                                      PageRouteBuilder(
+                                    opaque: false,
+                                    pageBuilder: (context, _, __) =>
+                                        const SizedBox.shrink(),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        );
+                      }
+
+                      return scaffold;
                     },
                   ),
                 ),


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] I have run `dart format .` in the terminal and committed any changes.
- [ ] I have run `dart analyze .` in the terminal and addressed any issues.
- [ ] I have run `flutter test` in the terminal and addressed any issues.
- [ ] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [ ] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [X] Bugfix
- [X] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
Crop and paintEditor open in full screen, regardless of the constraints of the main editor. This PR allows using subPage within the constraints.

Why? I am not sure what happened, but recently a bug was introduced, and adding painting layers, which are added in full screen, fully shifts the painting layers upon closing the subPage. I have honestly no idea when this regression was introduced.

Issue Number: N/A

## New Behavior
Although the shift bug has not been fixed, allowing subPage editors within constraints solves the problem and allows for a nicer UX.

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
