### PR TITLE
feat(main_editor_configs): allow disabling native shortcuts from down…

### DIFF
--- a/lib/core/models/editor_configs/main_editor_configs.dart
+++ b/lib/core/models/editor_configs/main_editor_configs.dart
@@ -29,6 +29,7 @@ class MainEditorConfigs extends ZoomConfigs {
     super.invertTrackpadDirection,
     this.transformSetup,
     this.enableCloseButton = true,
+    this.enableKeyboardShortcuts = true,
     this.enableEscapeButton = true,
     this.canZoomWhenLayerSelected = true,
     this.mobilePanInteraction = MobilePanInteraction.move,
@@ -51,6 +52,12 @@ class MainEditorConfigs extends ZoomConfigs {
 
   /// Determines whether the close button is displayed on the widget.
   final bool enableCloseButton;
+
+  /// Whether keyboard shortcuts are enabled.
+  ///
+  /// When set to `true`, the editor responds to keyboard events (shortcuts).
+  /// If set to `false`, keyboard shortcuts are disabled.
+  final bool enableKeyboardShortcuts;
 
   /// Defines the configuration for pan interactions on mobile devices.
   ///
@@ -124,6 +131,7 @@ class MainEditorConfigs extends ZoomConfigs {
   /// others unchanged.
   MainEditorConfigs copyWith({
     bool? enableCloseButton,
+    bool? enableKeyboardShortcuts,
     bool? enableEscapeButton,
     MainEditorTransformSetup? transformSetup,
     MainEditorStyle? style,
@@ -147,6 +155,8 @@ class MainEditorConfigs extends ZoomConfigs {
     return MainEditorConfigs(
       enableSubEditorPage: enableSubEditorPage ?? this.enableSubEditorPage,
       enableCloseButton: enableCloseButton ?? this.enableCloseButton,
+      enableKeyboardShortcuts:
+          enableKeyboardShortcuts ?? this.enableKeyboardShortcuts,
       enableEscapeButton: enableEscapeButton ?? this.enableEscapeButton,
       transformSetup: transformSetup ?? this.transformSetup,
       style: style ?? this.style,

--- a/lib/features/main_editor/services/desktop_interaction_manager.dart
+++ b/lib/features/main_editor/services/desktop_interaction_manager.dart
@@ -87,7 +87,11 @@ class DesktopInteractionManager {
     required Function onEscape,
     required Function(bool) onUndoRedo,
   }) {
-    if (!context.mounted || event is! KeyDownEvent) return false;
+    if (!context.mounted ||
+        !configs.mainEditor.enableKeyboardShortcuts ||
+        event is! KeyDownEvent) {
+      return false;
+    }
 
     final key = event.logicalKey.keyLabel;
 


### PR DESCRIPTION
…stream

## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [ ] I have run `dart format .` in the terminal and committed any changes.
- [ ] I have run `dart analyze .` in the terminal and addressed any issues.
- [ ] I have run `flutter test` in the terminal and addressed any issues.
- [ ] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [ ] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Checklist (Optional)
- [ ] Tests have been added for the changes.
- [ ] Documentation has been added/updated.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [ ] Bugfix
- [x] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
Users perceive "unwanted" app-side shortcuts triggering main editor library, such as arrows to rotate or layer movement. Although this is a nice functionality, it could be made so this is optional, or eventually in the future better customized from app-side (i.e. a set of pre-included functions, but let app-side do the mapping)

## New Behavior
add a flag `enableKeyboardShortcuts` to disable library side shortcuts

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
