### PR TITLE
fix: update activeFilters and activeTuneAdjustments to directly use historyPointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.4.3
+- **FIX**(state-manager): Update activeFilters and activeTuneAdjustments to directly use historyPointer.
+
 ## 12.4.2
 - **FEAT**(state-manager): Add `replaceHistory()` to replace an existing history entry in the stack (current pointer by default, or a custom index).
 

--- a/lib/features/main_editor/services/state_manager.dart
+++ b/lib/features/main_editor/services/state_manager.dart
@@ -106,19 +106,9 @@ class StateManager {
   void updateActiveItems() {
     var activeHistory = _stateHistory.getRange(0, _historyPointer + 1);
 
-    activeFilters = activeHistory
-        .lastWhere(
-          (item) => item.filters.isNotEmpty,
-          orElse: EditorStateHistory.new,
-        )
-        .filters;
+    activeFilters = _stateHistory[historyPointer].filters;
 
-    activeTuneAdjustments = activeHistory
-        .lastWhere(
-          (item) => item.tuneAdjustments.isNotEmpty,
-          orElse: EditorStateHistory.new,
-        )
-        .tuneAdjustments;
+    activeTuneAdjustments = _stateHistory[historyPointer].tuneAdjustments;
 
     activeLayers = _stateHistory[historyPointer].layers;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.4.2
+version: 12.4.3
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/shared/services/import_export/import_export_test.dart
+++ b/test/shared/services/import_export/import_export_test.dart
@@ -149,7 +149,7 @@ void main() {
           editor,
           onAfterImport: () {
             editor.addHistory(filters: const []);
-            expect(editor.stateManager.activeFilters.allMatrices.length, 1);
+            expect(editor.stateManager.activeFilters.allMatrices.length, 0);
           },
         );
 
@@ -179,7 +179,7 @@ void main() {
           editor,
           onAfterImport: () {
             editor.addHistory(tuneAdjustments: []);
-            expect(editor.stateManager.activeTuneAdjustments.length, 1);
+            expect(editor.stateManager.activeTuneAdjustments.length, 0);
           },
         );
 


### PR DESCRIPTION
## Description

Update the `activeFilters` and `activeTuneAdjustments` to directly reference the current `historyPointer`, simplifying the logic and improving performance.

**Related Issue:** Closes #

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

