### PR TITLE
feat: add timeline support for layers and tune adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.2.0
+- **FEAT**(timeline): Add video timeline visibility to layers, filters, and tune adjustments with configurable `startTime`, `endTime`, enter/exit durations and curves.
+- **FEAT**(complete-parameters): Add `filterStates`, `tuneAdjustments`, and `capturedLayers` to `CompleteParameters`. Add `captureLayersOnDone` config to `MainEditorConfigs`.
+
 ## 12.1.0
 - **FEAT**(layers): Add layer export API to capture individual layers as PNG images. Use `Layer.captureAsPng()` for single layers or `Layer.captureAllLayers()` for batch export with shared isolate reuse. The main editor exposes `captureAllLayers()` and `captureAllLayersWithMeta()` convenience methods.
 - **FEAT**(layers): Add `ExportedLayer` model containing the source layer, encoded image bytes, and logical size metadata.

--- a/example/lib/features/ai/ai_text_commands/providers/ai_message_base_provider.dart
+++ b/example/lib/features/ai/ai_text_commands/providers/ai_message_base_provider.dart
@@ -59,7 +59,7 @@ abstract class AiMessageBaseProvider {
       'transform': state.transformConfigs.isNotEmpty
           ? state.transformConfigs.toMap()
           : null,
-      'filters': state.activeFilters,
+      'filters': state.activeFilters.allMatrices,
       'tune': state.activeTuneAdjustments.map((tune) => tune.toMap()).toList(),
     };
     final systemConfig = buildAiSystemConfig(
@@ -129,7 +129,7 @@ abstract class AiMessageBaseProvider {
 
       editor.addHistory(
         blur: blur,
-        filters: filters,
+        filters: filters != null ? [FilterState(matrices: filters)] : null,
         tuneAdjustments: tuneAdjustments,
         layers: layers,
         transformConfigs: transformConfigs,

--- a/lib/core/models/complete_parameters.dart
+++ b/lib/core/models/complete_parameters.dart
@@ -4,7 +4,10 @@ import 'package:flutter/foundation.dart';
 
 import '/features/audio_editor/models/audio_track.dart';
 import '/features/clips_editor/models/video_clip.dart';
+import '/features/filter_editor/types/filter_state.dart';
 import '/features/filter_editor/utils/combine_color_matrix_utils.dart';
+import '/features/tune_editor/models/tune_adjustment_matrix.dart';
+import 'layers/exported_layer.dart';
 import 'layers/layer.dart';
 
 /// A data class that contains all parameters needed for applying visual
@@ -67,6 +70,9 @@ class CompleteParameters {
     required this.image,
     required this.isTransformed,
     required this.layers,
+    this.filterStates = const [],
+    this.tuneAdjustments = const [],
+    this.capturedLayers = const [],
     this.videoClips = const [],
     this.customAudioTrack,
   });
@@ -133,6 +139,25 @@ class CompleteParameters {
   /// rendered on top of the video during export.
   final List<Layer> layers;
 
+  /// The active filter states with their timeline metadata.
+  ///
+  /// Each [FilterState] contains the filter matrices and optional
+  /// video-timeline metadata (startTime, endTime, enter/exit transitions).
+  final List<FilterState> filterStates;
+
+  /// The active tune adjustments with their timeline metadata.
+  ///
+  /// Each [TuneAdjustmentMatrix] contains the adjustment matrix and optional
+  /// video-timeline metadata (startTime, endTime, enter/exit transitions).
+  final List<TuneAdjustmentMatrix> tuneAdjustments;
+
+  /// The captured layer images, if [MainEditorConfigs.captureLayersOnDone]
+  /// was enabled.
+  ///
+  /// Each [ExportedLayer] contains the layer metadata, its rendered image
+  /// bytes, and its logical size.
+  final List<ExportedLayer> capturedLayers;
+
   /// The list of video clips currently included in the editor timeline.
   ///
   /// Each [VideoClip] represents a segment of video with its own
@@ -151,6 +176,9 @@ class CompleteParameters {
     double? blur,
     List<List<double>>? matrixFilterList,
     List<List<double>>? matrixTuneAdjustmentsList,
+    List<FilterState>? filterStates,
+    List<TuneAdjustmentMatrix>? tuneAdjustments,
+    List<ExportedLayer>? capturedLayers,
     Duration? startTime,
     Duration? endTime,
     int? cropWidth,
@@ -171,6 +199,9 @@ class CompleteParameters {
       matrixFilterList: matrixFilterList ?? this.matrixFilterList,
       matrixTuneAdjustmentsList:
           matrixTuneAdjustmentsList ?? this.matrixTuneAdjustmentsList,
+      filterStates: filterStates ?? this.filterStates,
+      tuneAdjustments: tuneAdjustments ?? this.tuneAdjustments,
+      capturedLayers: capturedLayers ?? this.capturedLayers,
       startTime: startTime ?? this.startTime,
       endTime: endTime ?? this.endTime,
       cropWidth: cropWidth ?? this.cropWidth,

--- a/lib/core/models/editor_configs/main_editor_configs.dart
+++ b/lib/core/models/editor_configs/main_editor_configs.dart
@@ -44,6 +44,7 @@ class MainEditorConfigs extends ZoomConfigs {
       // SubEditorMode.sticker,
     ],
     this.enableSubEditorPage = false,
+    this.captureLayersOnDone = false,
     this.style = const MainEditorStyle(),
     this.icons = const MainEditorIcons(),
     this.widgets = const MainEditorWidgets(),
@@ -98,6 +99,13 @@ class MainEditorConfigs extends ZoomConfigs {
   /// Defines the safe area configuration for the editor.
   final EditorSafeArea safeArea;
 
+  /// Whether to capture all active layers as images when [doneEditing] is
+  /// called and include them in [CompleteParameters.capturedLayers].
+  ///
+  /// Defaults to `false`. Enable this when you need individual layer images
+  /// for further processing (e.g. video rendering).
+  final bool captureLayersOnDone;
+
   /// Whether to use the sub-editor page without pushing a new route.
   final bool enableSubEditorPage;
 
@@ -151,9 +159,11 @@ class MainEditorConfigs extends ZoomConfigs {
     EditorSafeArea? safeArea,
     List<SubEditorMode>? tools,
     bool? enableSubEditorPage,
+    bool? captureLayersOnDone,
   }) {
     return MainEditorConfigs(
       enableSubEditorPage: enableSubEditorPage ?? this.enableSubEditorPage,
+      captureLayersOnDone: captureLayersOnDone ?? this.captureLayersOnDone,
       enableCloseButton: enableCloseButton ?? this.enableCloseButton,
       enableKeyboardShortcuts:
           enableKeyboardShortcuts ?? this.enableKeyboardShortcuts,

--- a/lib/core/models/editor_configs/video/layer_timeline_configs.dart
+++ b/lib/core/models/editor_configs/video/layer_timeline_configs.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/widgets.dart';
+
+/// Signature for a builder that wraps a layer widget with an animated
+/// transition driven by [animation].
+///
+/// The [child] is the layer widget, and [animation] progresses from 0 → 1
+/// when the layer enters and 1 → 0 when it exits.
+typedef LayerTimelineTransitionBuilder =
+    Widget Function(Widget child, Animation<double> animation);
+
+/// Configuration for how layers with [Layer.startTime] / [Layer.endTime]
+/// are shown and hidden on the video timeline.
+///
+/// The per-layer [Layer.enterDuration] and [Layer.exitDuration] represent
+/// durations in **video time**, not real time. For example, if
+/// `enterDuration` is 2 s and the layer starts at 3 s, the transition runs
+/// from 3 s → 5 s of video playback. Seeking to 4 s will show the animation
+/// at 50 %.
+///
+/// Only evaluated when the video editor is active. In image-editor mode this
+/// config is entirely ignored to avoid any performance overhead.
+class LayerTimelineConfigs {
+  /// Creates a [LayerTimelineConfigs] instance.
+  const LayerTimelineConfigs({
+    this.enterCurve = Curves.easeIn,
+    this.exitCurve = Curves.easeOut,
+    this.transitionBuilder = defaultFadeTransition,
+  });
+
+  /// The curve applied to the fade-in animation.
+  final Curve enterCurve;
+
+  /// The curve applied to the fade-out animation.
+  final Curve exitCurve;
+
+  /// A builder that wraps the layer widget with an animated transition.
+  ///
+  /// Defaults to a simple [FadeTransition].
+  final LayerTimelineTransitionBuilder transitionBuilder;
+
+  /// The default transition – a simple fade.
+  static Widget defaultFadeTransition(
+    Widget child,
+    Animation<double> animation,
+  ) {
+    return FadeTransition(opacity: animation, child: child);
+  }
+
+  /// Creates a copy with the given values overridden.
+  LayerTimelineConfigs copyWith({
+    Curve? enterCurve,
+    Curve? exitCurve,
+    LayerTimelineTransitionBuilder? transitionBuilder,
+  }) {
+    return LayerTimelineConfigs(
+      enterCurve: enterCurve ?? this.enterCurve,
+      exitCurve: exitCurve ?? this.exitCurve,
+      transitionBuilder: transitionBuilder ?? this.transitionBuilder,
+    );
+  }
+}

--- a/lib/core/models/editor_configs/video/video_editor_configs.dart
+++ b/lib/core/models/editor_configs/video/video_editor_configs.dart
@@ -3,10 +3,12 @@ import 'package:flutter/widgets.dart';
 import '/core/models/custom_widgets/video_editor_widgets.dart';
 import '/core/models/icons/video_editor_icons.dart';
 import '/core/models/styles/video_editor_style.dart';
+import 'layer_timeline_configs.dart';
 
 export '/core/models/custom_widgets/video_editor_widgets.dart';
 export '/core/models/icons/video_editor_icons.dart';
 export '/core/models/styles/video_editor_style.dart';
+export 'layer_timeline_configs.dart';
 
 /// Configuration settings for the video editor.
 class VideoEditorConfigs {
@@ -36,6 +38,7 @@ class VideoEditorConfigs {
     this.trimBarMinScale = 1,
     this.trimBarMaxScale = 3,
     this.playTimeSmoothingDuration = Duration.zero,
+    this.layerTimeline = const LayerTimelineConfigs(),
   }) : assert(trimBarMinScale > 0, 'trimBarMinScale must be greater than 0'),
        assert(
          trimBarMaxScale > trimBarMinScale,
@@ -121,6 +124,10 @@ class VideoEditorConfigs {
   /// Curve for the animated indicator switch-out effect.
   final Curve animatedIndicatorSwitchOutCurve;
 
+  /// Configuration for how layers with time ranges are animated in/out
+  /// on the video timeline.
+  final LayerTimelineConfigs layerTimeline;
+
   /// Creates a copy of this instance with the given parameters overridden.
   VideoEditorConfigs copyWith({
     VideoEditorIcons? icons,
@@ -143,6 +150,7 @@ class VideoEditorConfigs {
     Duration? animatedIndicatorDuration,
     Curve? animatedIndicatorSwitchInCurve,
     Curve? animatedIndicatorSwitchOutCurve,
+    LayerTimelineConfigs? layerTimeline,
   }) {
     return VideoEditorConfigs(
       icons: icons ?? this.icons,
@@ -172,6 +180,7 @@ class VideoEditorConfigs {
       animatedIndicatorSwitchOutCurve:
           animatedIndicatorSwitchOutCurve ??
           this.animatedIndicatorSwitchOutCurve,
+      layerTimeline: layerTimeline ?? this.layerTimeline,
     );
   }
 
@@ -200,7 +209,8 @@ class VideoEditorConfigs {
         other.animatedIndicatorSwitchInCurve ==
             animatedIndicatorSwitchInCurve &&
         other.animatedIndicatorSwitchOutCurve ==
-            animatedIndicatorSwitchOutCurve;
+            animatedIndicatorSwitchOutCurve &&
+        other.layerTimeline == layerTimeline;
   }
 
   @override
@@ -223,7 +233,8 @@ class VideoEditorConfigs {
         controlsPosition.hashCode ^
         animatedIndicatorDuration.hashCode ^
         animatedIndicatorSwitchInCurve.hashCode ^
-        animatedIndicatorSwitchOutCurve.hashCode;
+        animatedIndicatorSwitchOutCurve.hashCode ^
+        layerTimeline.hashCode;
   }
 }
 

--- a/lib/core/models/history/state_history.dart
+++ b/lib/core/models/history/state_history.dart
@@ -2,7 +2,7 @@
 import 'package:flutter/foundation.dart';
 
 import '/features/crop_rotate_editor/models/transform_configs.dart';
-import '/features/filter_editor/types/filter_matrix.dart';
+import '/features/filter_editor/types/filter_state.dart';
 import '/features/tune_editor/models/tune_adjustment_matrix.dart';
 import '../layers/layer.dart';
 
@@ -29,7 +29,7 @@ class EditorStateHistory {
   final List<Layer> layers;
 
   /// The applied filters.
-  final FilterMatrix filters;
+  final List<FilterState> filters;
 
   /// The applied tune adjustments.
   final List<TuneAdjustmentMatrix> tuneAdjustments;
@@ -47,7 +47,7 @@ class EditorStateHistory {
   EditorStateHistory copyWith({
     double? blur,
     List<Layer>? layers,
-    FilterMatrix? filters,
+    List<FilterState>? filters,
     List<TuneAdjustmentMatrix>? tuneAdjustments,
     TransformConfigs? transformConfigs,
   }) {

--- a/lib/core/models/layers/emoji_layer.dart
+++ b/lib/core/models/layers/emoji_layer.dart
@@ -37,6 +37,13 @@ class EmojiLayer extends Layer {
     super.boxConstraints,
     super.key,
     super.groupId,
+    super.startTime,
+    super.endTime,
+    super.enterDuration,
+    super.exitDuration,
+    super.enterCurve,
+    super.exitCurve,
+    super.transitionBuilder,
   });
 
   /// Factory constructor for creating an EmojiLayer instance from a Layer
@@ -60,6 +67,12 @@ class EmojiLayer extends Layer {
       scale: layer.scale,
       meta: layer.meta,
       groupId: layer.groupId,
+      startTime: layer.startTime,
+      endTime: layer.endTime,
+      enterDuration: layer.enterDuration,
+      exitDuration: layer.exitDuration,
+      enterCurve: layer.enterCurve,
+      exitCurve: layer.exitCurve,
       emoji: map[keyConverter('emoji')],
       boxConstraints: layer.boxConstraints,
     );
@@ -117,6 +130,13 @@ class EmojiLayer extends Layer {
     BoxConstraints? boxConstraints,
     String? id,
     String? groupId,
+    Duration? startTime,
+    Duration? endTime,
+    Duration? enterDuration,
+    Duration? exitDuration,
+    Curve? enterCurve,
+    Curve? exitCurve,
+    LayerTimelineTransitionBuilder? transitionBuilder,
   }) {
     return EmojiLayer(
       emoji: emoji ?? this.emoji,
@@ -130,6 +150,13 @@ class EmojiLayer extends Layer {
       boxConstraints: boxConstraints ?? this.boxConstraints,
       id: id ?? this.id,
       groupId: groupId ?? this.groupId,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      enterDuration: enterDuration ?? this.enterDuration,
+      exitDuration: exitDuration ?? this.exitDuration,
+      enterCurve: enterCurve ?? this.enterCurve,
+      exitCurve: exitCurve ?? this.exitCurve,
+      transitionBuilder: transitionBuilder ?? this.transitionBuilder,
     );
   }
 

--- a/lib/core/models/layers/layer.dart
+++ b/lib/core/models/layers/layer.dart
@@ -9,6 +9,7 @@ import 'package:flutter/rendering.dart';
 
 import '/core/constants/int_constants.dart';
 import '/core/models/editor_configs/image_generation_configs/image_generation_configs.dart';
+import '/core/models/editor_configs/video/layer_timeline_configs.dart';
 import '/shared/extensions/box_constraints_extension.dart';
 import '/shared/extensions/export_bool_extension.dart';
 import '/shared/extensions/num_extension.dart';
@@ -17,6 +18,7 @@ import '/shared/services/import_export/types/widget_loader.dart';
 import '/shared/services/import_export/utils/key_minifier.dart';
 import '/shared/utils/map_utils.dart';
 import '/shared/utils/parser/bool_parser.dart';
+import '/shared/utils/parser/curve_parser.dart';
 import '/shared/utils/parser/double_parser.dart';
 import '/shared/utils/unique_id_generator.dart';
 import '../editor_image.dart';
@@ -27,6 +29,8 @@ import 'paint_layer.dart';
 import 'text_layer.dart';
 import 'widget_layer.dart';
 
+export '/core/models/editor_configs/video/layer_timeline_configs.dart'
+    show LayerTimelineTransitionBuilder;
 export 'emoji_layer.dart';
 export 'paint_layer.dart';
 export 'text_layer.dart';
@@ -47,6 +51,13 @@ class Layer {
     this.meta,
     this.boxConstraints,
     this.groupId,
+    this.startTime,
+    this.endTime,
+    this.enterDuration,
+    this.exitDuration,
+    this.enterCurve,
+    this.exitCurve,
+    this.transitionBuilder,
   }) : key = key ??= GlobalKey(),
        keyInternalSize = GlobalKey(),
        repaintBoundaryKey = GlobalKey(),
@@ -99,6 +110,20 @@ class Layer {
       scale: safeParseDouble(map[keyConverter('scale')], fallback: 1),
       boxConstraints: boxConstraints,
       groupId: map[keyConverter('groupId')],
+      startTime: map[keyConverter('startTime')] != null
+          ? Duration(milliseconds: map[keyConverter('startTime')] as int)
+          : null,
+      endTime: map[keyConverter('endTime')] != null
+          ? Duration(milliseconds: map[keyConverter('endTime')] as int)
+          : null,
+      enterDuration: map[keyConverter('enterDuration')] != null
+          ? Duration(milliseconds: map[keyConverter('enterDuration')] as int)
+          : null,
+      exitDuration: map[keyConverter('exitDuration')] != null
+          ? Duration(milliseconds: map[keyConverter('exitDuration')] as int)
+          : null,
+      enterCurve: parseCurve(map[keyConverter('enterCurve')] as String?),
+      exitCurve: parseCurve(map[keyConverter('exitCurve')] as String?),
     );
 
     /// Determines the layer type from the map and returns the appropriate
@@ -134,6 +159,43 @@ class Layer {
 
   /// Optional group identifier for grouping layers.
   String? groupId;
+
+  /// The time at which this layer becomes visible.
+  ///
+  /// Only used in the video editor. When `null`, the layer is always visible.
+  Duration? startTime;
+
+  /// The time at which this layer stops being visible.
+  ///
+  /// Only used in the video editor. When `null`, the layer is always visible.
+  Duration? endTime;
+
+  /// How long the fade-in animation lasts in **video time**.
+  ///
+  /// The transition starts at [startTime] and finishes at
+  /// `startTime + enterDuration`. When `null`, no fade-in is applied.
+  Duration? enterDuration;
+
+  /// How long the fade-out animation lasts in **video time**.
+  ///
+  /// The transition starts at `endTime - exitDuration` and finishes at
+  /// [endTime]. When `null`, no fade-out is applied.
+  Duration? exitDuration;
+
+  /// The curve applied to the fade-in animation for this layer.
+  ///
+  /// When `null`, falls back to [LayerTimelineConfigs.enterCurve].
+  Curve? enterCurve;
+
+  /// The curve applied to the fade-out animation for this layer.
+  ///
+  /// When `null`, falls back to [LayerTimelineConfigs.exitCurve].
+  Curve? exitCurve;
+
+  /// A builder that wraps this layer with an animated transition.
+  ///
+  /// When `null`, falls back to [LayerTimelineConfigs.transitionBuilder].
+  LayerTimelineTransitionBuilder? transitionBuilder;
 
   /// Global key associated with the Layer instance, used for accessing the
   /// widget tree.
@@ -223,6 +285,12 @@ class Layer {
           maxDecimalPlaces: maxDecimalPlaces,
         ),
       if (groupId != null) 'groupId': groupId,
+      if (startTime != null) 'startTime': startTime!.inMilliseconds,
+      if (endTime != null) 'endTime': endTime!.inMilliseconds,
+      if (enterDuration != null) 'enterDuration': enterDuration!.inMilliseconds,
+      if (exitDuration != null) 'exitDuration': exitDuration!.inMilliseconds,
+      if (enterCurve != null) 'enterCurve': curveToString(enterCurve!),
+      if (exitCurve != null) 'exitCurve': curveToString(exitCurve!),
     };
   }
 
@@ -258,6 +326,15 @@ class Layer {
           maxDecimalPlaces: maxDecimalPlaces,
         ),
       if (layer.groupId != groupId) 'groupId': groupId,
+      if (layer.startTime != startTime) 'startTime': startTime?.inMilliseconds,
+      if (layer.endTime != endTime) 'endTime': endTime?.inMilliseconds,
+      if (layer.enterDuration != enterDuration)
+        'enterDuration': enterDuration?.inMilliseconds,
+      if (layer.exitDuration != exitDuration)
+        'exitDuration': exitDuration?.inMilliseconds,
+      if (layer.enterCurve != enterCurve)
+        'enterCurve': curveToString(enterCurve!),
+      if (layer.exitCurve != exitCurve) 'exitCurve': curveToString(exitCurve!),
     };
   }
 
@@ -527,6 +604,13 @@ class Layer {
         other.interaction == interaction &&
         other.boxConstraints == boxConstraints &&
         other.groupId == groupId &&
+        other.startTime == startTime &&
+        other.endTime == endTime &&
+        other.enterDuration == enterDuration &&
+        other.exitDuration == exitDuration &&
+        other.enterCurve == enterCurve &&
+        other.exitCurve == exitCurve &&
+        other.transitionBuilder == transitionBuilder &&
         mapIsEqual(other.meta, meta);
   }
 
@@ -541,7 +625,14 @@ class Layer {
         interaction.hashCode ^
         boxConstraints.hashCode ^
         meta.hashCode ^
-        groupId.hashCode;
+        groupId.hashCode ^
+        startTime.hashCode ^
+        endTime.hashCode ^
+        enterDuration.hashCode ^
+        exitDuration.hashCode ^
+        enterCurve.hashCode ^
+        exitCurve.hashCode ^
+        transitionBuilder.hashCode;
   }
 
   /// Creates a copy of this [Layer] with the given fields replaced with
@@ -557,6 +648,13 @@ class Layer {
     LayerInteraction? interaction,
     Map<String, dynamic>? meta,
     BoxConstraints? boxConstraints,
+    Duration? startTime,
+    Duration? endTime,
+    Duration? enterDuration,
+    Duration? exitDuration,
+    Curve? enterCurve,
+    Curve? exitCurve,
+    LayerTimelineTransitionBuilder? transitionBuilder,
   }) {
     return Layer(
       id: id ?? this.id,
@@ -569,6 +667,13 @@ class Layer {
       interaction: interaction ?? this.interaction,
       meta: meta ?? this.meta,
       boxConstraints: boxConstraints ?? this.boxConstraints,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      enterDuration: enterDuration ?? this.enterDuration,
+      exitDuration: exitDuration ?? this.exitDuration,
+      enterCurve: enterCurve ?? this.enterCurve,
+      exitCurve: exitCurve ?? this.exitCurve,
+      transitionBuilder: transitionBuilder ?? this.transitionBuilder,
     );
   }
 
@@ -591,6 +696,18 @@ class Layer {
       ..add(FlagProperty('isEmojiLayer', value: isEmojiLayer, ifTrue: 'true'))
       ..add(FlagProperty('isPaintLayer', value: isPaintLayer, ifTrue: 'true'))
       ..add(FlagProperty('isWidgetLayer', value: isWidgetLayer, ifTrue: 'true'))
-      ..add(FlagProperty('isTextLayer', value: isTextLayer, ifTrue: 'true'));
+      ..add(FlagProperty('isTextLayer', value: isTextLayer, ifTrue: 'true'))
+      ..add(DiagnosticsProperty<Duration>('startTime', startTime))
+      ..add(DiagnosticsProperty<Duration>('endTime', endTime))
+      ..add(DiagnosticsProperty<Duration>('enterDuration', enterDuration))
+      ..add(DiagnosticsProperty<Duration>('exitDuration', exitDuration))
+      ..add(DiagnosticsProperty<Curve>('enterCurve', enterCurve))
+      ..add(DiagnosticsProperty<Curve>('exitCurve', exitCurve))
+      ..add(
+        ObjectFlagProperty<LayerTimelineTransitionBuilder>.has(
+          'transitionBuilder',
+          transitionBuilder,
+        ),
+      );
   }
 }

--- a/lib/core/models/layers/paint_layer.dart
+++ b/lib/core/models/layers/paint_layer.dart
@@ -46,6 +46,13 @@ class PaintLayer extends Layer {
     super.boxConstraints,
     super.key,
     super.groupId,
+    super.startTime,
+    super.endTime,
+    super.enterDuration,
+    super.exitDuration,
+    super.enterCurve,
+    super.exitCurve,
+    super.transitionBuilder,
   });
 
   /// Factory constructor for creating a PaintLayer instance from a
@@ -69,6 +76,10 @@ class PaintLayer extends Layer {
       scale: layer.scale,
       meta: layer.meta,
       groupId: layer.groupId,
+      startTime: layer.startTime,
+      endTime: layer.endTime,
+      enterDuration: layer.enterDuration,
+      exitDuration: layer.exitDuration,
       opacity: safeParseDouble(map[keyConverter('opacity')], fallback: 1.0),
       rawSize: Size(
         safeParseDouble(map[keyConverter('rawSize')]?['w'], fallback: 0),
@@ -164,6 +175,13 @@ class PaintLayer extends Layer {
     BoxConstraints? boxConstraints,
     String? id,
     String? groupId,
+    Duration? startTime,
+    Duration? endTime,
+    Duration? enterDuration,
+    Duration? exitDuration,
+    Curve? enterCurve,
+    Curve? exitCurve,
+    LayerTimelineTransitionBuilder? transitionBuilder,
   }) {
     return PaintLayer(
       item: item ?? this.item,
@@ -179,6 +197,13 @@ class PaintLayer extends Layer {
       meta: meta ?? this.meta,
       boxConstraints: boxConstraints ?? this.boxConstraints,
       groupId: groupId ?? this.groupId,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      enterDuration: enterDuration ?? this.enterDuration,
+      exitDuration: exitDuration ?? this.exitDuration,
+      enterCurve: enterCurve ?? this.enterCurve,
+      exitCurve: exitCurve ?? this.exitCurve,
+      transitionBuilder: transitionBuilder ?? this.transitionBuilder,
     );
   }
 

--- a/lib/core/models/layers/text_layer.dart
+++ b/lib/core/models/layers/text_layer.dart
@@ -47,6 +47,13 @@ class TextLayer extends Layer {
     super.boxConstraints,
     super.key,
     super.groupId,
+    super.startTime,
+    super.endTime,
+    super.enterDuration,
+    super.exitDuration,
+    super.enterCurve,
+    super.exitCurve,
+    super.transitionBuilder,
   });
 
   /// Factory constructor for creating a TextLayer instance from a Layer
@@ -133,6 +140,10 @@ class TextLayer extends Layer {
       meta: layer.meta,
       boxConstraints: layer.boxConstraints,
       groupId: layer.groupId,
+      startTime: layer.startTime,
+      endTime: layer.endTime,
+      enterDuration: layer.enterDuration,
+      exitDuration: layer.exitDuration,
       text: map[keyConverter('text')] ?? '-',
       fontScale: fontScale,
       maxTextWidth: tryParseDouble(map[keyConverter('maxTextWidth')]),
@@ -336,6 +347,13 @@ class TextLayer extends Layer {
     BoxConstraints? boxConstraints,
     String? id,
     String? groupId,
+    Duration? startTime,
+    Duration? endTime,
+    Duration? enterDuration,
+    Duration? exitDuration,
+    Curve? enterCurve,
+    Curve? exitCurve,
+    LayerTimelineTransitionBuilder? transitionBuilder,
   }) {
     return TextLayer(
       text: text ?? this.text,
@@ -358,6 +376,13 @@ class TextLayer extends Layer {
       meta: meta ?? this.meta,
       boxConstraints: boxConstraints ?? this.boxConstraints,
       groupId: groupId ?? this.groupId,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      enterDuration: enterDuration ?? this.enterDuration,
+      exitDuration: exitDuration ?? this.exitDuration,
+      enterCurve: enterCurve ?? this.enterCurve,
+      exitCurve: exitCurve ?? this.exitCurve,
+      transitionBuilder: transitionBuilder ?? this.transitionBuilder,
     );
   }
 

--- a/lib/core/models/layers/widget_layer.dart
+++ b/lib/core/models/layers/widget_layer.dart
@@ -45,6 +45,13 @@ class WidgetLayer extends Layer {
     super.boxConstraints,
     super.key,
     super.groupId,
+    super.startTime,
+    super.endTime,
+    super.enterDuration,
+    super.exitDuration,
+    super.enterCurve,
+    super.exitCurve,
+    super.transitionBuilder,
   });
 
   /// Factory constructor for creating a WidgetLayer instance from a
@@ -128,6 +135,10 @@ class WidgetLayer extends Layer {
       scale: layer.scale,
       meta: layer.meta,
       groupId: layer.groupId,
+      startTime: layer.startTime,
+      endTime: layer.endTime,
+      enterDuration: layer.enterDuration,
+      exitDuration: layer.exitDuration,
       widget: widget,
       width: layerWidth != null ? safeParseDouble(layerWidth) : null,
       exportConfigs: exportConfigs,
@@ -213,6 +224,13 @@ class WidgetLayer extends Layer {
     BoxConstraints? boxConstraints,
     WidgetLayerExportConfigs? exportConfigs,
     String? groupId,
+    Duration? startTime,
+    Duration? endTime,
+    Duration? enterDuration,
+    Duration? exitDuration,
+    Curve? enterCurve,
+    Curve? exitCurve,
+    LayerTimelineTransitionBuilder? transitionBuilder,
   }) {
     return WidgetLayer(
       widget: widget ?? this.widget,
@@ -228,6 +246,13 @@ class WidgetLayer extends Layer {
       groupId: groupId ?? this.groupId,
       meta: meta ?? this.meta,
       boxConstraints: boxConstraints ?? this.boxConstraints,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      enterDuration: enterDuration ?? this.enterDuration,
+      exitDuration: exitDuration ?? this.exitDuration,
+      enterCurve: enterCurve ?? this.enterCurve,
+      exitCurve: exitCurve ?? this.exitCurve,
+      transitionBuilder: transitionBuilder ?? this.transitionBuilder,
     );
   }
 

--- a/lib/designs/whatsapp/widgets/filter/whatsapp_filters.dart
+++ b/lib/designs/whatsapp/widgets/filter/whatsapp_filters.dart
@@ -75,10 +75,12 @@ class WhatsappFilters extends StatelessWidget {
               blurFactor: stateManager.activeBlur,
               configs: editor.configs,
               selectedFilter: activeFilters.isNotEmpty
-                  ? activeFilters
+                  ? activeFilters.allMatrices
                   : emptyFilter,
               onSelectFilter: (filter) {
-                editor.addHistory(filters: filter.filters);
+                editor.addHistory(
+                  filters: [FilterState(matrices: filter.filters)],
+                );
               },
             ),
           ),

--- a/lib/features/filter_editor/filter_editor.dart
+++ b/lib/features/filter_editor/filter_editor.dart
@@ -21,6 +21,7 @@ import 'constants/identity_matrix_constant.dart';
 import 'utils/lerp_color_matrix_utils.dart';
 
 export 'types/filter_matrix.dart';
+export 'types/filter_state.dart';
 export 'utils/filter_generator/filter_addons.dart';
 export 'utils/filter_generator/filter_model.dart';
 export 'utils/filter_generator/filter_presets.dart';

--- a/lib/features/filter_editor/types/filter_state.dart
+++ b/lib/features/filter_editor/types/filter_state.dart
@@ -1,25 +1,33 @@
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 
-import '/core/constants/int_constants.dart';
-import '/shared/extensions/num_extension.dart';
 import '/shared/utils/parser/curve_parser.dart';
-import '/shared/utils/parser/double_parser.dart';
 
-/// A class representing the adjustment matrix for a tune adjustment item.
+import 'filter_matrix.dart';
+
+/// Extension on a list of [FilterState] objects to conveniently access
+/// all combined filter matrices.
+extension FilterStateListExtension on List<FilterState> {
+  /// Returns all [FilterMatrix] entries from every [FilterState] in the list,
+  /// flattened into a single [FilterMatrix].
+  FilterMatrix get allMatrices => expand((f) => f.matrices).toList();
+}
+
+/// Wraps a [FilterMatrix] together with optional video-timeline metadata.
 ///
-/// This class holds the adjustment [id], the [value] of the adjustment, and
-/// the corresponding transformation [matrix] that applies the adjustment.
-class TuneAdjustmentMatrix {
-  /// Creates a [TuneAdjustmentMatrix] instance from a [Map] representation.
-  ///
-  /// This factory constructor extracts [id], [value], and [matrix] from the
-  /// provided [map].
-  factory TuneAdjustmentMatrix.fromMap(Map<String, dynamic> map) {
-    return TuneAdjustmentMatrix(
-      id: map['id']?.toString() ?? '-',
-      value: safeParseDouble(map['value']?.toString()),
-      matrix: (map['matrix'] as List?)?.map(safeParseDouble).toList() ?? [],
+/// When used outside the video editor every timeline field stays `null` and
+/// the filter simply applies unconditionally.
+class FilterState {
+  /// Creates a [FilterState] instance from a [Map] representation.
+  factory FilterState.fromMap(Map<String, dynamic> map) {
+    return FilterState(
+      matrices:
+          (map['matrices'] as List?)
+              ?.map(
+                (e) => (e as List).map((v) => (v as num).toDouble()).toList(),
+              )
+              .toList() ??
+          [],
       startTime: map['startTime'] != null
           ? Duration(milliseconds: map['startTime'] as int)
           : null,
@@ -37,16 +45,9 @@ class TuneAdjustmentMatrix {
     );
   }
 
-  /// Creates a [TuneAdjustmentMatrix] with the given [id], [value], and
-  /// [matrix].
-  ///
-  /// - [id] is the unique identifier for the adjustment.
-  /// - [value] is the adjustment value.
-  /// - [matrix] is a list of doubles representing the matrix transformation.
-  TuneAdjustmentMatrix({
-    required this.id,
-    required this.value,
-    required this.matrix,
+  /// Creates a [FilterState] with the given fields.
+  const FilterState({
+    this.matrices = const [],
     this.startTime,
     this.endTime,
     this.enterDuration,
@@ -55,21 +56,15 @@ class TuneAdjustmentMatrix {
     this.exitCurve,
   });
 
-  /// The unique identifier for the tune adjustment.
-  final String id;
+  /// The color-filter matrices that make up this filter effect.
+  final FilterMatrix matrices;
 
-  /// The value of the tune adjustment.
-  final double value;
-
-  /// The transformation matrix associated with the tune adjustment.
-  final List<double> matrix;
-
-  /// The time at which this adjustment becomes active.
+  /// The time at which this filter becomes active.
   ///
   /// Only used in the video editor. When `null`, always active.
   final Duration? startTime;
 
-  /// The time at which this adjustment becomes inactive.
+  /// The time at which this filter becomes inactive.
   ///
   /// Only used in the video editor. When `null`, always active.
   final Duration? endTime;
@@ -86,16 +81,16 @@ class TuneAdjustmentMatrix {
   /// The curve applied to the exit transition.
   final Curve? exitCurve;
 
-  /// Converts this [TuneAdjustmentMatrix] instance into a [Map] representation.
-  ///
-  /// The map contains the [id], [value], and [matrix] as key-value pairs.
-  Map<String, dynamic> toMap({int maxDecimalPlaces = kMaxSafeDecimalPlaces}) {
+  /// Whether [matrices] contains at least one matrix.
+  bool get isNotEmpty => matrices.isNotEmpty;
+
+  /// Whether [matrices] is empty.
+  bool get isEmpty => matrices.isEmpty;
+
+  /// Converts this instance into a [Map] representation.
+  Map<String, dynamic> toMap() {
     return {
-      'id': id,
-      'value': value.roundSmart(maxDecimalPlaces),
-      'matrix': matrix
-          .map((value) => value.roundSmart(maxDecimalPlaces))
-          .toList(),
+      'matrices': matrices,
       if (startTime != null) 'startTime': startTime!.inMilliseconds,
       if (endTime != null) 'endTime': endTime!.inMilliseconds,
       if (enterDuration != null) 'enterDuration': enterDuration!.inMilliseconds,
@@ -105,15 +100,10 @@ class TuneAdjustmentMatrix {
     };
   }
 
-  /// Creates a copy of this [TuneAdjustmentMatrix] instance with the same
-  /// values.
-  ///
-  /// The [copy] method allows duplicating the matrix with identical properties.
-  TuneAdjustmentMatrix copy() {
-    return TuneAdjustmentMatrix(
-      id: id,
-      value: value,
-      matrix: [...matrix],
+  /// Creates a deep copy of this instance.
+  FilterState copy() {
+    return FilterState(
+      matrices: matrices.map((row) => [...row]).toList(),
       startTime: startTime,
       endTime: endTime,
       enterDuration: enterDuration,
@@ -126,12 +116,14 @@ class TuneAdjustmentMatrix {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
+    if (other is! FilterState) return false;
 
-    return other is TuneAdjustmentMatrix &&
-        other.id == id &&
-        other.value == value &&
-        listEquals(other.matrix, matrix) &&
-        other.startTime == startTime &&
+    if (matrices.length != other.matrices.length) return false;
+    for (var i = 0; i < matrices.length; i++) {
+      if (!listEquals(matrices[i], other.matrices[i])) return false;
+    }
+
+    return other.startTime == startTime &&
         other.endTime == endTime &&
         other.enterDuration == enterDuration &&
         other.exitDuration == exitDuration &&
@@ -141,9 +133,7 @@ class TuneAdjustmentMatrix {
 
   @override
   int get hashCode =>
-      id.hashCode ^
-      value.hashCode ^
-      matrix.hashCode ^
+      matrices.hashCode ^
       startTime.hashCode ^
       endTime.hashCode ^
       enterDuration.hashCode ^

--- a/lib/features/filter_editor/widgets/filter_generator.dart
+++ b/lib/features/filter_editor/widgets/filter_generator.dart
@@ -2,9 +2,13 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
+import '/shared/utils/timeline_progress.dart';
 import '../../tune_editor/models/tune_adjustment_matrix.dart';
+import '../constants/identity_matrix_constant.dart';
 import '../types/filter_matrix.dart';
+import '../types/filter_state.dart';
 import '../utils/combine_color_matrix_utils.dart';
+import '../utils/lerp_color_matrix_utils.dart';
 
 /// A widget for applying color filters to its child widget.
 class ColorFilterGenerator extends StatefulWidget {
@@ -14,6 +18,10 @@ class ColorFilterGenerator extends StatefulWidget {
     required this.filters,
     required this.tuneAdjustments,
     required this.child,
+    this.filterStates,
+    this.playTimeNotifier,
+    this.defaultEnterCurve = Curves.easeIn,
+    this.defaultExitCurve = Curves.easeOut,
   });
 
   /// The matrix of filters to apply.
@@ -24,6 +32,27 @@ class ColorFilterGenerator extends StatefulWidget {
 
   /// The child widget to which the filters are applied.
   final Widget child;
+
+  /// Optional timeline-aware filter states for the video editor.
+  ///
+  /// When provided together with [playTimeNotifier], each [FilterState] is
+  /// evaluated against the current video position and lerped with the identity
+  /// matrix during enter/exit transitions.
+  final List<FilterState>? filterStates;
+
+  /// Notifier that provides the current video playback position.
+  ///
+  /// When `null`, timeline fields on [filterStates] and [tuneAdjustments] are
+  /// ignored and all matrices are applied unconditionally.
+  final ValueNotifier<Duration>? playTimeNotifier;
+
+  /// Default enter curve used when a [FilterState] or [TuneAdjustmentMatrix]
+  /// does not specify its own.
+  final Curve defaultEnterCurve;
+
+  /// Default exit curve used when a [FilterState] or [TuneAdjustmentMatrix]
+  /// does not specify its own.
+  final Curve defaultExitCurve;
 
   /// Creates the state for the ColorFilterGenerator widget.
   @override
@@ -45,15 +74,33 @@ class ColorFilterGeneratorState extends State<ColorFilterGenerator> {
   void initState() {
     super.initState();
     _recomputeMatrix();
+    widget.playTimeNotifier?.addListener(_onTimeChanged);
   }
 
   @override
   void didUpdateWidget(covariant ColorFilterGenerator oldWidget) {
     super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.playTimeNotifier != widget.playTimeNotifier) {
+      oldWidget.playTimeNotifier?.removeListener(_onTimeChanged);
+      widget.playTimeNotifier?.addListener(_onTimeChanged);
+    }
+
     if (oldWidget.filters.hashCode != widget.filters.hashCode ||
         oldWidget.tuneAdjustments.hashCode != widget.tuneAdjustments.hashCode) {
       _recomputeMatrix();
     }
+  }
+
+  @override
+  void dispose() {
+    widget.playTimeNotifier?.removeListener(_onTimeChanged);
+    super.dispose();
+  }
+
+  void _onTimeChanged() {
+    _recomputeMatrix();
+    setState(() {});
   }
 
   /// Refreshes the filter editor by generating the filtered widget and
@@ -64,12 +111,86 @@ class ColorFilterGeneratorState extends State<ColorFilterGenerator> {
   }
 
   void _recomputeMatrix() {
-    _combinedMatrix = mergeColorMatrices(
-      filterList: widget.filters,
-      tuneAdjustmentList: widget.tuneAdjustments
+    final playTime = widget.playTimeNotifier?.value;
+    final filterStates = widget.filterStates;
+    final hasTimeline = playTime != null && filterStates != null;
+
+    final List<List<double>> effectiveFilters;
+    final List<List<double>> effectiveTunes;
+
+    if (hasTimeline) {
+      effectiveFilters = _resolveFilterStates(filterStates, playTime);
+      effectiveTunes = _resolveTuneAdjustments(
+        widget.tuneAdjustments,
+        playTime,
+      );
+    } else {
+      effectiveFilters = widget.filters;
+      effectiveTunes = widget.tuneAdjustments
           .map((item) => item.matrix)
-          .toList(),
+          .toList();
+    }
+
+    _combinedMatrix = mergeColorMatrices(
+      filterList: effectiveFilters,
+      tuneAdjustmentList: effectiveTunes,
     );
+  }
+
+  List<List<double>> _resolveFilterStates(
+    List<FilterState> states,
+    Duration playTime,
+  ) {
+    final result = <List<double>>[];
+    for (final fs in states) {
+      final progress = computeTimelineProgress(
+        currentTime: playTime,
+        startTime: fs.startTime,
+        endTime: fs.endTime,
+        enterDuration: fs.enterDuration,
+        exitDuration: fs.exitDuration,
+        defaultEnterCurve: widget.defaultEnterCurve,
+        defaultExitCurve: widget.defaultExitCurve,
+        enterCurve: fs.enterCurve,
+        exitCurve: fs.exitCurve,
+      );
+      if (progress <= 0.0) continue;
+      for (final matrix in fs.matrices) {
+        if (progress >= 1.0) {
+          result.add(matrix);
+        } else {
+          result.add(lerpColorMatrix(identityMatrix, matrix, progress));
+        }
+      }
+    }
+    return result;
+  }
+
+  List<List<double>> _resolveTuneAdjustments(
+    List<TuneAdjustmentMatrix> tunes,
+    Duration playTime,
+  ) {
+    final result = <List<double>>[];
+    for (final tune in tunes) {
+      final progress = computeTimelineProgress(
+        currentTime: playTime,
+        startTime: tune.startTime,
+        endTime: tune.endTime,
+        enterDuration: tune.enterDuration,
+        exitDuration: tune.exitDuration,
+        defaultEnterCurve: widget.defaultEnterCurve,
+        defaultExitCurve: widget.defaultExitCurve,
+        enterCurve: tune.enterCurve,
+        exitCurve: tune.exitCurve,
+      );
+      if (progress <= 0.0) continue;
+      if (progress >= 1.0) {
+        result.add(tune.matrix);
+      } else {
+        result.add(lerpColorMatrix(identityMatrix, tune.matrix, progress));
+      }
+    }
+    return result;
   }
 
   @override

--- a/lib/features/filter_editor/widgets/filtered_widget.dart
+++ b/lib/features/filter_editor/widgets/filtered_widget.dart
@@ -11,6 +11,7 @@ import '/core/models/editor_image.dart';
 import '/shared/widgets/auto_image.dart';
 import '../../tune_editor/models/tune_adjustment_matrix.dart';
 import '../types/filter_matrix.dart';
+import '../types/filter_state.dart';
 import 'filter_generator.dart';
 
 /// Represents an image where filters and blur factors can be applied.
@@ -30,6 +31,8 @@ class FilteredWidget extends StatelessWidget {
     this.blankSize,
     this.videoPlayer,
     this.enableCachedSize = false,
+    this.filterStates,
+    this.playTimeNotifier,
   }) : assert(
          image != null || videoPlayer != null || blankSize != null,
          'Image or videoPlayer or blankSize cannot be null',
@@ -76,6 +79,12 @@ class FilteredWidget extends StatelessWidget {
   /// size.
   final bool enableCachedSize;
 
+  /// Optional timeline-aware filter states for the video editor.
+  final List<FilterState>? filterStates;
+
+  /// Notifier that provides the current video playback position.
+  final ValueNotifier<Duration>? playTimeNotifier;
+
   @override
   Widget build(BuildContext context) {
     return SizedBox(
@@ -90,6 +99,8 @@ class FilteredWidget extends StatelessWidget {
             key: filterKey,
             filters: filters,
             tuneAdjustments: tuneAdjustments,
+            filterStates: filterStates,
+            playTimeNotifier: playTimeNotifier,
             child: _buildContent(),
           ),
           if (blurFactor > 0) _buildBlur(),

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -615,7 +615,6 @@ class ProImageEditorState extends State<ProImageEditor>
           ),
           blur: 0,
           layers: [],
-          filters: [],
           tuneAdjustments: [],
         ),
       );
@@ -733,7 +732,7 @@ class ProImageEditorState extends State<ProImageEditor>
     List<Layer>? layers,
     Layer? newLayer,
     TransformConfigs? transformConfigs,
-    FilterMatrix? filters,
+    List<FilterState>? filters,
     List<TuneAdjustmentMatrix>? tuneAdjustments,
     double? blur,
     bool heroScreenshotRequired = false,
@@ -750,7 +749,7 @@ class ProImageEditorState extends State<ProImageEditor>
             (newLayer != null
                 ? [...activeLayerList, newLayer]
                 : activeLayerList),
-        filters: filters ?? [],
+        filters: filters ?? const [],
         tuneAdjustments: tuneAdjustments ?? [],
       ),
       historyLimit: stateHistoryConfigs.stateHistoryLimit,
@@ -802,6 +801,38 @@ class ProImageEditorState extends State<ProImageEditor>
         ..insert(index, layer),
     );
 
+    _controllers.uiLayerCtrl.add(null);
+  }
+
+  /// Updates the [startTime] and/or [endTime] of the layer at the given
+  /// [index] and records the change in the state history.
+  ///
+  /// Both [startTime] and [endTime] are optional. Only non-null values are
+  /// applied. This is primarily used by the video editor to define when a
+  /// layer is visible on the timeline.
+  void setLayerTimeline({
+    required int index,
+    Duration? startTime,
+    Duration? endTime,
+    Duration? enterDuration,
+    Duration? exitDuration,
+    Curve? enterCurve,
+    Curve? exitCurve,
+    LayerTimelineTransitionBuilder? transitionBuilder,
+    Map<String, dynamic>? meta,
+  }) {
+    final layers = _layerCopyManager.copyLayerList(activeLayers);
+    final layer = layers[index];
+    if (startTime != null) layer.startTime = startTime;
+    if (endTime != null) layer.endTime = endTime;
+    if (enterDuration != null) layer.enterDuration = enterDuration;
+    if (exitDuration != null) layer.exitDuration = exitDuration;
+    if (enterCurve != null) layer.enterCurve = enterCurve;
+    if (exitCurve != null) layer.exitCurve = exitCurve;
+    if (transitionBuilder != null) layer.transitionBuilder = transitionBuilder;
+    if (meta != null) layer.meta = {...layer.meta ?? {}, ...meta};
+
+    addHistory(layers: layers);
     _controllers.uiLayerCtrl.add(null);
   }
 
@@ -965,7 +996,6 @@ class ProImageEditorState extends State<ProImageEditor>
         transformConfigs: transformSetup.transformConfigs,
         blur: 0,
         layers: [],
-        filters: [],
         tuneAdjustments: [],
       ),
     );
@@ -1662,7 +1692,7 @@ class ProImageEditorState extends State<ProImageEditor>
           mainBodySize: sizesManager.bodySize,
           transformConfigs: stateManager.transformConfigs,
           appliedBlurFactor: stateManager.activeBlur,
-          appliedFilters: stateManager.activeFilters,
+          appliedFilters: stateManager.activeFilters.allMatrices,
           appliedTuneAdjustments: stateManager.activeTuneAdjustments,
           initialZoomMatrix: interactiveViewer.currentState?.transformMatrix4,
         ),
@@ -1796,7 +1826,7 @@ class ProImageEditorState extends State<ProImageEditor>
           mainBodySize: sizesManager.bodySize,
           enableFakeHero: true,
           appliedBlurFactor: stateManager.activeBlur,
-          appliedFilters: stateManager.activeFilters,
+          appliedFilters: stateManager.activeFilters.allMatrices,
           appliedTuneAdjustments: stateManager.activeTuneAdjustments,
           onDone: (transformConfigs, fitToScreenFactor, imageInfos) async {
             List<Layer> updatedLayers = LayerTransformGenerator(
@@ -1864,7 +1894,7 @@ class ProImageEditorState extends State<ProImageEditor>
             mainBodySize: sizesManager.bodySize,
             convertToUint8List: false,
             appliedBlurFactor: stateManager.activeBlur,
-            appliedFilters: stateManager.activeFilters,
+            appliedFilters: stateManager.activeFilters.allMatrices,
             appliedTuneAdjustments: stateManager.activeTuneAdjustments,
           ),
         ),
@@ -1908,7 +1938,7 @@ class ProImageEditorState extends State<ProImageEditor>
           mainBodySize: sizesManager.bodySize,
           convertToUint8List: false,
           appliedBlurFactor: stateManager.activeBlur,
-          appliedFilters: stateManager.activeFilters,
+          appliedFilters: stateManager.activeFilters.allMatrices,
           appliedTuneAdjustments: stateManager.activeTuneAdjustments,
         ),
       ),
@@ -1916,7 +1946,10 @@ class ProImageEditorState extends State<ProImageEditor>
 
     if (filters == null) return;
 
-    addHistory(filters: filters, heroScreenshotRequired: true);
+    addHistory(
+      filters: [FilterState(matrices: filters)],
+      heroScreenshotRequired: true,
+    );
 
     setState(() {});
     mainEditorCallbacks?.handleUpdateUI();
@@ -1942,7 +1975,7 @@ class ProImageEditorState extends State<ProImageEditor>
           transformConfigs: stateManager.transformConfigs,
           convertToUint8List: false,
           appliedBlurFactor: stateManager.activeBlur,
-          appliedFilters: stateManager.activeFilters,
+          appliedFilters: stateManager.activeFilters.allMatrices,
           appliedTuneAdjustments: stateManager.activeTuneAdjustments,
         ),
       ),
@@ -2357,6 +2390,10 @@ class ProImageEditorState extends State<ProImageEditor>
         Uint8List? bytes = await captureEditorImage();
         await onImageEditingComplete?.call(bytes);
 
+        final capturedLayers = mainEditorConfigs.captureLayersOnDone
+            ? await captureAllLayersWithMeta()
+            : <ExportedLayer>[];
+
         final transform = stateManager.transformConfigs;
         final isTransformed = transform.isNotEmpty;
 
@@ -2367,7 +2404,9 @@ class ProImageEditorState extends State<ProImageEditor>
         await onCompleteWithParameters?.call(
           CompleteParameters(
             blur: stateManager.activeBlur,
-            matrixFilterList: stateManager.activeFilters,
+            matrixFilterList: stateManager.activeFilters.allMatrices,
+            filterStates: stateManager.activeFilters,
+            tuneAdjustments: stateManager.activeTuneAdjustments,
             matrixTuneAdjustmentsList: stateManager.activeTuneAdjustments
                 .map((item) => item.matrix)
                 .toList(),
@@ -2383,6 +2422,7 @@ class ProImageEditorState extends State<ProImageEditor>
             image: bytes,
             isTransformed: isTransformed,
             layers: activeLayers,
+            capturedLayers: capturedLayers,
             customAudioTrack: _videoController?.audioTrack,
             videoClips: _videoController?.clips ?? [],
           ),
@@ -3073,6 +3113,7 @@ class ProImageEditorState extends State<ProImageEditor>
       state: this,
       dragSelectionService: _layerDragSelectionService,
       mouseService: _mouseService,
+      playTimeNotifier: _videoController?.playTimeNotifier,
       onContextMenuToggled: (isOpen) {
         _isContextMenuOpen = isOpen;
       },
@@ -3149,6 +3190,7 @@ class ProImageEditorState extends State<ProImageEditor>
       sizesManager: sizesManager,
       stateManager: stateManager,
       videoPlayer: _videoController!.videoPlayer,
+      playTimeNotifier: _videoController?.playTimeNotifier,
     );
   }
 }

--- a/lib/features/main_editor/services/layer_copy_manager.dart
+++ b/lib/features/main_editor/services/layer_copy_manager.dart
@@ -134,6 +134,13 @@ class LayerCopyManager {
       customSecondaryColor: layer.customSecondaryColor,
       interaction: layer.interaction.copyWith(),
       boxConstraints: layer.boxConstraints?.copyWith(),
+      startTime: layer.startTime,
+      endTime: layer.endTime,
+      enterDuration: layer.enterDuration,
+      exitDuration: layer.exitDuration,
+      enterCurve: layer.enterCurve,
+      exitCurve: layer.exitCurve,
+      transitionBuilder: layer.transitionBuilder,
     )..groupId = layer.groupId;
   }
 
@@ -156,6 +163,13 @@ class LayerCopyManager {
       meta: layer.meta,
       interaction: layer.interaction.copyWith(),
       boxConstraints: layer.boxConstraints?.copyWith(),
+      startTime: layer.startTime,
+      endTime: layer.endTime,
+      enterDuration: layer.enterDuration,
+      exitDuration: layer.exitDuration,
+      enterCurve: layer.enterCurve,
+      exitCurve: layer.exitCurve,
+      transitionBuilder: layer.transitionBuilder,
     )..groupId = layer.groupId;
   }
 
@@ -180,6 +194,13 @@ class LayerCopyManager {
       interaction: layer.interaction.copyWith(),
       boxConstraints: layer.boxConstraints?.copyWith(),
       exportConfigs: layer.exportConfigs.copyWith(),
+      startTime: layer.startTime,
+      endTime: layer.endTime,
+      enterDuration: layer.enterDuration,
+      exitDuration: layer.exitDuration,
+      enterCurve: layer.enterCurve,
+      exitCurve: layer.exitCurve,
+      transitionBuilder: layer.transitionBuilder,
     )..groupId = layer.groupId;
   }
 
@@ -204,6 +225,13 @@ class LayerCopyManager {
       opacity: layer.opacity,
       interaction: layer.interaction.copyWith(),
       boxConstraints: layer.boxConstraints?.copyWith(),
+      startTime: layer.startTime,
+      endTime: layer.endTime,
+      enterDuration: layer.enterDuration,
+      exitDuration: layer.exitDuration,
+      enterCurve: layer.enterCurve,
+      exitCurve: layer.exitCurve,
+      transitionBuilder: layer.transitionBuilder,
     )..groupId = layer.groupId;
   }
 }

--- a/lib/features/main_editor/services/main_editor_state_history_service.dart
+++ b/lib/features/main_editor/services/main_editor_state_history_service.dart
@@ -167,7 +167,6 @@ class MainEditorStateHistoryService {
           EditorStateHistory(
             transformConfigs: TransformConfigs.empty(),
             blur: 0,
-            filters: [],
             layers: [],
             tuneAdjustments: [],
           ),

--- a/lib/features/main_editor/services/state_manager.dart
+++ b/lib/features/main_editor/services/state_manager.dart
@@ -2,7 +2,7 @@ import '/core/models/editor_image.dart';
 import '/core/models/history/state_history.dart';
 import '/core/models/layers/layer.dart';
 import '/core/models/multi_threading/thread_capture_model.dart';
-import '/features/filter_editor/types/filter_matrix.dart';
+import '/features/filter_editor/types/filter_state.dart';
 import '/features/tune_editor/models/tune_adjustment_matrix.dart';
 import '../../crop_rotate_editor/models/transform_configs.dart';
 
@@ -106,8 +106,6 @@ class StateManager {
   void updateActiveItems() {
     var activeHistory = _stateHistory.getRange(0, _historyPointer + 1);
 
-    _activeFilters = [];
-
     _activeFilters = activeHistory
         .lastWhere(
           (item) => item.filters.isNotEmpty,
@@ -149,14 +147,14 @@ class StateManager {
     }
   }
 
-  /// A list of active filters applied to the image.
-  /// This stores instances of `FilterMatrix`, representing various filter
-  /// adjustments.
-  FilterMatrix _activeFilters = [];
+  /// The active filter states applied to the image.
+  /// Each [FilterState] contains filter matrices and optional
+  /// video-timeline metadata.
+  List<FilterState> _activeFilters = const [];
 
-  /// A getter that returns the list of currently applied filters.
-  /// Use this to retrieve the active `FilterMatrix` configurations.
-  FilterMatrix get activeFilters => _activeFilters;
+  /// A getter that returns the currently applied filter states.
+  /// Use this to retrieve the active list of [FilterState].
+  List<FilterState> get activeFilters => _activeFilters;
 
   /// A list of active tune adjustments for the image, such as brightness,
   /// contrast, etc.

--- a/lib/features/main_editor/widgets/main_editor_background_image.dart
+++ b/lib/features/main_editor/widgets/main_editor_background_image.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/editor_image.dart';
+import '/features/filter_editor/types/filter_state.dart';
 import '/features/filter_editor/widgets/filter_generator.dart';
 import '/shared/widgets/auto_image.dart';
 import '/shared/widgets/transform/transformed_content_generator.dart';
@@ -82,7 +83,7 @@ class MainEditorBackgroundImage extends StatelessWidget {
                 configs: configs,
                 image: editorImage,
                 blankSize: blankSize,
-                filters: stateManager.activeFilters,
+                filters: stateManager.activeFilters.allMatrices,
                 tuneAdjustments: stateManager.activeTuneAdjustments,
                 blurFactor: stateManager.activeBlur,
               ),
@@ -112,7 +113,10 @@ class MainEditorBackgroundImage extends StatelessWidget {
         ),
       )
       ..add(
-        IntProperty('activeFiltersCount', stateManager.activeFilters.length),
+        IntProperty(
+          'activeFiltersCount',
+          stateManager.activeFilters.allMatrices.length,
+        ),
       )
       ..add(
         IntProperty(

--- a/lib/features/main_editor/widgets/main_editor_background_video.dart
+++ b/lib/features/main_editor/widgets/main_editor_background_video.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
+import '/features/filter_editor/types/filter_state.dart';
 import '/features/filter_editor/widgets/filter_generator.dart';
 import '/shared/widgets/transform/transformed_content_generator.dart';
 import '../../filter_editor/widgets/filtered_widget.dart';
@@ -28,6 +29,7 @@ class MainEditorBackgroundVideo extends StatelessWidget {
     required this.backgroundImageColorFilterKey,
     required this.isInitialized,
     required this.videoPlayer,
+    this.playTimeNotifier,
   });
 
   /// Manages the state of the editor.
@@ -48,6 +50,9 @@ class MainEditorBackgroundVideo extends StatelessWidget {
   /// The video player widget to display in the background.
   final Widget videoPlayer;
 
+  /// Notifier that provides the current video playback position.
+  final ValueNotifier<Duration>? playTimeNotifier;
+
   @override
   Widget build(BuildContext context) {
     return Hero(
@@ -64,10 +69,12 @@ class MainEditorBackgroundVideo extends StatelessWidget {
                 width: sizesManager.decodedImageSize.width,
                 height: sizesManager.decodedImageSize.height,
                 configs: configs,
-                filters: stateManager.activeFilters,
+                filters: stateManager.activeFilters.allMatrices,
                 tuneAdjustments: stateManager.activeTuneAdjustments,
                 blurFactor: stateManager.activeBlur,
                 videoPlayer: videoPlayer,
+                filterStates: stateManager.activeFilters,
+                playTimeNotifier: playTimeNotifier,
               ),
             ),
     );

--- a/lib/features/main_editor/widgets/main_editor_layers.dart
+++ b/lib/features/main_editor/widgets/main_editor_layers.dart
@@ -37,6 +37,7 @@ class MainEditorLayers extends StatefulWidget {
     required this.onDuplicateLayer,
     required this.mouseService,
     required this.dragSelectionService,
+    this.playTimeNotifier,
   });
 
   /// Represents the current state of the editor.
@@ -86,6 +87,12 @@ class MainEditorLayers extends StatefulWidget {
 
   /// Callback triggered when the context menu is toggled.
   final Function(bool isOpen)? onContextMenuToggled;
+
+  /// Notifier providing the current video playback position.
+  ///
+  /// When non-null, layers with [Layer.startTime] / [Layer.endTime] are
+  /// animated in/out based on the current time.
+  final ValueNotifier<Duration>? playTimeNotifier;
 
   @override
   State<MainEditorLayers> createState() => _MainEditorLayersState();
@@ -187,6 +194,7 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
       enableMouseCursor: !widget.dragSelectionService.isActive,
       onDuplicate: () => widget.onDuplicateLayer(layer),
       onContextMenuToggled: widget.onContextMenuToggled,
+      playTimeNotifier: widget.playTimeNotifier,
     );
   }
 }

--- a/lib/shared/services/import_export/constants/export_import_version.dart
+++ b/lib/shared/services/import_export/constants/export_import_version.dart
@@ -44,8 +44,13 @@ class ExportImportVersion {
   /// editor version >= `11.1.0`.
   static const version_6_4_0 = '6.4.0';
 
+  /// The version string representing version `6.5.0` which adds timeline
+  /// fields (startTime, endTime, enter/exit duration & curve) to filters,
+  /// tune adjustments and layers.
+  static const version_6_5_0 = '6.5.0';
+
   /// Represents the latest version of the export/import functionality.
-  static const latest = ExportImportVersion.version_6_4_0;
+  static const latest = ExportImportVersion.version_6_5_0;
 }
 
 /// An extension on the `String` class that provides functionality

--- a/lib/shared/services/import_export/constants/minified_keys.dart
+++ b/lib/shared/services/import_export/constants/minified_keys.dart
@@ -58,6 +58,12 @@ const Map<String, String> kMinifiedLayerKeys = {
   'boxConstraints': 'bx',
   'maxTextWidth': 'mt',
   'shadows': 'sh',
+  'startTime': 'st',
+  'endTime': 'et',
+  'enterDuration': 'ed',
+  'exitDuration': 'xd',
+  'enterCurve': 'ev',
+  'exitCurve': 'xv',
 
   /// Only in version < 8.0.0
   'enableInteraction': 'ei',

--- a/lib/shared/services/import_export/export_state_history.dart
+++ b/lib/shared/services/import_export/export_state_history.dart
@@ -10,7 +10,7 @@ import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/history/state_history.dart';
 import '/core/models/layers/layer.dart';
 import '/core/platform/io/io_helper.dart';
-import '/features/filter_editor/types/filter_matrix.dart';
+import '/features/filter_editor/types/filter_state.dart';
 import '/features/tune_editor/models/tune_adjustment_matrix.dart';
 import '/shared/extensions/export_string_extension.dart';
 import '/shared/extensions/num_extension.dart';
@@ -138,13 +138,13 @@ class ExportStateHistory {
 
     /// Helper function to collect history states up to a given position.
     EditorStateHistory accumulateHistory(int position) {
-      FilterMatrix filters = [];
+      List<FilterState> filters = [];
       List<TuneAdjustmentMatrix> tuneAdjustments = [];
       double? blur;
       TransformConfigs? transformConfigs;
 
       for (var item in changes.getRange(0, position)) {
-        if (item.filters.isNotEmpty) filters.addAll(item.filters);
+        if (item.filters.isNotEmpty) filters = item.filters;
         if (item.blur != null) blur = item.blur;
         if (item.tuneAdjustments.isNotEmpty) {
           tuneAdjustments = item.tuneAdjustments;
@@ -221,11 +221,7 @@ class ExportStateHistory {
         if (layers.isNotEmpty) 'layers'.toHistoryKey(minifier): layers,
         if (enableFilterExport)
           'filters'.toHistoryKey(minifier): element.filters
-              .map(
-                (item) => item
-                    .map((value) => value.roundSmart(maxDecimalPlaces))
-                    .toList(),
-              )
+              .map((f) => f.toMap())
               .toList(),
         if (enableTuneExport)
           'tune'.toHistoryKey(minifier): element.tuneAdjustments

--- a/lib/shared/services/import_export/import_state_history.dart
+++ b/lib/shared/services/import_export/import_state_history.dart
@@ -11,6 +11,7 @@ import '/core/models/layers/layer.dart';
 import '/core/platform/io/io_helper.dart';
 import '/features/crop_rotate_editor/models/transform_configs.dart';
 import '/features/filter_editor/constants/identity_matrix_constant.dart';
+import '/features/filter_editor/types/filter_state.dart';
 import '/features/filter_editor/utils/lerp_color_matrix_utils.dart';
 import '/features/tune_editor/models/tune_adjustment_matrix.dart';
 import '../../utils/parser/double_parser.dart';
@@ -150,7 +151,7 @@ class ImportStateHistory {
           : null;
 
       /// Filters
-      final filters = parseFilters(historyItem[filtersKey], version);
+      final filters = parseFilterStates(historyItem[filtersKey], version);
 
       /// Tune Adjustments
       final tuneAdjustments = (historyItem[tuneKey] as List<dynamic>? ?? [])
@@ -186,6 +187,45 @@ class ImportStateHistory {
       version: version,
       requirePrecacheList: requirePrecacheList,
     );
+  }
+
+  /// Parses filter data into a list of [FilterState].
+  ///
+  /// New format (list of Maps each with `matrices` key + optional timeline
+  /// fields) is parsed via [FilterState.fromMap]. Older formats (plain list
+  /// of matrices) are handled by [parseFilters] and wrapped in a single
+  /// [FilterState].
+  @visibleForTesting
+  static List<FilterState> parseFilterStates(
+    dynamic filtersData,
+    String version,
+  ) {
+    if (filtersData == null) return const [];
+
+    // New format: list of FilterState maps
+    if (filtersData is List &&
+        filtersData.isNotEmpty &&
+        filtersData.first is Map) {
+      final firstMap = filtersData.first as Map;
+      if (firstMap.containsKey('matrices')) {
+        return filtersData
+            .map(
+              (e) => FilterState.fromMap(Map<String, dynamic>.from(e as Map)),
+            )
+            .toList();
+      }
+    }
+
+    // Single FilterState map (backward compat with previous format)
+    if (filtersData is Map<String, dynamic> &&
+        filtersData.containsKey('matrices')) {
+      return [FilterState.fromMap(filtersData)];
+    }
+
+    // Old formats: plain list of matrices
+    final matrices = parseFilters(filtersData, version);
+    if (matrices.isEmpty) return const [];
+    return [FilterState(matrices: matrices)];
   }
 
   /// Helper to parse filters

--- a/lib/shared/utils/parser/curve_parser.dart
+++ b/lib/shared/utils/parser/curve_parser.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/animation.dart';
+
+/// A map from curve name strings to Flutter [Curve] constants.
+const Map<String, Curve> _curvesByName = {
+  'linear': Curves.linear,
+  'decelerate': Curves.decelerate,
+  'fastLinearToSlowEaseIn': Curves.fastLinearToSlowEaseIn,
+  'ease': Curves.ease,
+  'easeIn': Curves.easeIn,
+  'easeInToLinear': Curves.easeInToLinear,
+  'easeInSine': Curves.easeInSine,
+  'easeInQuad': Curves.easeInQuad,
+  'easeInCubic': Curves.easeInCubic,
+  'easeInQuart': Curves.easeInQuart,
+  'easeInQuint': Curves.easeInQuint,
+  'easeInExpo': Curves.easeInExpo,
+  'easeInCirc': Curves.easeInCirc,
+  'easeInBack': Curves.easeInBack,
+  'easeOut': Curves.easeOut,
+  'linearToEaseOut': Curves.linearToEaseOut,
+  'easeOutSine': Curves.easeOutSine,
+  'easeOutQuad': Curves.easeOutQuad,
+  'easeOutCubic': Curves.easeOutCubic,
+  'easeOutQuart': Curves.easeOutQuart,
+  'easeOutQuint': Curves.easeOutQuint,
+  'easeOutExpo': Curves.easeOutExpo,
+  'easeOutCirc': Curves.easeOutCirc,
+  'easeOutBack': Curves.easeOutBack,
+  'easeInOut': Curves.easeInOut,
+  'easeInOutSine': Curves.easeInOutSine,
+  'easeInOutQuad': Curves.easeInOutQuad,
+  'easeInOutCubic': Curves.easeInOutCubic,
+  'easeInOutCubicEmphasized': Curves.easeInOutCubicEmphasized,
+  'easeInOutQuart': Curves.easeInOutQuart,
+  'easeInOutQuint': Curves.easeInOutQuint,
+  'easeInOutExpo': Curves.easeInOutExpo,
+  'easeInOutCirc': Curves.easeInOutCirc,
+  'easeInOutBack': Curves.easeInOutBack,
+  'fastOutSlowIn': Curves.fastOutSlowIn,
+  'slowMiddle': Curves.slowMiddle,
+  'bounceIn': Curves.bounceIn,
+  'bounceOut': Curves.bounceOut,
+  'bounceInOut': Curves.bounceInOut,
+  'elasticIn': Curves.elasticIn,
+  'elasticOut': Curves.elasticOut,
+  'elasticInOut': Curves.elasticInOut,
+};
+
+/// Reverse lookup: [Curve] instance → name string.
+final Map<Curve, String> _namesByCurve = {
+  for (final entry in _curvesByName.entries) entry.value: entry.key,
+};
+
+/// Converts a [Curve] constant to its string name.
+///
+/// Returns `null` for custom curves that are not part of [Curves].
+String? curveToString(Curve curve) => _namesByCurve[curve];
+
+/// Parses a [String] name into a [Curve] constant.
+///
+/// Returns `null` if the [name] is not recognised.
+Curve? parseCurve(String? name) => name == null ? null : _curvesByName[name];

--- a/lib/shared/utils/timeline_progress.dart
+++ b/lib/shared/utils/timeline_progress.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/animation.dart';
+
+/// Computes a visibility progress value (0.0 – 1.0) for a timeline item
+/// based on the current video position.
+///
+/// - Before [startTime] → 0.0
+/// - During enter ([startTime] → [startTime] + [enterDuration]) → 0.0…1.0
+/// - Fully visible region → 1.0
+/// - During exit ([endTime] - [exitDuration] → [endTime]) → 1.0…0.0
+/// - After [endTime] → 0.0
+/// - If both [startTime] and [endTime] are `null` → always 1.0
+double computeTimelineProgress({
+  required Duration currentTime,
+  required Duration? startTime,
+  required Duration? endTime,
+  required Duration? enterDuration,
+  required Duration? exitDuration,
+  required Curve defaultEnterCurve,
+  required Curve defaultExitCurve,
+  Curve? enterCurve,
+  Curve? exitCurve,
+}) {
+  if (startTime != null && currentTime < startTime) return 0.0;
+  if (endTime != null && currentTime > endTime) return 0.0;
+
+  if (startTime != null &&
+      enterDuration != null &&
+      enterDuration > Duration.zero) {
+    final fadeInEnd = startTime + enterDuration;
+    if (currentTime < fadeInEnd) {
+      final elapsed = (currentTime - startTime).inMicroseconds;
+      final total = enterDuration.inMicroseconds;
+      final t = (elapsed / total).clamp(0.0, 1.0);
+      return (enterCurve ?? defaultEnterCurve).transform(t);
+    }
+  }
+
+  if (endTime != null && exitDuration != null && exitDuration > Duration.zero) {
+    final fadeOutStart = endTime - exitDuration;
+    if (currentTime > fadeOutStart) {
+      final remaining = (endTime - currentTime).inMicroseconds;
+      final total = exitDuration.inMicroseconds;
+      final t = (remaining / total).clamp(0.0, 1.0);
+      return (exitCurve ?? defaultExitCurve).transform(t);
+    }
+  }
+
+  return 1.0;
+}

--- a/lib/shared/widgets/layer/layer_timeline_visibility.dart
+++ b/lib/shared/widgets/layer/layer_timeline_visibility.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/widgets.dart';
+
+import '/core/models/editor_configs/video/layer_timeline_configs.dart';
+import '/core/models/layers/layer.dart';
+import '/shared/utils/timeline_progress.dart';
+
+/// Controls layer visibility based on [Layer.startTime] / [Layer.endTime]
+/// relative to the current video time.
+///
+/// The animation progress is derived directly from the video position so that
+/// seeking immediately reflects the correct transition state (e.g. seeking to
+/// the middle of a 5 s fade-in shows the layer at 50 %).
+class LayerTimelineVisibility extends StatefulWidget {
+  /// Creates a [LayerTimelineVisibility].
+  const LayerTimelineVisibility({
+    super.key,
+    required this.layer,
+    required this.playTimeNotifier,
+    required this.configs,
+    required this.child,
+  });
+
+  /// The layer whose time range is evaluated.
+  final Layer layer;
+
+  /// Notifier that provides the current video playback position.
+  final ValueNotifier<Duration> playTimeNotifier;
+
+  /// Animation configuration for the enter/exit transition.
+  final LayerTimelineConfigs configs;
+
+  /// The layer widget to show/hide.
+  final Widget child;
+
+  @override
+  State<LayerTimelineVisibility> createState() =>
+      _LayerTimelineVisibilityState();
+}
+
+class _LayerTimelineVisibilityState extends State<LayerTimelineVisibility>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this);
+
+    _controller.value = _computeProgress(widget.playTimeNotifier.value);
+    widget.playTimeNotifier.addListener(_onTimeChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant LayerTimelineVisibility oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.playTimeNotifier != widget.playTimeNotifier) {
+      oldWidget.playTimeNotifier.removeListener(_onTimeChanged);
+      widget.playTimeNotifier.addListener(_onTimeChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.playTimeNotifier.removeListener(_onTimeChanged);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// Computes a curved progress value (0.0 – 1.0) based on [currentTime].
+  double _computeProgress(Duration currentTime) {
+    return computeTimelineProgress(
+      currentTime: currentTime,
+      startTime: widget.layer.startTime,
+      endTime: widget.layer.endTime,
+      enterDuration: widget.layer.enterDuration,
+      exitDuration: widget.layer.exitDuration,
+      defaultEnterCurve: widget.configs.enterCurve,
+      defaultExitCurve: widget.configs.exitCurve,
+      enterCurve: widget.layer.enterCurve,
+      exitCurve: widget.layer.exitCurve,
+    );
+  }
+
+  void _onTimeChanged() {
+    final progress = _computeProgress(widget.playTimeNotifier.value);
+    if (_controller.value != progress) {
+      _controller.value = progress;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        if (_controller.isDismissed) return const SizedBox.shrink();
+        final builder =
+            widget.layer.transitionBuilder ?? widget.configs.transitionBuilder;
+        return builder(child!, _controller);
+      },
+      child: widget.child,
+    );
+  }
+}

--- a/lib/shared/widgets/layer/layer_widget.dart
+++ b/lib/shared/widgets/layer/layer_widget.dart
@@ -24,6 +24,7 @@ import '/shared/widgets/layer/widgets/layer_widget_emoji_item.dart';
 import '/shared/widgets/layer/widgets/layer_widget_paint_item.dart';
 import '/shared/widgets/layer/widgets/layer_widget_text_item.dart';
 import 'interaction_helper/layer_interaction_helper_widget.dart';
+import 'layer_timeline_visibility.dart';
 import 'widgets/layer_widget_custom_item.dart';
 
 /// A widget representing a layer within a design canvas.
@@ -41,6 +42,7 @@ class LayerWidget extends StatefulWidget with SimpleConfigsAccess {
     this.isInteractive = false,
     this.enableMouseCursor = true,
     this.callbacks = const ProImageEditorCallbacks(),
+    this.playTimeNotifier,
   });
   @override
   final ProImageEditorConfigs configs;
@@ -73,6 +75,12 @@ class LayerWidget extends StatefulWidget with SimpleConfigsAccess {
   /// A flag indicating whether the mouse cursor should be enabled for this
   /// widget.
   final bool enableMouseCursor;
+
+  /// Notifier providing the current video playback position.
+  ///
+  /// When non-null and the layer has [Layer.startTime] / [Layer.endTime],
+  /// the layer is animated in/out based on the current time.
+  final ValueNotifier<Duration>? playTimeNotifier;
 
   @override
   createState() => _LayerWidgetState();
@@ -320,24 +328,35 @@ class _LayerWidgetState extends State<LayerWidget>
     final adjustedTop =
         offsetY - overlayPadding.vertical * (_fractionalOffset.dy + 0.5);
 
+    Widget content = FractionalTranslation(
+      translation: _fractionalOffset,
+      child: Hero(
+        // Important that hero is above transform
+        createRectTween: (begin, end) => RectTween(begin: begin, end: end),
+        tag: _layer.id,
+        child: Transform(
+          transform: transformMatrix,
+          alignment: Alignment.center,
+          child: _buildInteractionHandlers(),
+        ),
+      ),
+    );
+
+    final playTime = widget.playTimeNotifier;
+    if (playTime != null &&
+        (_layer.startTime != null || _layer.endTime != null)) {
+      content = LayerTimelineVisibility(
+        layer: _layer,
+        playTimeNotifier: playTime,
+        configs: configs.videoEditor.layerTimeline,
+        child: content,
+      );
+    }
+
     return Positioned(
       left: adjustedLeft,
       top: adjustedTop,
-      child: RepaintBoundary(
-        child: FractionalTranslation(
-          translation: _fractionalOffset,
-          child: Hero(
-            // Important that hero is above transform
-            createRectTween: (begin, end) => RectTween(begin: begin, end: end),
-            tag: _layer.id,
-            child: Transform(
-              transform: transformMatrix,
-              alignment: Alignment.center,
-              child: _buildInteractionHandlers(),
-            ),
-          ),
-        ),
-      ),
+      child: RepaintBoundary(child: content),
     );
   }
 
@@ -362,7 +381,13 @@ class _LayerWidgetState extends State<LayerWidget>
       onDuplicate: widget.onDuplicate,
       onGroupLayers: _layersService?.handleGroupLayers,
       onUngroupLayers: () => _layersService?.handleUngroupLayers(_layer),
-      child: _buildCursor(
+      child: _LayerCursorRegion(
+        showMoveCursor: _showMoveCursor,
+        enableMove: _layer.interaction.enableMove,
+        enableMouseCursor: widget.enableMouseCursor,
+        hoverCursor: layerInteraction.style.hoverCursor,
+        onHoverEnter: _onHoverEnter,
+        onHoverExit: _onHoverLeave,
         child: ValueListenableBuilder(
           valueListenable: _lastHitState,
           builder: (_, _, _) {
@@ -379,7 +404,23 @@ class _LayerWidgetState extends State<LayerWidget>
                       : layerInteraction.style.overlayPadding,
                   child: FittedBox(
                     key: _layer.keyInternalSize,
-                    child: _buildContent(),
+                    child: _LayerContentItem(
+                      layerType: _layerType,
+                      layer: _layer,
+                      isSelected: _isSelected,
+                      enableHitDetection:
+                          _layerInteractionManager?.enabledHitDetection ??
+                          false,
+                      showMoveCursor: _showMoveCursor,
+                      onHitChanged: (state) {
+                        _lastHitState.value = state;
+                      },
+                      emojiEditorConfigs: emojiEditorConfigs,
+                      textEditorConfigs: textEditorConfigs,
+                      stickerEditorConfigs: stickerEditorConfigs,
+                      paintEditorConfigs: paintEditorConfigs,
+                      designMode: designMode,
+                    ),
                   ),
                 ),
               ),
@@ -390,84 +431,126 @@ class _LayerWidgetState extends State<LayerWidget>
     );
   }
 
-  Widget _buildCursor({required Widget child}) {
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    _layer.debugFillProperties(properties);
+  }
+}
+
+class _LayerCursorRegion extends StatelessWidget {
+  const _LayerCursorRegion({
+    required this.showMoveCursor,
+    required this.enableMove,
+    required this.enableMouseCursor,
+    required this.hoverCursor,
+    required this.onHoverEnter,
+    required this.onHoverExit,
+    required this.child,
+  });
+
+  final ValueNotifier<bool> showMoveCursor;
+  final bool enableMove;
+  final bool enableMouseCursor;
+  final MouseCursor hoverCursor;
+  final VoidCallback onHoverEnter;
+  final VoidCallback onHoverExit;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
     return ValueListenableBuilder(
-      valueListenable: _showMoveCursor,
-      builder: (_, showCursor, _) {
+      valueListenable: showMoveCursor,
+      builder: (_, showCursor, child) {
         return MouseRegion(
           hitTestBehavior: HitTestBehavior.translucent,
-          cursor:
-              showCursor &&
-                  _layer.interaction.enableMove &&
-                  widget.enableMouseCursor
-              ? layerInteraction.style.hoverCursor
+          cursor: showCursor && enableMove && enableMouseCursor
+              ? hoverCursor
               : MouseCursor.defer,
-          onEnter: (event) => _onHoverEnter(),
-          onExit: (event) => _onHoverLeave(),
+          onEnter: (event) => onHoverEnter(),
+          onExit: (event) => onHoverExit(),
           child: child,
         );
       },
+      child: child,
     );
   }
+}
 
-  /// Builds the content widget based on the type of layer being displayed.
-  Widget _buildContent() {
+class _LayerContentItem extends StatelessWidget {
+  const _LayerContentItem({
+    required this.layerType,
+    required this.layer,
+    required this.isSelected,
+    required this.enableHitDetection,
+    required this.showMoveCursor,
+    required this.onHitChanged,
+    required this.emojiEditorConfigs,
+    required this.textEditorConfigs,
+    required this.stickerEditorConfigs,
+    required this.paintEditorConfigs,
+    required this.designMode,
+  });
+
+  final LayerWidgetType layerType;
+  final Layer layer;
+  final bool isSelected;
+  final bool enableHitDetection;
+  final ValueNotifier<bool> showMoveCursor;
+  final ValueChanged<bool> onHitChanged;
+  final EmojiEditorConfigs emojiEditorConfigs;
+  final TextEditorConfigs textEditorConfigs;
+  final StickerEditorConfigs stickerEditorConfigs;
+  final PaintEditorConfigs paintEditorConfigs;
+  final ImageEditorDesignMode designMode;
+
+  @override
+  Widget build(BuildContext context) {
     Widget? content;
-    switch (_layerType) {
+    switch (layerType) {
       case LayerWidgetType.emoji:
         content = LayerWidgetEmojiItem(
-          layer: _layer as EmojiLayer,
+          layer: layer as EmojiLayer,
           emojiEditorConfigs: emojiEditorConfigs,
           textEditorConfigs: textEditorConfigs,
           designMode: designMode,
         );
       case LayerWidgetType.text:
         content = LayerWidgetTextItem(
-          layer: _layer as TextLayer,
+          layer: layer as TextLayer,
           textEditorConfigs: textEditorConfigs,
-          showMoveCursor: _showMoveCursor,
-          onHitChanged: (state) {
-            _lastHitState.value = state;
-          },
+          showMoveCursor: showMoveCursor,
+          onHitChanged: onHitChanged,
         );
       case LayerWidgetType.widget:
         content = LayerWidgetCustomItem(
-          layer: _layer as WidgetLayer,
+          layer: layer as WidgetLayer,
           stickerEditorConfigs: stickerEditorConfigs,
         );
       case LayerWidgetType.canvas:
         content = LayerWidgetPaintItem(
-          layer: _layer as PaintLayer,
-          isSelected: _isSelected,
-          enableHitDetection:
-              _layerInteractionManager?.enabledHitDetection ?? false,
-          onHitChanged: (state) {
-            _lastHitState.value = state;
-          },
-          paintEditorConfigs: widget.configs.paintEditor,
+          layer: layer as PaintLayer,
+          isSelected: isSelected,
+          enableHitDetection: enableHitDetection,
+          onHitChanged: onHitChanged,
+          paintEditorConfigs: paintEditorConfigs,
         );
       case LayerWidgetType.censor:
         content = LayerWidgetCensorItem(
-          layer: _layer as PaintLayer,
+          layer: layer as PaintLayer,
           censorConfigs: paintEditorConfigs.censorConfigs,
         );
       default:
         return const SizedBox.shrink();
     }
 
-    if (_layer.boxConstraints != null) {
+    if (layer.boxConstraints != null) {
       content = ConstrainedBox(
-        constraints: _layer.boxConstraints!,
+        constraints: layer.boxConstraints!,
         child: content,
       );
     }
 
-    return RepaintBoundary(key: _layer.repaintBoundaryKey, child: content);
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    _layer.debugFillProperties(properties);
+    return RepaintBoundary(key: layer.repaintBoundaryKey, child: content);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.1.0
+version: 12.2.0
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/shared/services/import_export/export_state_history_test.dart
+++ b/test/shared/services/import_export/export_state_history_test.dart
@@ -49,14 +49,13 @@ void main() {
       stateHistory = [
         EditorStateHistory(
           blur: null,
-          filters: [],
           layers: [],
           transformConfigs: null,
           tuneAdjustments: [],
         ),
         EditorStateHistory(
           blur: 2.0,
-          filters: presetFiltersList.first.filters,
+          filters: [FilterState(matrices: presetFiltersList.first.filters)],
           layers: [DummyLayer('layer1')],
           transformConfigs: null,
         ),

--- a/test/shared/services/import_export/import_export_test.dart
+++ b/test/shared/services/import_export/import_export_test.dart
@@ -138,20 +138,20 @@ void main() {
         final editor = await pumpTestEditor(tester);
 
         final testFilters = PresetFilters.addictiveRed.filters;
-        editor.addHistory(filters: testFilters);
+        editor.addHistory(filters: [FilterState(matrices: testFilters)]);
 
-        expect(editor.stateManager.activeFilters, testFilters);
+        expect(editor.stateManager.activeFilters.allMatrices, testFilters);
         expect(editor.stateManager.historyPointer, 1);
 
         await runExportImport(
           editor,
           onAfterImport: () {
-            editor.addHistory(filters: []);
-            expect(editor.stateManager.activeFilters.length, 1);
+            editor.addHistory(filters: const []);
+            expect(editor.stateManager.activeFilters.allMatrices.length, 1);
           },
         );
 
-        expect(editor.stateManager.activeFilters, testFilters);
+        expect(editor.stateManager.activeFilters.allMatrices, testFilters);
         expect(editor.stateManager.historyPointer, 1);
       });
     });


### PR DESCRIPTION
- Enhanced LayerCopyManager to include timeline properties (startTime, endTime, enterDuration, exitDuration, enterCurve, exitCurve, transitionBuilder) for layers.
- Updated MainEditorStateHistoryService to remove unused filters.
- Refactored StateManager to use FilterState instead of FilterMatrix, updating related methods and properties.
- Modified MainEditorBackgroundImage and MainEditorBackgroundVideo to utilize the new filter state structure.
- Implemented LayerTimelineVisibility to manage layer visibility based on timeline properties.
- Introduced utility functions for parsing curves and computing timeline progress.
- Updated import/export functionality to handle new timeline fields in filters and tune adjustments.
- Adjusted tests to reflect changes in filter handling and state management.
- Bumped version to 12.2.0 to reflect new features and improvements.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore