### PR TITLE
feat(crop-rotate): keep aspect ratio orientation on rotate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.5.0
+- **FEAT**(crop-rotate): Add `enableKeepAspectRatioOnRotate` option to keep the selected aspect ratio orientation when rotating (e.g. `9:16` stays `9:16` instead of becoming `16:9`), zooming the image in so it still fully covers the crop area.
+
 ## 12.4.8
 - **CHORE**: Update CI to Flutter 3.44 and fix deprecated API usages.
 

--- a/lib/core/models/editor_configs/crop_rotate_editor_configs.dart
+++ b/lib/core/models/editor_configs/crop_rotate_editor_configs.dart
@@ -56,6 +56,7 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
     this.enableProvideImageInfos = false,
     this.enableDoubleTap = true,
     this.enableFlipAnimation = true,
+    this.enableKeepAspectRatioOnRotate = false,
     this.showLayers = true,
     this.initAspectRatio,
     this.rotateAnimationCurve = Curves.decelerate,
@@ -120,6 +121,18 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
 
   /// Enables flip-animation when set to true.
   final bool enableFlipAnimation;
+
+  /// Keeps the crop frame's orientation when the image is rotated.
+  ///
+  /// By default a 90° rotation swaps the crop frame orientation, so a `9:16`
+  /// crop becomes `16:9` after rotating. When this is set to `true`, the crop
+  /// frame keeps the orientation it had before the rotation (e.g. `9:16` stays
+  /// `9:16`) and the image is zoomed in so it still fully covers the crop area.
+  ///
+  /// This works for fixed, `original` (`0`) and `free` (`-1`) aspect ratios.
+  /// For the free and original ratio the current crop frame orientation is
+  /// kept.
+  final bool enableKeepAspectRatioOnRotate;
 
   /// Determines if the mouse scroll direction should be inverted.
   final bool invertMouseScroll;
@@ -265,6 +278,7 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
     bool? enableTransformLayers,
     bool? enableDoubleTap,
     bool? enableFlipAnimation,
+    bool? enableKeepAspectRatioOnRotate,
     bool? invertMouseScroll,
     bool? invertDragDirection,
     CropMode? initialCropMode,
@@ -301,6 +315,8 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
           enableTransformLayers ?? this.enableTransformLayers,
       enableDoubleTap: enableDoubleTap ?? this.enableDoubleTap,
       enableFlipAnimation: enableFlipAnimation ?? this.enableFlipAnimation,
+      enableKeepAspectRatioOnRotate:
+          enableKeepAspectRatioOnRotate ?? this.enableKeepAspectRatioOnRotate,
       invertMouseScroll: invertMouseScroll ?? this.invertMouseScroll,
       invertDragDirection: invertDragDirection ?? this.invertDragDirection,
       initialCropMode: initialCropMode ?? this.initialCropMode,

--- a/lib/features/crop_rotate_editor/crop_rotate_editor.dart
+++ b/lib/features/crop_rotate_editor/crop_rotate_editor.dart
@@ -269,10 +269,33 @@ class CropRotateEditorState extends State<CropRotateEditor>
   /// The horizontal space for cropping.
   double _cropSpaceHorizontal = 0;
 
+  /// The aspect ratio currently applied to the crop area.
+  ///
+  /// When [CropRotateEditorConfigs.enableKeepAspectRatioOnRotate] is enabled
+  /// the ratio is inverted for every 90° rotation, so the crop frame keeps the
+  /// orientation the user selected (e.g. a `9:16` frame stays `9:16` instead of
+  /// turning into `16:9` after a rotation). Only fixed aspect ratios are
+  /// affected.
+  double get _activeAspectRatio {
+    if (cropRotateEditorConfigs.enableKeepAspectRatioOnRotate &&
+        _rotated90deg &&
+        aspectRatio > 0) {
+      return 1 / aspectRatio;
+    }
+    return aspectRatio;
+  }
+
   /// The ratio used for cropping, based on the aspect ratio and main image
   /// size.
