### PR TITLE
feat(callbacks): add onLayerInteractionEnd

### DIFF
--- a/lib/core/models/editor_callbacks/main_editor/main_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/main_editor/main_editor_callbacks.dart
@@ -41,6 +41,7 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
     this.onLayerTapUp,
     this.onImportHistoryStart,
     this.onImportHistoryEnd,
+    this.onLayerInteractionEnd,
     this.onHoverRemoveAreaChange,
     this.onStateHistoryChange,
     this.onImageDecoded,
@@ -78,6 +79,13 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
   ///
   /// The [Layer] parameter provides information about the removed layer.
   final Function(Layer layer)? onRemoveLayer;
+
+  /// A callback triggered when a layer interaction (drag/scale/rotate) ends.
+  ///
+  /// The [List<Layer>] parameter provides the layers that were being
+  /// interacted with. This is useful for applying final adjustments like
+  /// snap-to-grid on release.
+  final Function(List<Layer> layers)? onLayerInteractionEnd;
 
   /// A callback function that is triggered when a sub-editor is opened.
   ///
@@ -383,6 +391,15 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
     handleUpdateUI();
   }
 
+  /// Handles the end of a layer interaction (drag/scale/rotate).
+  ///
+  /// This method calls the [onLayerInteractionEnd] callback with the
+  /// provided [layers] and then calls [handleUpdateUI].
+  void handleLayerInteractionEnd(List<Layer> layers) {
+    onLayerInteractionEnd?.call(layers);
+    handleUpdateUI();
+  }
+
   /// Handles the opening of a sub-editor.
   ///
   /// This method calls the [onOpenSubEditor] callback with the provided
@@ -480,6 +497,7 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
     Function()? onImageDecoded,
     Future<TextLayer?> Function(TextLayer layer)? onEditTextLayer,
     Future<TextLayer?> Function()? onCreateTextLayer,
+    Function(List<Layer> layers)? onLayerInteractionEnd,
     Function(ProImageEditorState state, ImportStateHistory import)?
     onImportHistoryStart,
     Function(ProImageEditorState state, ImportStateHistory import)?
@@ -530,6 +548,8 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
       onCreateTextLayer: onCreateTextLayer ?? this.onCreateTextLayer,
       onImportHistoryStart: onImportHistoryStart ?? this.onImportHistoryStart,
       onImportHistoryEnd: onImportHistoryEnd ?? this.onImportHistoryEnd,
+      onLayerInteractionEnd:
+          onLayerInteractionEnd ?? this.onLayerInteractionEnd,
       onHoverRemoveAreaChange:
           onHoverRemoveAreaChange ?? this.onHoverRemoveAreaChange,
       onStateHistoryChange: onStateHistoryChange ?? this.onStateHistoryChange,

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -1340,6 +1340,10 @@ class ProImageEditorState extends State<ProImageEditor>
   /// lines and flags.
   void _onScaleEnd(ScaleEndDetails details) async {
     mainEditorCallbacks?.handleScaleEnd(details);
+    if (selectedLayers.isNotEmpty) {
+      mainEditorCallbacks
+          ?.handleLayerInteractionEnd(List.of(selectedLayers));
+    }
     layerInteractionManager.activeInteractionLayer = null;
 
     /// Check if layers should be removed.

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -1341,8 +1341,7 @@ class ProImageEditorState extends State<ProImageEditor>
   void _onScaleEnd(ScaleEndDetails details) async {
     mainEditorCallbacks?.handleScaleEnd(details);
     if (selectedLayers.isNotEmpty) {
-      mainEditorCallbacks
-          ?.handleLayerInteractionEnd(List.of(selectedLayers));
+      mainEditorCallbacks?.handleLayerInteractionEnd(List.of(selectedLayers));
     }
     layerInteractionManager.activeInteractionLayer = null;
 


### PR DESCRIPTION
## PR Checklist (Required)
Please ensure your PR meets the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/hm21/pro_image_editor/blob/stable/CONTRIBUTING.md#style-guides
- [X] I have run `dart format .` in the terminal and committed any changes.
- [X] I have run `dart analyze .` in the terminal and addressed any issues.
- [ ] I have run `flutter test` in the terminal and addressed any issues.
- [ ] I have pulled from the stable branch before committing.
- [ ] I have updated the `CHANGELOG.md` file with my changes (For the version, you can use X.X.X, I will later bump it after it's merged).
- [X] The PR title follows the conventional commit style (e.g., `feat(paint-editor): add new triangle shape`).
- [ ] If this PR introduces breaking changes, I have verified that there is no way to implement the changes without them.

## PR Type
Please indicate the types of changes this PR introduces by checking the relevant boxes:

- [ ] Bugfix
- [X] Feature
- [ ] Performance
- [ ] Refactor (no functional or API changes)
- [ ] Code style updates (e.g., formatting, local variables)
- [ ] Documentation updates
- [ ] CI-related changes
- [ ] Other... Please describe:

## Current Behavior
It is not possible to trigger events once the interaction with a layer finishes.

Issue Number: N/A

## New Behavior
This PR adds an onLayerInteractionEnd callback to allow taking action after the "release" of a layer in the editor.

## Breaking Changes?
Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains breaking changes, please describe the impact and provide the migration path for existing applications. -->

## Additional Information
