### PR TITLE
feat(helper-lines): allow lines override

### DIFF
--- a/lib/features/main_editor/services/layer_interaction_manager.dart
+++ b/lib/features/main_editor/services/layer_interaction_manager.dart
@@ -423,9 +423,16 @@ class LayerInteractionManager {
   final _horizontalSnapHelper = _LayerAlignGuideHelper();
   final _verticalSnapHelper = _LayerAlignGuideHelper();
 
+  /// Optional override for helper line configuration at runtime.
+  ///
+  /// When set, this takes precedence over [configs.helperLines], allowing
+  /// helper lines to be toggled without recreating the editor widget.
+  HelperLineConfigs? helperLinesOverride;
+
   /// Configuration settings for displaying and managing helper lines within
   /// the editor.
-  HelperLineConfigs get helperLineConfigs => configs.helperLines;
+  HelperLineConfigs get helperLineConfigs =>
+      helperLinesOverride ?? configs.helperLines;
 
   /// Resets the state of the layer interaction manager by:
   ///


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [X] I have run `dart format .` in the terminal and committed any changes.
- [X] I have run `dart analyze .` in the terminal and addressed any issues.
- [ ] I have run `flutter test` in the terminal and addressed any issues.
- [ ] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [X] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [ ] Bugfix
- [X] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
Since the Configs are immutable final, I would like a toggle button in my topbar to allow users to toggle helper lines on-demand (the zoom flag helps but it is not immediately noticed)

Issue Number: N/A

## New Behavior
Allows an override helperLine config which is read in runtime without having to rebuild the editor allows to change the setting. We could remove final from the Configs or its attributes if preferred, but I assume it is not preferred, so I added as an override.

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
