### PR TITLE
fix(layer): improve exported layer resolution to avoid blurry output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.4.4
+- **FIX**(layers): Improve exported layer resolution for scaled layers to avoid blurry output.
+
 ## 12.4.3
 - **FIX**(state-manager): Update activeFilters and activeTuneAdjustments to directly use historyPointer.
 

--- a/lib/core/models/layers/layer.dart
+++ b/lib/core/models/layers/layer.dart
@@ -366,7 +366,7 @@ class Layer {
 
     final dpr =
         basePixelRatio ?? MediaQuery.maybeDevicePixelRatioOf(context) ?? 3.0;
-    final effectivePixelRatio = pixelRatio ?? (dpr * scale);
+    final effectivePixelRatio = pixelRatio ?? dpr;
 
     final boundary = context.findRenderObject() as RenderRepaintBoundary;
     final rawImage = await boundary.toImage(pixelRatio: effectivePixelRatio);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.4.3
+version: 12.4.4
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
 

## Description

Enhance the exported layer resolution for scaled layers to prevent blurry images. Update the version to 12.4.4 in the changelog and pubspec file.

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore