### PR TITLE
chore: update Flutter version and fix deprecated APIs

### DIFF
--- a/.github/workflows/flutter_analysis.yml
+++ b/.github/workflows/flutter_analysis.yml
@@ -18,7 +18,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: 3.41.1
+          flutter-version: 3.44.0
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -17,7 +17,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: 3.41.0
+          flutter-version: 3.44.0
 
       - name: Install Package Dependencies
         run: flutter pub get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.4.8
+- **CHORE**: Update CI to Flutter 3.44 and fix deprecated API usages.
+
 ## 12.4.7
 - **FIX**(example): Update Supabase initialization to use publishable key and upgrade `supabase_flutter` dependency to 2.14.1.
 

--- a/example/lib/features/reorder_layer_example.dart
+++ b/example/lib/features/reorder_layer_example.dart
@@ -245,7 +245,7 @@ class _ReorderLayerSheetState extends State<ReorderLayerSheet> {
         );
       },
       itemCount: widget.layers.length,
-      onReorder: widget.onReorder,
+      onReorderItem: widget.onReorder,
     );
   }
 }

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -15,7 +15,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
-  jni
   onnxruntime
 )
 

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -42,7 +42,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ProVideoEditorPlugin.register(with: registry.registrar(forPlugin: "ProVideoEditorPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
-  VideoPlayerPlugin.register(with: registry.registrar(forPlugin: "VideoPlayerPlugin"))
+  FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
   VolumeControllerPlugin.register(with: registry.registrar(forPlugin: "VolumeControllerPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -18,7 +18,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
-  jni
   onnxruntime
 )
 

--- a/lib/designs/grounded/widgets/bottombar/grounded_main_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_main_bar.dart
@@ -150,7 +150,7 @@ class GroundedMainBarState extends State<GroundedMainBar>
                 child: SizeTransition(
                   sizeFactor: animation,
                   axis: Axis.vertical,
-                  axisAlignment: -1,
+                  alignment: Alignment.topCenter,
                   child: child,
                 ),
               );

--- a/lib/designs/whatsapp/whatsapp_sticker_editor.dart
+++ b/lib/designs/whatsapp/whatsapp_sticker_editor.dart
@@ -244,7 +244,7 @@ class _WhatsAppStickerPageState extends State<WhatsAppStickerPage> {
           child: _isStickerEditorEnabled
               ? SizeTransition(
                   sizeFactor: animation,
-                  axisAlignment: -1,
+                  alignment: Alignment.topCenter,
                   child: child,
                 )
               : ScaleTransition(

--- a/lib/features/clips_editor/pages/clips_editor_page.dart
+++ b/lib/features/clips_editor/pages/clips_editor_page.dart
@@ -264,8 +264,7 @@ class ClipsEditorPageState extends State<ClipsEditorPage>
             child: ReorderableListView.builder(
               reverse: reversedList,
               padding: clipsEditorConfigs.style.bodyPadding,
-              onReorder: (oldIndex, newIndex) {
-                if (newIndex > oldIndex) newIndex--;
+              onReorderItem: (oldIndex, newIndex) {
                 final item = _videoClips.removeAt(oldIndex);
                 _videoClips.insert(newIndex, item);
                 setState(() {});

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -3118,7 +3118,7 @@ class ProImageEditorState extends State<ProImageEditor>
                               transitionBuilder: (child, animation) {
                                 return SizeTransition(
                                   sizeFactor: animation,
-                                  axisAlignment: -1,
+                                  alignment: Alignment.topCenter,
                                   child: child,
                                 );
                               },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.4.7
+version: 12.4.8
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
## Description

Update the Flutter version to 3.44.0 in CI workflows and adjust reorder callbacks in multiple files. Also, update the package version to 12.4.8 and add a changelog entry for the CI updates and deprecated API fixes.

**Related Issue:** Closes #

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