-  double get _ratio =>
-      1 / (aspectRatio == 0 ? _mainImageSize.aspectRatio : aspectRatio);
+  double get _ratio => 1 / (_activeAspectRatio == 0
+      ? _mainImageSize.aspectRatio
+      : _activeAspectRatio);
+
+  /// Indicates whether a locked-aspect-ratio rotation animation is in progress.
+  ///
+  /// Used to defer the history entry to the end of the crop-area transition
+  /// instead of adding it when the rotation animation completes.
+  bool _lockedRotationActive = false;
 
   /// The opacity of the painter.
   double _painterOpacity = 0;
@@ -352,6 +375,10 @@ class CropRotateEditorState extends State<CropRotateEditor>
 
   double _rotationScaleFactor = 1;
 
+  /// Opacity of the whole crop overlay, used to briefly hide and show the crop
+  /// frame while a locked aspect-ratio rotation runs.
+  double _cropFrameOpacity = 1;
+
   @override
   CropCornerPainter? get cropPainter {
     return showWidgets
@@ -361,6 +388,7 @@ class CropRotateEditorState extends State<CropRotateEditor>
             viewRect: _viewRect,
             scaleFactor: userScaleFactor,
             rotationScaleFactor: _rotationScaleFactor,
+            frameOpacity: _cropFrameOpacity,
             interactionOpacity: _interactionOpacityProgress,
             screenSize: Size(editorBodySize.width, editorBodySize.height),
             fadeInOpacity: _painterOpacity,
@@ -414,10 +442,13 @@ class CropRotateEditorState extends State<CropRotateEditor>
     );
     rotateCtrl.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
-        if (_blockInteraction) {
+        /// While a locked-aspect-ratio rotation is running the crop area is
+        /// still being animated, so the history entry is added once that
+        /// transition finishes instead of here.
+        if (!_lockedRotationActive && _blockInteraction) {
           addHistory(scaleRotation: oldScaleFactor);
+          _blockInteraction = false;
         }
-        _blockInteraction = false;
         cropRotateEditorCallbacks?.handleRotateEnd(rotateAnimation.value);
       }
     });
@@ -903,6 +934,9 @@ class CropRotateEditorState extends State<CropRotateEditor>
 
   /// Rotates the image clockwise.
   void rotate() {
+    /// Ignore new rotations while a locked-aspect-ratio rotation (which hides
+    /// and shows the crop frame) is still running.
+    if (_lockedRotationActive) return;
     _blockInteraction = true;
     var piHelper =
         cropRotateEditorConfigs.rotateDirection == RotateDirection.left
@@ -920,12 +954,89 @@ class CropRotateEditorState extends State<CropRotateEditor>
             curve: cropRotateEditorConfigs.rotateAnimationCurve,
           ),
         );
-    rotateCtrl
-      ..reset()
-      ..forward();
-    calcFitToScreen();
+    rotateCtrl.reset();
+
+    if (cropRotateEditorConfigs.enableKeepAspectRatioOnRotate &&
+        !cropRect.isEmpty) {
+      /// The rotation is started inside the helper, after fading the frame out.
+      _rotateWithLockedAspectRatio();
+    } else {
+      rotateCtrl.forward();
+      calcFitToScreen();
+    }
 
     cropRotateEditorCallbacks?.handleRotateStart(rotateAnimation.value);
+  }
+
+  /// Rotates while keeping the crop frame's orientation, hiding the frame
+  /// during the rotation so it never appears to change its aspect ratio.
+  ///
+  /// Because the crop frame lives inside the rotating image transform, letting
+  /// it rotate would make e.g. a `9:16` frame widen towards `1:1` half way
+  /// through the 90° rotation. To avoid this the crop overlay is faded out, the
+  /// image is rotated and zoomed while the frame is hidden, and the frame is
+  /// then faded back in at the preserved aspect ratio. Inverting the current
+  /// crop ratio works for fixed, original and free aspect ratios.
+  Future<void> _rotateWithLockedAspectRatio() async {
+    _lockedRotationActive = true;
+
+    final Rect startCropRect = cropRect;
+    final Rect startViewRect = _viewRect;
+
+    /// Recalculate the crop area with the inverted aspect ratio to get the
+    /// target the image is zoomed/fitted to.
+    calcCropRect(newRatio: startCropRect.width / startCropRect.height);
+    final Rect targetCropRect = cropRect;
+    final Rect targetViewRect = _viewRect;
+
+    /// 1) Fade the crop overlay out while the image is still static, so the
+    /// user never sees the frame change its aspect ratio.
+    cropRect = startCropRect;
+    _viewRect = startViewRect;
+    await loopWithTransitionTiming(
+      (double curveT) {
+        _cropFrameOpacity = 1 - curveT;
+        cropPainterKey.currentState?.setForegroundPainter(cropPainter);
+      },
+      mounted: mounted,
+      duration: cropRotateEditorConfigs.opacityOutsideCropAreaDuration,
+      transitionFunction: Curves.easeOut.transform,
+    );
+    if (!mounted) return;
+    _cropFrameOpacity = 0;
+
+    /// 2) Switch to the target crop (still hidden) and rotate + zoom the image.
+    cropRect = targetCropRect;
+    _viewRect = targetViewRect;
+    calcFitToScreen();
+    try {
+      await rotateCtrl.forward();
+    } catch (_) {
+      /// The ticker was canceled (e.g. the editor was disposed).
+      return;
+    }
+    if (!mounted) return;
+    _setOffsetLimits();
+
+    /// 3) Fade the crop overlay back in at the preserved aspect ratio.
+    await loopWithTransitionTiming(
+      (double curveT) {
+        _cropFrameOpacity = curveT;
+        cropPainterKey.currentState?.setForegroundPainter(cropPainter);
+      },
+      mounted: mounted,
+      duration: cropRotateEditorConfigs.fadeInOutsideCropAreaAnimationDuration,
+      transitionFunction:
+          cropRotateEditorConfigs.fadeInOutsideCropAreaAnimationCurve.transform,
+    );
+    if (!mounted) return;
+    _cropFrameOpacity = 1;
+
+    _lockedRotationActive = false;
+    if (_blockInteraction) {
+      addHistory(scaleRotation: oldScaleFactor);
+      _blockInteraction = false;
+    }
   }
 
   @override

--- a/lib/features/crop_rotate_editor/crop_rotate_editor.dart
+++ b/lib/features/crop_rotate_editor/crop_rotate_editor.dart
@@ -287,9 +287,11 @@ class CropRotateEditorState extends State<CropRotateEditor>
 
   /// The ratio used for cropping, based on the aspect ratio and main image
   /// size.
-  double get _ratio => 1 / (_activeAspectRatio == 0
-      ? _mainImageSize.aspectRatio
-      : _activeAspectRatio);
+  double get _ratio =>
+      1 /
+      (_activeAspectRatio == 0
+          ? _mainImageSize.aspectRatio
+          : _activeAspectRatio);
 
   /// Indicates whether a locked-aspect-ratio rotation animation is in progress.
   ///

--- a/lib/features/crop_rotate_editor/widgets/crop_corner_painter.dart
+++ b/lib/features/crop_rotate_editor/widgets/crop_corner_painter.dart
@@ -48,6 +48,7 @@ class CropCornerPainter extends CustomPainter {
     required this.scaleFactor,
     required this.style,
     required this.rotationScaleFactor,
+    this.frameOpacity = 1,
   });
 
   /// The rectangle defining the crop area.
@@ -109,6 +110,16 @@ class CropCornerPainter extends CustomPainter {
   /// This double value influences how elements are scaled when the image is
   /// rotated, ensuring that elements remain proportionate.
   final double rotationScaleFactor;
+
+  /// Overall opacity multiplier for the whole crop overlay (darkened area,
+  /// corners and helper lines).
+  ///
+  /// Unlike [fadeInOpacity] - which blends the outside area towards the
+  /// background color (hero state) - this simply fades the entire crop UI
+  /// towards fully transparent. It is used to briefly hide and show the crop
+  /// frame while a locked aspect-ratio rotation runs. A value of `1` keeps the
+  /// default behavior.
+  final double frameOpacity;
 
   double get _cropOffsetLeft => cropRect.left;
   double get _cropOffsetRight => cropRect.right;
@@ -194,7 +205,7 @@ class CropCornerPainter extends CustomPainter {
       path,
       Paint()
         ..color = interpolatedColor.withValues(
-          alpha: (opacity + fadeInFactor).clamp(0, 1),
+          alpha: ((opacity + fadeInFactor).clamp(0, 1)) * frameOpacity,
         )
         ..style = PaintingStyle.fill,
     );
@@ -266,7 +277,9 @@ class CropCornerPainter extends CustomPainter {
       canvas.drawPath(
         path,
         Paint()
-          ..color = style.cropCornerColor.withValues(alpha: fadeInOpacity)
+          ..color = style.cropCornerColor.withValues(
+            alpha: fadeInOpacity * frameOpacity,
+          )
           ..style = PaintingStyle.fill,
       );
     } else {
@@ -332,7 +345,9 @@ class CropCornerPainter extends CustomPainter {
       canvas.drawPath(
         path,
         Paint()
-          ..color = style.cropCornerColor.withValues(alpha: fadeInOpacity)
+          ..color = style.cropCornerColor.withValues(
+            alpha: fadeInOpacity * frameOpacity,
+          )
           ..strokeWidth = width
           ..strokeCap = StrokeCap.round
           ..style = PaintingStyle.stroke,
@@ -385,7 +400,11 @@ class CropCornerPainter extends CustomPainter {
 
     final cornerPaint = Paint()
       ..color = style.helperLineColor.withValues(
-        alpha: style.helperLineColor.a * fadeInOpacity * interactionOpacity,
+        alpha:
+            style.helperLineColor.a *
+            fadeInOpacity *
+            interactionOpacity *
+            frameOpacity,
       )
       ..style = PaintingStyle.fill;
     canvas.drawPath(path, cornerPaint);
@@ -403,7 +422,8 @@ class CropCornerPainter extends CustomPainter {
         oldDelegate.screenSize != screenSize ||
         oldDelegate.scaleFactor != scaleFactor ||
         oldDelegate.style != style ||
-        oldDelegate.rotationScaleFactor != rotationScaleFactor;
+        oldDelegate.rotationScaleFactor != rotationScaleFactor ||
+        oldDelegate.frameOpacity != frameOpacity;
   }
 
   /// Create a copy of the [CropCornerPainter].
@@ -419,6 +439,7 @@ class CropCornerPainter extends CustomPainter {
       scaleFactor: scaleFactor,
       style: style,
       rotationScaleFactor: rotationScaleFactor,
+      frameOpacity: frameOpacity,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.4.8
+version: 12.5.0
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/features/crop_rotate_editor/crop_rotate_editor_test.dart
+++ b/test/features/crop_rotate_editor/crop_rotate_editor_test.dart
@@ -245,6 +245,140 @@ void main() {
     });
   });
 
+  group('CropRotateEditor keep aspect ratio on rotate', () {
+    CropRotateEditorInitConfigs buildConfigs({
+      required bool enableLock,
+      double? initAspectRatio,
+    }) {
+      return CropRotateEditorInitConfigs(
+        theme: ThemeData.light(),
+        enableFakeHero: false,
+        mainImageSize: const Size(600, 800),
+        configs: ProImageEditorConfigs(
+          cropRotateEditor: CropRotateEditorConfigs(
+            initAspectRatio: initAspectRatio,
+            enableKeepAspectRatioOnRotate: enableLock,
+            animationDuration: Duration.zero,
+            cropDragAnimationDuration: Duration.zero,
+            fadeInOutsideCropAreaAnimationDuration: Duration.zero,
+            opacityOutsideCropAreaDuration: Duration.zero,
+          ),
+          imageGeneration: const ImageGenerationConfigs(
+            enableBackgroundGeneration: false,
+            enableIsolateGeneration: false,
+          ),
+        ),
+      );
+    }
+
+    Future<GlobalKey<CropRotateEditorState>> pumpLockEditor(
+      WidgetTester tester, {
+      required bool enableLock,
+      double? initAspectRatio,
+    }) async {
+      final editorKey = GlobalKey<CropRotateEditorState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CropRotateEditor.memory(
+              mockMemoryImage,
+              key: editorKey,
+              initConfigs: buildConfigs(
+                enableLock: enableLock,
+                initAspectRatio: initAspectRatio,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+      return editorKey;
+    }
+
+    testWidgets('keeps the selected ratio orientation when enabled', (
+      WidgetTester tester,
+    ) async {
+      final editorKey = await pumpLockEditor(
+        tester,
+        enableLock: true,
+        initAspectRatio: 9 / 16,
+      );
+
+      // Initially the crop frame matches the selected 9:16 ratio.
+      expect(
+        editorKey.currentState!.cropRect.size.aspectRatio,
+        closeTo(9 / 16, 0.01),
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey('crop-rotate-editor-rotate-btn')),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      // After rotating, the local crop rect is inverted so the on-screen frame
+      // keeps the 9:16 orientation.
+      expect(editorKey.currentState!.rotationCount, 1);
+      expect(
+        editorKey.currentState!.cropRect.size.aspectRatio,
+        closeTo(16 / 9, 0.01),
+      );
+    });
+
+    testWidgets('swaps the ratio orientation when disabled', (
+      WidgetTester tester,
+    ) async {
+      final editorKey = await pumpLockEditor(
+        tester,
+        enableLock: false,
+        initAspectRatio: 9 / 16,
+      );
+
+      expect(
+        editorKey.currentState!.cropRect.size.aspectRatio,
+        closeTo(9 / 16, 0.01),
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey('crop-rotate-editor-rotate-btn')),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      // Without the option the local crop rect stays unchanged, so on-screen it
+      // appears as 16:9 after the rotation.
+      expect(editorKey.currentState!.rotationCount, 1);
+      expect(
+        editorKey.currentState!.cropRect.size.aspectRatio,
+        closeTo(9 / 16, 0.01),
+      );
+    });
+
+    testWidgets('keeps orientation for the free aspect ratio', (
+      WidgetTester tester,
+    ) async {
+      // No initAspectRatio => free ratio, the crop frame matches the image
+      // (600x800 => 3:4).
+      final editorKey = await pumpLockEditor(tester, enableLock: true);
+
+      expect(
+        editorKey.currentState!.cropRect.size.aspectRatio,
+        closeTo(3 / 4, 0.01),
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey('crop-rotate-editor-rotate-btn')),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      // The local crop rect is inverted so the on-screen frame keeps the 3:4
+      // orientation even with a free ratio.
+      expect(editorKey.currentState!.rotationCount, 1);
+      expect(
+        editorKey.currentState!.cropRect.size.aspectRatio,
+        closeTo(4 / 3, 0.01),
+      );
+    });
+  });
+
   group('CropRotateEditor Aspect Ratio Dialog Tests', () {
     testWidgets('Opens and selects an aspect ratio', (
       WidgetTester tester,


### PR DESCRIPTION
## Summary

Closes #655.

Adds an opt-in flag `CropRotateEditorConfigs.enableKeepAspectRatioOnRotate` that keeps the crop frame's orientation when the image is rotated. With it enabled, a `9:16` crop **stays `9:16`** after a 90° rotation instead of inverting to `16:9`, and the image is zoomed in so it still fully covers the crop area.

```dart
ProImageEditorConfigs(
  cropRotateEditor: CropRotateEditorConfigs(
    enableKeepAspectRatioOnRotate: true,
  ),
)
```

- Works for **fixed**, **`original`** (`0`) and **`free`** (`-1`) aspect ratios — the current crop frame orientation is preserved by inverting its ratio.
- Defaults to `false`, so existing behavior is unchanged (backward compatible, as requested in the issue).

## How it works

- The crop frame lives inside the rotating image transform, so letting it rotate would make a `9:16` frame visibly widen towards `1:1` at the 45° mark. To avoid this, during a locked rotation the crop overlay is **faded out**, the image **rotates + zooms** while the frame is hidden, and the frame is then **faded back in** at the preserved aspect ratio.
- The target crop is computed by inverting the current crop ratio (`calcCropRect(newRatio: …)`), which keeps the on-screen orientation regardless of the ratio mode.
- The rotation mechanics (`angle`, `flipX`/`flipY`, export `cropRect`) are unchanged, so cropping/export stay correct — no flip-swap changes were needed.

## Changes

- `CropRotateEditorConfigs`: new `enableKeepAspectRatioOnRotate` flag (+ `copyWith`).
- `CropRotateEditor`: locked-rotation flow (fade out → rotate/zoom → fade in); only active when the flag is enabled, otherwise the normal rotate path is used.
- `CropCornerPainter`: new `frameOpacity` multiplier to cleanly fade the crop overlay to transparent (the existing `fadeInOpacity` blends towards the background/hero state, which would hide the image outside the crop while rotating).

## Tests

Added widget tests covering the enabled (fixed + free ratio) and disabled cases. `flutter analyze` is clean and all crop-rotate tests pass.