### PR TITLE
fix(services): ignore Alt on Ctrl shortcuts

### DIFF
--- a/lib/core/services/keyboard_service.dart
+++ b/lib/core/services/keyboard_service.dart
@@ -35,4 +35,13 @@ class KeyboardService {
   bool get isShiftPressed =>
       isKeyPressed(LogicalKeyboardKey.shiftLeft) ||
       isKeyPressed(LogicalKeyboardKey.shiftRight);
+
+  /// Returns `true` if either Alt key is currently pressed.
+  ///
+  /// This includes:
+  /// - [LogicalKeyboardKey.altLeft]
+  /// - [LogicalKeyboardKey.altRight]
+  bool get isAltPressed =>
+      isKeyPressed(LogicalKeyboardKey.altLeft) ||
+      isKeyPressed(LogicalKeyboardKey.altRight);
 }

--- a/lib/features/crop_rotate_editor/services/crop_desktop_interaction_manager.dart
+++ b/lib/features/crop_rotate_editor/services/crop_desktop_interaction_manager.dart
@@ -77,7 +77,9 @@ class CropDesktopInteractionManager {
             _shiftDown = true;
             break;
           case 'Z':
-            if (_ctrlDown) onUndoRedo(!_shiftDown);
+            if (_ctrlDown && !HardwareKeyboard.instance.isAltPressed) {
+              onUndoRedo(!_shiftDown);
+            }
             break;
         }
       } else if (event is KeyUpEvent) {

--- a/lib/features/main_editor/services/desktop_interaction_manager.dart
+++ b/lib/features/main_editor/services/desktop_interaction_manager.dart
@@ -124,7 +124,9 @@ class DesktopInteractionManager {
         _keyboardRotate(isLeftRotation: false, selectedLayers: selectedLayers);
         break;
       case 'Z':
-        if (_keyboard.isCtrlPressed) onUndoRedo(!_keyboard.isShiftPressed);
+        if (_keyboard.isCtrlPressed && !_keyboard.isAltPressed) {
+          onUndoRedo(!_keyboard.isShiftPressed);
+        }
         break;
     }
 

--- a/lib/features/paint_editor/services/paint_desktop_interaction_manager.dart
+++ b/lib/features/paint_editor/services/paint_desktop_interaction_manager.dart
@@ -46,7 +46,9 @@ class PaintDesktopInteractionManager {
             _shiftDown = true;
             break;
           case 'Z':
-            if (_ctrlDown) onUndoRedo(!_shiftDown);
+            if (_ctrlDown && !HardwareKeyboard.instance.isAltPressed) {
+              onUndoRedo(!_shiftDown);
+            }
             break;
         }
       } else if (event is KeyUpEvent) {


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] I have run `dart format .` in the terminal and committed any changes.
- [ ] I have run `dart analyze .` in the terminal and addressed any issues.
- [ ] I have run `flutter test` in the terminal and addressed any issues.
- [ ] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [ ] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [X] Bugfix
- [X] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
Users with Polish keyboard layout complain that Ctrl+Alt+Z (a common typing character shortcut) collides with Ctrl+Z, causing their image history to undo work.

## New Behavior
This PR blocks Ctrl based shortcuts when Alt is pressed

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
