### PR TITLE
feat: add optional initialization delay for background processor setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.3.5
+- **FEAT**(processor): Add `initializationDelay` to `ProcessorConfigs` to optionally defer isolate/thread startup and avoid jank during page transition animations.
+
 ## 12.3.4
 - **FIX**(main-editor): Preserve active `filters`, `tuneAdjustments`, and `meta` in `addHistory()` when values are not explicitly provided.
 - **FIX**(main-editor): Store copied `filters`/`tuneAdjustments`/`meta` in history entries to prevent shared-reference mutations across undo/redo states.

--- a/lib/core/models/editor_configs/image_generation_configs/processor_configs.dart
+++ b/lib/core/models/editor_configs/image_generation_configs/processor_configs.dart
@@ -64,8 +64,7 @@ class ProcessorConfigs {
           numberOfBackgroundProcessors ?? this.numberOfBackgroundProcessors,
       maxConcurrency: maxConcurrency ?? this.maxConcurrency,
       processorMode: processorMode ?? this.processorMode,
-      initializationDelay:
-          initializationDelay ?? this.initializationDelay,
+      initializationDelay: initializationDelay ?? this.initializationDelay,
     );
   }
 }

--- a/lib/core/models/editor_configs/image_generation_configs/processor_configs.dart
+++ b/lib/core/models/editor_configs/image_generation_configs/processor_configs.dart
@@ -11,6 +11,7 @@ class ProcessorConfigs {
     this.numberOfBackgroundProcessors = 2,
     this.maxConcurrency = 1,
     this.processorMode = ProcessorMode.auto,
+    this.initializationDelay,
   }) : assert(
          numberOfBackgroundProcessors > 0,
          'minBackgroundProcessors must be positive',
@@ -37,6 +38,15 @@ class ProcessorConfigs {
   /// Defaults to [ProcessorMode.auto].
   final ProcessorMode processorMode;
 
+  /// Optional delay before initializing background isolates/threads.
+  ///
+  /// This can be useful to avoid jank during page transition animations
+  /// at startup. For example, setting this to `Duration(milliseconds: 300)`
+  /// will wait 300ms before spawning isolates.
+  ///
+  /// Defaults to `null` (no delay).
+  final Duration? initializationDelay;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   ///
@@ -47,12 +57,15 @@ class ProcessorConfigs {
     int? numberOfBackgroundProcessors,
     int? maxConcurrency,
     ProcessorMode? processorMode,
+    Duration? initializationDelay,
   }) {
     return ProcessorConfigs(
       numberOfBackgroundProcessors:
           numberOfBackgroundProcessors ?? this.numberOfBackgroundProcessors,
       maxConcurrency: maxConcurrency ?? this.maxConcurrency,
       processorMode: processorMode ?? this.processorMode,
+      initializationDelay:
+          initializationDelay ?? this.initializationDelay,
     );
   }
 }

--- a/lib/shared/services/content_recorder/services/thread_manager.dart
+++ b/lib/shared/services/content_recorder/services/thread_manager.dart
@@ -20,7 +20,16 @@ abstract class ThreadManager<T extends Thread> {
   /// initializes the threading environment.
   ThreadManager(this.configs) {
     /// Only initialize multithreading if it's enabled.
-    if (configs.enableIsolateGeneration) initialize();
+    if (configs.enableIsolateGeneration) {
+      final delay = configs.processorConfigs.initializationDelay;
+      if (delay != null) {
+        Future.delayed(delay, () {
+          if (!isDestroyed) initialize();
+        });
+      } else {
+        initialize();
+      }
+    }
   }
 
   /// List of threads.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.3.4
+version: 12.3.5
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Introduce an optional `initializationDelay` in `ProcessorConfigs` to defer the startup of background isolates/threads. This change aims to reduce jank during page transitions by allowing a delay before initialization. The implementation checks for the delay and initializes accordingly.

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore