### PR TITLE
feat(text-editor): add spellCheckConfiguration to TextEditorConfigs for enabling spell checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.0.12
+- **FEAT**(text-editor): Add `spellCheckConfiguration` to `TextEditorConfigs` for enabling spell checking in the text input field.
+
 ## 12.0.11
 - **FEAT**(text-editor): Add `inputLetterSpacing` and `inputShadows` to `TextEditorStyle` for customizing letter spacing and text shadows.
 - **FEAT**(callbacks): Add `onLayerInteractionEnd` callback to `MainEditorCallbacks`, triggered when layer interaction ends.

--- a/lib/core/models/editor_configs/text_editor_configs.dart
+++ b/lib/core/models/editor_configs/text_editor_configs.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 // Project imports:
 import '../custom_widgets/text_editor_widgets.dart';
@@ -67,6 +67,7 @@ class TextEditorConfigs
     this.widgets = const TextEditorWidgets(),
     this.enableImageBoundaryTextWrap = false,
     this.resizeToAvoidBottomInset = true,
+    this.spellCheckConfiguration,
   }) : assert(initFontSize > 0, 'initFontSize must be positive'),
        assert(
          maxScale >= minScale,
@@ -210,6 +211,12 @@ class TextEditorConfigs
   /// the content.
   final bool resizeToAvoidBottomInset;
 
+  /// The spell check configuration for the text input field.
+  ///
+  /// When provided, enables spell checking with the given configuration.
+  /// When `null`, spell checking is disabled.
+  final SpellCheckConfiguration? spellCheckConfiguration;
+
   /// Creates a copy of this `TextEditorConfigs` object with the given fields
   /// replaced with new values.
   ///
@@ -249,6 +256,7 @@ class TextEditorConfigs
     bool? showFontScaleButton,
     bool? showTextAlignButton,
     bool? resizeToAvoidBottomInset,
+    SpellCheckConfiguration? spellCheckConfiguration,
   }) {
     return TextEditorConfigs(
       layerFractionalOffset:
@@ -293,6 +301,8 @@ class TextEditorConfigs
       showTextAlignButton: showTextAlignButton ?? this.showTextAlignButton,
       resizeToAvoidBottomInset:
           resizeToAvoidBottomInset ?? this.resizeToAvoidBottomInset,
+      spellCheckConfiguration:
+          spellCheckConfiguration ?? this.spellCheckConfiguration,
     );
   }
 }

--- a/lib/features/text_editor/widgets/rounded_background_text/rounded_background_text_field.dart
+++ b/lib/features/text_editor/widgets/rounded_background_text/rounded_background_text_field.dart
@@ -189,6 +189,7 @@ class _RoundedBackgroundTextFieldState
           leadingDistribution: widget.configs.style.leadingDistribution,
           height: widget.configs.style.textHeight,
         ),
+        spellCheckConfiguration: widget.configs.spellCheckConfiguration,
         decoration: InputDecoration.collapsed(
           hintText: _textController.text.isEmpty ? widget.hint : '',
           hintStyle:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.0.11
+version: 12.0.12
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
 
## Description

Enable spell checking in the text input field by adding `spellCheckConfiguration` to `TextEditorConfigs`. This allows users to customize spell checking behavior.



**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore