### PR TITLE
fix: recalculate layer visibility on time changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.2.1
+- **FIX**(timeline): Recalculate layer visibility when `startTime`, `endTime`, `enterDuration`, or `exitDuration` change while the video is paused.
+
 ## 12.2.0
 - **FEAT**(timeline): Add video timeline visibility to layers, filters, and tune adjustments with configurable `startTime`, `endTime`, enter/exit durations and curves.
 - **FEAT**(complete-parameters): Add `filterStates`, `tuneAdjustments`, and `capturedLayers` to `CompleteParameters`. Add `captureLayersOnDone` config to `MainEditorConfigs`.

--- a/lib/shared/widgets/layer/layer_timeline_visibility.dart
+++ b/lib/shared/widgets/layer/layer_timeline_visibility.dart
@@ -57,6 +57,12 @@ class _LayerTimelineVisibilityState extends State<LayerTimelineVisibility>
       oldWidget.playTimeNotifier.removeListener(_onTimeChanged);
       widget.playTimeNotifier.addListener(_onTimeChanged);
     }
+    if (oldWidget.layer.startTime != widget.layer.startTime ||
+        oldWidget.layer.endTime != widget.layer.endTime ||
+        oldWidget.layer.enterDuration != widget.layer.enterDuration ||
+        oldWidget.layer.exitDuration != widget.layer.exitDuration) {
+      _controller.value = _computeProgress(widget.playTimeNotifier.value);
+    }
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.2.0
+version: 12.2.1
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
## Description

Update the version to 12.2.1 and ensure layer visibility recalculates when `startTime`, `endTime`, `enterDuration`, or `exitDuration` change while the video is paused.

**Related Issue:** Closes #

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

