### PR TITLE
feat: export user-defined metadata in CompleteParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.3.6
+- **FEAT**(complete-parameters): Export `meta` field in `CompleteParameters` so user-defined metadata is available in the `onCompleteWithParameters` callback.
+
 ## 12.3.5
 - **FEAT**(processor): Add `initializationDelay` to `ProcessorConfigs` to optionally defer isolate/thread startup and avoid jank during page transition animations.
 

--- a/lib/core/models/complete_parameters.dart
+++ b/lib/core/models/complete_parameters.dart
@@ -71,6 +71,7 @@ class CompleteParameters {
               (map['editorSize']['height'] as num).toDouble(),
             )
           : null,
+      meta: Map<String, dynamic>.from(map['meta'] ?? {}),
     );
   }
 
@@ -104,6 +105,7 @@ class CompleteParameters {
     required this.temporaryDecodedImageSize,
     required this.bodySize,
     required this.editorSize,
+    this.meta = const {},
   });
 
   /// The blur strength to apply (in logical pixels).
@@ -211,6 +213,9 @@ class CompleteParameters {
   /// The overall size of the editor widget.
   final Size? editorSize;
 
+  /// Custom metadata associated with the current editor state.
+  final Map<String, dynamic> meta;
+
   /// Creates a copy of this [CompleteParameters] object with optional new
   /// values for specific fields.
   CompleteParameters copyWith({
@@ -238,6 +243,7 @@ class CompleteParameters {
     Size? temporaryDecodedImageSize,
     Size? bodySize,
     Size? editorSize,
+    Map<String, dynamic>? meta,
   }) {
     return CompleteParameters(
       blur: blur ?? this.blur,
@@ -266,6 +272,7 @@ class CompleteParameters {
           temporaryDecodedImageSize ?? this.temporaryDecodedImageSize,
       bodySize: bodySize ?? this.bodySize,
       editorSize: editorSize ?? this.editorSize,
+      meta: meta ?? this.meta,
     );
   }
 
@@ -297,6 +304,7 @@ class CompleteParameters {
         other.temporaryDecodedImageSize == temporaryDecodedImageSize &&
         other.bodySize == bodySize &&
         other.editorSize == editorSize &&
+        mapEquals(other.meta, meta) &&
         listEquals(other.layers, layers);
   }
 
@@ -322,6 +330,7 @@ class CompleteParameters {
         temporaryDecodedImageSize.hashCode ^
         bodySize.hashCode ^
         editorSize.hashCode ^
+        meta.hashCode ^
         layers.hashCode;
   }
 
@@ -362,6 +371,7 @@ class CompleteParameters {
           'width': editorSize!.width,
           'height': editorSize!.height,
         },
+      'meta': meta,
     };
   }
 
@@ -388,6 +398,7 @@ class CompleteParameters {
         'temporaryDecodedImageSize: $temporaryDecodedImageSize, '
         'bodySize: $bodySize, '
         'editorSize: $editorSize, '
+        'meta: $meta, '
         'layers: $layers)';
   }
 }

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -2649,6 +2649,7 @@ class ProImageEditorState extends State<ProImageEditor>
             temporaryDecodedImageSize: sizesManager.temporaryDecodedImageSize,
             bodySize: sizesManager.bodySize,
             editorSize: sizesManager.editorSize,
+            meta: stateManager.activeMeta,
           ),
         );
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.3.5
+version: 12.3.6
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
## Description

Add support for exporting user-defined metadata in the `CompleteParameters` class, making it available in the `onCompleteWithParameters` callback.

**Related Issue:** Closes #

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

