### PR TITLE
fix: remove hidden BottomAppBar SafeArea gap in sub-editors

### DIFF
--- a/lib/features/blur_editor/blur_editor.dart
+++ b/lib/features/blur_editor/blur_editor.dart
@@ -256,11 +256,15 @@ class BlurEditorState extends State<BlurEditor>
             right: blurEditorConfigs.safeArea.right,
             child: RecordInvisibleWidget(
               controller: screenshotCtrl,
-              child: Scaffold(
-                backgroundColor: blurEditorConfigs.style.background,
-                appBar: _buildAppBar(),
-                body: _buildBody(),
-                bottomNavigationBar: _buildBottomNavBar(),
+              child: MediaQuery.removePadding(
+                context: context,
+                removeBottom: !blurEditorConfigs.safeArea.bottom,
+                child: Scaffold(
+                  backgroundColor: blurEditorConfigs.style.background,
+                  appBar: _buildAppBar(),
+                  body: _buildBody(),
+                  bottomNavigationBar: _buildBottomNavBar(),
+                ),
               ),
             ),
           ),

--- a/lib/features/crop_rotate_editor/crop_rotate_editor.dart
+++ b/lib/features/crop_rotate_editor/crop_rotate_editor.dart
@@ -2148,21 +2148,17 @@ class CropRotateEditorState extends State<CropRotateEditor>
                   ),
                   child: MediaQuery.removePadding(
                     context: context,
-                    removeBottom:
-                        !cropRotateEditorConfigs.safeArea.bottom,
+                    removeBottom: !cropRotateEditorConfigs.safeArea.bottom,
                     child: Scaffold(
                       resizeToAvoidBottomInset: false,
-                      backgroundColor:
-                          cropRotateEditorConfigs.style.background,
+                      backgroundColor: cropRotateEditorConfigs.style.background,
                       appBar: _buildAppBar(constraints),
                       body: Center(
                         child: SizedBox(
                           width:
                               constraints.maxWidth *
                               (cropRotateEditorConfigs.maxWidthFactor ??
-                                  (!kIsWeb && Platform.isAndroid
-                                      ? 0.9
-                                      : 1)),
+                                  (!kIsWeb && Platform.isAndroid ? 0.9 : 1)),
                           child: _buildBody(),
                         ),
                       ),

--- a/lib/features/crop_rotate_editor/crop_rotate_editor.dart
+++ b/lib/features/crop_rotate_editor/crop_rotate_editor.dart
@@ -2146,20 +2146,28 @@ class CropRotateEditorState extends State<CropRotateEditor>
                       preferBelow: true,
                     ),
                   ),
