### PR TITLE
feat(interactive-viewer): add clip behavior configuration for interactive content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.5.1
+- **FEAT**(main-editor): Add `clipBehavior` option to `MainEditorConfigs` (default `Clip.hardEdge`) to control clipping of the editor's interactive content area.
+
 ## 12.5.0
 - **FEAT**(crop-rotate): Add `enableKeepAspectRatioOnRotate` option to keep the selected aspect ratio orientation when rotating (e.g. `9:16` stays `9:16` instead of becoming `16:9`), zooming the image in so it still fully covers the crop area.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 12.5.1
-- **FEAT**(main-editor): Add `clipBehavior` option to `MainEditorConfigs` (default `Clip.hardEdge`) to control clipping of the editor's interactive content area.
+- **FEAT**(main-editor): Add `interactiveViewerClipBehavior` option to `MainEditorConfigs` (default `Clip.hardEdge`) to control clipping of the editor's interactive content area.
 
 ## 12.5.0
 - **FEAT**(crop-rotate): Add `enableKeepAspectRatioOnRotate` option to keep the selected aspect ratio orientation when rotating (e.g. `9:16` stays `9:16` instead of becoming `16:9`), zooming the image in so it still fully covers the crop area.

--- a/lib/core/models/editor_configs/main_editor_configs.dart
+++ b/lib/core/models/editor_configs/main_editor_configs.dart
@@ -175,7 +175,7 @@ class MainEditorConfigs extends ZoomConfigs {
     bool? enableSubEditorPage,
     bool? captureImageOnDone,
     bool? captureLayersOnDone,
-    Clip? clipBehavior,
+    Clip? interactiveViewerClipBehavior,
   }) {
     return MainEditorConfigs(
       enableSubEditorPage: enableSubEditorPage ?? this.enableSubEditorPage,
@@ -206,7 +206,7 @@ class MainEditorConfigs extends ZoomConfigs {
       safeArea: safeArea ?? this.safeArea,
       tools: tools ?? this.tools,
       interactiveViewerClipBehavior:
-          clipBehavior ?? this.interactiveViewerClipBehavior,
+          interactiveViewerClipBehavior ?? this.interactiveViewerClipBehavior,
     );
   }
 }

--- a/lib/core/models/editor_configs/main_editor_configs.dart
+++ b/lib/core/models/editor_configs/main_editor_configs.dart
@@ -50,6 +50,7 @@ class MainEditorConfigs extends ZoomConfigs {
     this.icons = const MainEditorIcons(),
     this.widgets = const MainEditorWidgets(),
     this.safeArea = const EditorSafeArea(),
+    this.clipBehavior = Clip.hardEdge,
   });
 
   /// Determines whether the close button is displayed on the widget.
@@ -99,6 +100,11 @@ class MainEditorConfigs extends ZoomConfigs {
 
   /// Defines the safe area configuration for the editor.
   final EditorSafeArea safeArea;
+
+  /// Defines the clip behavior of the editor's interactive content area.
+  ///
+  /// Defaults to [Clip.hardEdge].
+  final Clip clipBehavior;
 
   /// Whether to capture all active layers as images when [doneEditing] is
   /// called and include them in [CompleteParameters.capturedLayers].
@@ -169,6 +175,7 @@ class MainEditorConfigs extends ZoomConfigs {
     bool? enableSubEditorPage,
     bool? captureImageOnDone,
     bool? captureLayersOnDone,
+    Clip? clipBehavior,
   }) {
     return MainEditorConfigs(
       enableSubEditorPage: enableSubEditorPage ?? this.enableSubEditorPage,
@@ -198,6 +205,7 @@ class MainEditorConfigs extends ZoomConfigs {
       boundaryMargin: boundaryMargin ?? this.boundaryMargin,
       safeArea: safeArea ?? this.safeArea,
       tools: tools ?? this.tools,
+      clipBehavior: clipBehavior ?? this.clipBehavior,
     );
   }
 }

--- a/lib/core/models/editor_configs/main_editor_configs.dart
+++ b/lib/core/models/editor_configs/main_editor_configs.dart
@@ -50,7 +50,7 @@ class MainEditorConfigs extends ZoomConfigs {
     this.icons = const MainEditorIcons(),
     this.widgets = const MainEditorWidgets(),
     this.safeArea = const EditorSafeArea(),
-    this.clipBehavior = Clip.hardEdge,
+    this.interactiveViewerClipBehavior = Clip.hardEdge,
   });
 
   /// Determines whether the close button is displayed on the widget.
@@ -104,7 +104,7 @@ class MainEditorConfigs extends ZoomConfigs {
   /// Defines the clip behavior of the editor's interactive content area.
   ///
   /// Defaults to [Clip.hardEdge].
-  final Clip clipBehavior;
+  final Clip interactiveViewerClipBehavior;
 
   /// Whether to capture all active layers as images when [doneEditing] is
   /// called and include them in [CompleteParameters.capturedLayers].
@@ -205,7 +205,8 @@ class MainEditorConfigs extends ZoomConfigs {
       boundaryMargin: boundaryMargin ?? this.boundaryMargin,
       safeArea: safeArea ?? this.safeArea,
       tools: tools ?? this.tools,
-      clipBehavior: clipBehavior ?? this.clipBehavior,
+      interactiveViewerClipBehavior:
+          clipBehavior ?? this.interactiveViewerClipBehavior,
     );
   }
 }

--- a/lib/features/main_editor/widgets/main_editor_interactive_content.dart
+++ b/lib/features/main_editor/widgets/main_editor_interactive_content.dart
@@ -186,6 +186,7 @@ class MainEditorInteractiveContent extends StatelessWidget {
     return ExtendedInteractiveViewer(
       key: interactiveViewerKey,
       enableExternalGestureDetector: true,
+      clipBehavior: mainConfigs.clipBehavior,
       zoomConfigs: mainConfigs,
       onInteractionStart: (details) {
         callbacks.mainEditorCallbacks?.onEditorZoomScaleStart?.call(details);

--- a/lib/features/main_editor/widgets/main_editor_interactive_content.dart
+++ b/lib/features/main_editor/widgets/main_editor_interactive_content.dart
@@ -186,7 +186,7 @@ class MainEditorInteractiveContent extends StatelessWidget {
     return ExtendedInteractiveViewer(
       key: interactiveViewerKey,
       enableExternalGestureDetector: true,
-      clipBehavior: mainConfigs.clipBehavior,
+      clipBehavior: mainConfigs.interactiveViewerClipBehavior,
       zoomConfigs: mainConfigs,
       onInteractionStart: (details) {
         callbacks.mainEditorCallbacks?.onEditorZoomScaleStart?.call(details);

--- a/lib/shared/widgets/extended/interactive_viewer/extended_interactive_viewer.dart
+++ b/lib/shared/widgets/extended/interactive_viewer/extended_interactive_viewer.dart
@@ -21,7 +21,16 @@ class ExtendedInteractiveViewer extends StatefulWidget {
     this.onMatrix4Change,
     this.initialMatrix4,
     this.enableExternalGestureDetector = false,
+    this.clipBehavior = Clip.hardEdge,
   });
+
+  /// How to clip the child during zoom/pan.
+  ///
+  /// Defaults to [Clip.hardEdge], which confines the transformed child to the
+  /// viewport. Set to [Clip.none] to let the zoomed child overflow the
+  /// viewport (e.g. a video editor where the zoomed frame should extend over
+  /// the letterbox area).
+  final Clip clipBehavior;
 
   /// Configuration options that control zoom behavior and limits.
   ///
@@ -310,6 +319,7 @@ class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer>
       onInteractionEnd: widget.onInteractionEnd,
       enableExternalGestureDetector: widget.enableExternalGestureDetector,
       invertTrackpadDirection: widget.zoomConfigs.invertTrackpadDirection,
+      clipBehavior: widget.clipBehavior,
       child: widget.child,
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.5.0
+version: 12.5.1
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/


### PR DESCRIPTION
## Description

Added a `clipBehavior` option to `MainEditorConfigs` to control the clipping of the editor's interactive content area, defaulting to `Clip.hardEdge`.

**Related Issue:** Closes #

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

