### PR TITLE
feat: add filter name support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.3.2
+- **FEAT**(filter-editor): Add `name` field to `FilterState` to carry the filter name through the editor, history, and import/export.
+- **FEAT**(state-manager): Expose `activeMeta` as a public field, updated on every undo/redo alongside `activeLayers`.
+
 ## 12.3.1
 - **FEAT**(state-history): Add `meta` field (`Map<String, dynamic>`) to `EditorStateHistory` for user-defined data that is preserved across undo/redo and import/export.
 - **FEAT**(layers): Add `basePixelRatio` parameter to `captureAsPng`, `captureAllLayers`, and `captureAllLayersWithMeta` for image-relative layer export resolution.

--- a/example/lib/features/ai/ai_text_commands/providers/ai_message_base_provider.dart
+++ b/example/lib/features/ai/ai_text_commands/providers/ai_message_base_provider.dart
@@ -129,7 +129,8 @@ abstract class AiMessageBaseProvider {
 
       editor.addHistory(
         blur: blur,
-        filters: filters != null ? [FilterState(matrices: filters)] : null,
+        filters:
+            filters != null ? [FilterState(name: '', matrices: filters)] : null,
         tuneAdjustments: tuneAdjustments,
         layers: layers,
         transformConfigs: transformConfigs,

--- a/lib/designs/whatsapp/widgets/filter/whatsapp_filters.dart
+++ b/lib/designs/whatsapp/widgets/filter/whatsapp_filters.dart
@@ -79,7 +79,9 @@ class WhatsappFilters extends StatelessWidget {
                   : emptyFilter,
               onSelectFilter: (filter) {
                 editor.addHistory(
-                  filters: [FilterState(matrices: filter.filters)],
+                  filters: [
+                    FilterState(name: filter.name, matrices: filter.filters),
+                  ],
                 );
               },
             ),

--- a/lib/features/filter_editor/filter_editor.dart
+++ b/lib/features/filter_editor/filter_editor.dart
@@ -220,7 +220,10 @@ class FilterEditorState extends State<FilterEditor>
   void done() async {
     doneEditing(
       editorImage: widget.editorImage,
-      returnValue: _getActiveFilters(),
+      returnValue: FilterState(
+        name: selectedFilter.name,
+        matrices: _getActiveFilters(),
+      ),
       blur: appliedBlurFactor,
       matrixFilterList: _getActiveFilters(),
       matrixTuneAdjustmentsList: appliedTuneAdjustments

--- a/lib/features/filter_editor/types/filter_state.dart
+++ b/lib/features/filter_editor/types/filter_state.dart
@@ -21,6 +21,7 @@ class FilterState {
   /// Creates a [FilterState] instance from a [Map] representation.
   factory FilterState.fromMap(Map<String, dynamic> map) {
     return FilterState(
+      name: map['name'] as String? ?? '',
       matrices:
           (map['matrices'] as List?)
               ?.map(
@@ -48,6 +49,7 @@ class FilterState {
 
   /// Creates a [FilterState] with the given fields.
   const FilterState({
+    required this.name,
     this.matrices = const [],
     this.startTime,
     this.endTime,
@@ -57,6 +59,9 @@ class FilterState {
     this.exitCurve,
     this.meta = const {},
   });
+
+  /// The name of the filter.
+  final String name;
 
   /// The color-filter matrices that make up this filter effect.
   final FilterMatrix matrices;
@@ -95,6 +100,7 @@ class FilterState {
   /// Converts this instance into a [Map] representation.
   Map<String, dynamic> toMap() {
     return {
+      if (name.isNotEmpty) 'name': name,
       'matrices': matrices,
       if (startTime != null) 'startTime': startTime!.inMilliseconds,
       if (endTime != null) 'endTime': endTime!.inMilliseconds,
@@ -108,6 +114,7 @@ class FilterState {
 
   /// Creates a copy of this instance with the given fields replaced.
   FilterState copyWith({
+    String? name,
     FilterMatrix? matrices,
     Duration? startTime,
     Duration? endTime,
@@ -118,6 +125,7 @@ class FilterState {
     Map<String, dynamic>? meta,
   }) {
     return FilterState(
+      name: name ?? this.name,
       matrices: matrices ?? this.matrices.map((row) => [...row]).toList(),
       startTime: startTime ?? this.startTime,
       endTime: endTime ?? this.endTime,
@@ -132,6 +140,7 @@ class FilterState {
   /// Creates a deep copy of this instance.
   FilterState copy() {
     return FilterState(
+      name: name,
       matrices: matrices.map((row) => [...row]).toList(),
       startTime: startTime,
       endTime: endTime,
@@ -153,7 +162,8 @@ class FilterState {
       if (!listEquals(matrices[i], other.matrices[i])) return false;
     }
 
-    return other.startTime == startTime &&
+    return other.name == name &&
+        other.startTime == startTime &&
         other.endTime == endTime &&
         other.enterDuration == enterDuration &&
         other.exitDuration == exitDuration &&
@@ -164,6 +174,7 @@ class FilterState {
 
   @override
   int get hashCode =>
+      name.hashCode ^
       matrices.hashCode ^
       startTime.hashCode ^
       endTime.hashCode ^

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -1723,7 +1723,7 @@ class ProImageEditorState extends State<ProImageEditor>
       editorName = SubEditor.cropRotate;
     } else if (T is TuneAdjustmentMatrix || page is TuneEditor) {
       editorName = SubEditor.tune;
-    } else if (T is FilterMatrix || page is FilterEditor) {
+    } else if (T is FilterMatrix || T is FilterState || page is FilterEditor) {
       editorName = SubEditor.filter;
     } else if (T is double || page is BlurEditor) {
       editorName = SubEditor.blur;
@@ -2094,7 +2094,7 @@ class ProImageEditorState extends State<ProImageEditor>
   /// original image is retained.
   void openFilterEditor() async {
     if (!mounted) return;
-    FilterMatrix? filters = await openPage(
+    FilterState? filterState = await openPage(
       FilterEditor.autoSource(
         key: filterEditor,
         editorImage: widget.blankSize == null
@@ -2117,10 +2117,10 @@ class ProImageEditorState extends State<ProImageEditor>
       ),
     );
 
-    if (filters == null) return;
+    if (filterState == null) return;
 
     addHistory(
-      filters: [FilterState(matrices: filters)],
+      filters: [filterState],
       heroScreenshotRequired: true,
     );
 

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -2119,10 +2119,7 @@ class ProImageEditorState extends State<ProImageEditor>
 
     if (filterState == null) return;
 
-    addHistory(
-      filters: [filterState],
-      heroScreenshotRequired: true,
-    );
+    addHistory(filters: [filterState], heroScreenshotRequired: true);
 
     setState(() {});
     mainEditorCallbacks?.handleUpdateUI();

--- a/lib/features/main_editor/services/state_manager.dart
+++ b/lib/features/main_editor/services/state_manager.dart
@@ -122,6 +122,8 @@ class StateManager {
 
     activeLayers = _stateHistory[historyPointer].layers;
 
+    activeMeta = _stateHistory[historyPointer].meta;
+
     _transformConfigs =
         activeHistory
             .lastWhere(
@@ -179,6 +181,9 @@ class StateManager {
 
   /// Get the list of layers from the current image editor changes.
   List<Layer> activeLayers = [];
+
+  /// The metadata of the current history entry.
+  Map<String, dynamic> activeMeta = const {};
 
   /// Flag indicating if a hero screenshot is required.
   bool heroScreenshotRequired = false;

--- a/lib/shared/services/import_export/import_state_history.dart
+++ b/lib/shared/services/import_export/import_state_history.dart
@@ -232,7 +232,7 @@ class ImportStateHistory {
     // Old formats: plain list of matrices
     final matrices = parseFilters(filtersData, version);
     if (matrices.isEmpty) return const [];
-    return [FilterState(matrices: matrices)];
+    return [FilterState(name: '', matrices: matrices)];
   }
 
   /// Helper to parse filters

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.3.1
+version: 12.3.2
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/shared/services/import_export/export_state_history_test.dart
+++ b/test/shared/services/import_export/export_state_history_test.dart
@@ -55,7 +55,12 @@ void main() {
         ),
         EditorStateHistory(
           blur: 2.0,
-          filters: [FilterState(matrices: presetFiltersList.first.filters)],
+          filters: [
+            FilterState(
+              name: 'filter',
+              matrices: presetFiltersList.first.filters,
+            ),
+          ],
           layers: [DummyLayer('layer1')],
           transformConfigs: null,
         ),

--- a/test/shared/services/import_export/import_export_test.dart
+++ b/test/shared/services/import_export/import_export_test.dart
@@ -138,7 +138,9 @@ void main() {
         final editor = await pumpTestEditor(tester);
 
         final testFilters = PresetFilters.addictiveRed.filters;
-        editor.addHistory(filters: [FilterState(matrices: testFilters)]);
+        editor.addHistory(
+          filters: [FilterState(name: 'filter', matrices: testFilters)],
+        );
 
         expect(editor.stateManager.activeFilters.allMatrices, testFilters);
         expect(editor.stateManager.historyPointer, 1);


### PR DESCRIPTION
## Description

Add support for filter names in `FilterState`, enhancing filter management across the editor and history. 

**Related Issue:** Closes #

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