-                  child: Scaffold(
-                    resizeToAvoidBottomInset: false,
-                    backgroundColor: cropRotateEditorConfigs.style.background,
-                    appBar: _buildAppBar(constraints),
-                    body: Center(
-                      child: SizedBox(
-                        width:
-                            constraints.maxWidth *
-                            (cropRotateEditorConfigs.maxWidthFactor ??
-                                (!kIsWeb && Platform.isAndroid ? 0.9 : 1)),
-                        child: _buildBody(),
+                  child: MediaQuery.removePadding(
+                    context: context,
+                    removeBottom:
+                        !cropRotateEditorConfigs.safeArea.bottom,
+                    child: Scaffold(
+                      resizeToAvoidBottomInset: false,
+                      backgroundColor:
+                          cropRotateEditorConfigs.style.background,
+                      appBar: _buildAppBar(constraints),
+                      body: Center(
+                        child: SizedBox(
+                          width:
+                              constraints.maxWidth *
+                              (cropRotateEditorConfigs.maxWidthFactor ??
+                                  (!kIsWeb && Platform.isAndroid
+                                      ? 0.9
+                                      : 1)),
+                          child: _buildBody(),
+                        ),
                       ),
+                      bottomNavigationBar: _buildBottomAppBar(),
                     ),
-                    bottomNavigationBar: _buildBottomAppBar(),
                   ),
                 ),
               );

--- a/lib/features/filter_editor/filter_editor.dart
+++ b/lib/features/filter_editor/filter_editor.dart
@@ -309,11 +309,15 @@ class FilterEditorState extends State<FilterEditor>
             right: filterEditorConfigs.safeArea.right,
             child: RecordInvisibleWidget(
               controller: screenshotCtrl,
-              child: Scaffold(
-                backgroundColor: filterEditorConfigs.style.background,
-                appBar: _buildAppBar(),
-                body: _buildBody(),
-                bottomNavigationBar: _buildBottomNavBar(),
+              child: MediaQuery.removePadding(
+                context: context,
+                removeBottom: !filterEditorConfigs.safeArea.bottom,
+                child: Scaffold(
+                  backgroundColor: filterEditorConfigs.style.background,
+                  appBar: _buildAppBar(),
+                  body: _buildBody(),
+                  bottomNavigationBar: _buildBottomNavBar(),
+                ),
               ),
             ),
           ),

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -880,12 +880,16 @@ class PaintEditorState extends State<PaintEditor>
               controller: screenshotCtrl,
               child: LayoutBuilder(
                 builder: (context, constraints) {
-                  return Scaffold(
-                    resizeToAvoidBottomInset: false,
-                    backgroundColor: paintEditorConfigs.style.background,
-                    appBar: _buildAppBar(constraints),
-                    body: _buildBody(),
-                    bottomNavigationBar: _buildBottomBar(),
+                  return MediaQuery.removePadding(
+                    context: context,
+                    removeBottom: !paintEditorConfigs.safeArea.bottom,
+                    child: Scaffold(
+                      resizeToAvoidBottomInset: false,
+                      backgroundColor: paintEditorConfigs.style.background,
+                      appBar: _buildAppBar(constraints),
+                      body: _buildBody(),
+                      bottomNavigationBar: _buildBottomBar(),
+                    ),
                   );
                 },
               ),

--- a/lib/features/text_editor/text_editor.dart
+++ b/lib/features/text_editor/text_editor.dart
@@ -355,13 +355,17 @@ class TextEditorState extends State<TextEditor>
               bottom: textEditorConfigs.safeArea.bottom,
               left: textEditorConfigs.safeArea.left,
               right: textEditorConfigs.safeArea.right,
-              child: Scaffold(
-                resizeToAvoidBottomInset:
-                    textEditorConfigs.resizeToAvoidBottomInset,
-                backgroundColor: textEditorConfigs.style.background,
-                appBar: _buildAppBar(constraints),
-                body: _buildBody(),
-                bottomNavigationBar: _buildBottomBar(),
+              child: MediaQuery.removePadding(
+                context: context,
+                removeBottom: !textEditorConfigs.safeArea.bottom,
+                child: Scaffold(
+                  resizeToAvoidBottomInset:
+                      textEditorConfigs.resizeToAvoidBottomInset,
+                  backgroundColor: textEditorConfigs.style.background,
+                  appBar: _buildAppBar(constraints),
+                  body: _buildBody(),
+                  bottomNavigationBar: _buildBottomBar(),
+                ),
               ),
             ),
           ),

--- a/lib/features/tune_editor/tune_editor.dart
+++ b/lib/features/tune_editor/tune_editor.dart
@@ -389,11 +389,15 @@ class TuneEditorState extends State<TuneEditor>
             right: tuneEditorConfigs.safeArea.right,
             child: RecordInvisibleWidget(
               controller: screenshotCtrl,
-              child: Scaffold(
-                backgroundColor: tuneEditorConfigs.style.background,
-                appBar: _buildAppBar(),
-                body: _buildBody(),
-                bottomNavigationBar: _buildBottomNavBar(),
+              child: MediaQuery.removePadding(
+                context: context,
+                removeBottom: !tuneEditorConfigs.safeArea.bottom,
+                child: Scaffold(
+                  backgroundColor: tuneEditorConfigs.style.background,
+                  appBar: _buildAppBar(),
+                  body: _buildBody(),
+                  bottomNavigationBar: _buildBottomNavBar(),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Problem

When a user sets `EditorSafeArea(bottom: false)` on any sub-editor config (paint, text, blur, filter, tune, crop/rotate), a **hidden gap** appears between the subtool toolbar row and the bottom action row (Close/Undo/Redo/Done).

The gap is approximately **34px** on devices with a bottom safe area (e.g. iPhone with home indicator).

### Visual

```
┌────────────────────────────┐
│   Image / Canvas Area      │
├────────────────────────────┤
│ Color │ Thickness │ Opacity│  ← subtool toolbar (BottomAppBar, 65px)
│                            │
│     ~34px hidden gap       │  ← THIS IS THE BUG
│                            │
├────────────────────────────┤
│  ✕  │  ↩  │  ↪  │  ✓     │  ← bottom action row (GroundedBottomBar)
└────────────────────────────┘
```

## Root Cause

Flutter's `BottomAppBar` widget **internally** wraps its content in `SafeArea(bottom: true)` ([source: bottom_app_bar.dart line 230](https://github.com/flutter/flutter/blob/stable/packages/flutter/lib/src/material/bottom_app_bar.dart#L230)):

```dart
// Inside Flutter's BottomAppBar.build():
final Widget child = SizedBox(
  height: height,           // 65px
  child: Padding(
    padding: widget.padding, // EdgeInsets.zero
    child: widget.child,
  ),
);

return PhysicalShape(
  child: Material(
    child: SafeArea(child: child),  // ← adds bottom padding externally
  ),
);
```

When the editor's outer `SafeArea(bottom: false)` is set:
- It does **NOT** add visible padding (correct)
- It does **NOT** consume the `viewPadding.bottom` from `MediaQuery` (this is the issue)

So the `BottomAppBar`'s internal `SafeArea(bottom: true)` still sees the full `viewPadding.bottom` (~34px) and adds it as invisible padding **below** the `SizedBox(height: 65)`, expanding the `BottomAppBar` beyond its intended 65px height.

Since `BottomAppBar` is used inside a `Column` (via `GroundedBottomWrapper`) alongside `GroundedBottomBar`, this extra padding creates a visible gap between the two bars.

## Fix

Wrap each sub-editor's `Scaffold` in `MediaQuery.removePadding(removeBottom: ...)`:

```dart
// Before:
SafeArea(
  bottom: config.safeArea.bottom,  // false
  child: Scaffold(
    bottomNavigationBar: _buildBottomBar(),  // BottomAppBar sees full padding
  ),
)

// After:
SafeArea(
  bottom: config.safeArea.bottom,  // false
  child: MediaQuery.removePadding(
    context: context,
    removeBottom: !config.safeArea.bottom,  // true when safeArea.bottom is false
    child: Scaffold(
      bottomNavigationBar: _buildBottomBar(),  // BottomAppBar sees zero padding
    ),
  ),
)
```

`MediaQuery.removePadding(removeBottom: true)` zeroes out `viewPadding.bottom` in the MediaQuery data for all descendants, so `BottomAppBar`'s internal `SafeArea` has nothing to add.

## Backward Compatibility

| User's `safeArea.bottom` | `removeBottom` value | Effect |
|---|---|---|
| `true` **(default)** | `!true` → `false` | **No-op.** `MediaQuery.removePadding(removeBottom: false)` changes nothing. Zero impact on existing users. |
| `false` (explicitly set) | `!false` → `true` | **Fixes the gap.** Bottom padding is consumed before it reaches `BottomAppBar`. |

This is a **fully backward-compatible** fix. Users on default settings experience zero change.

## Files Changed

| File | Change |
|------|--------|
| `lib/features/paint_editor/paint_editor.dart` | Wrap Scaffold in `MediaQuery.removePadding` |
| `lib/features/text_editor/text_editor.dart` | Wrap Scaffold in `MediaQuery.removePadding` |
| `lib/features/blur_editor/blur_editor.dart` | Wrap Scaffold in `MediaQuery.removePadding` |
| `lib/features/filter_editor/filter_editor.dart` | Wrap Scaffold in `MediaQuery.removePadding` |
| `lib/features/tune_editor/tune_editor.dart` | Wrap Scaffold in `MediaQuery.removePadding` |
| `lib/features/crop_rotate_editor/crop_rotate_editor.dart` | Wrap Scaffold in `MediaQuery.removePadding` |

## Reproduction Steps

1. Set `safeArea: EditorSafeArea(top: false, bottom: false)` on any sub-editor config (e.g. `paintEditor`)
2. Open the paint editor on a device with bottom safe area (iPhone with home indicator)
3. Observe the gap between the subtool toolbar and the bottom action row

## How to Verify the Fix

1. Apply this change
2. Set `safeArea: EditorSafeArea(top: false, bottom: false)` on any sub-editor
3. Open the sub-editor on an iPhone (or simulator with home indicator)
4. The subtool toolbar and bottom action row should be directly adjacent with no gap