### PR TITLE
fix: prevent layer scale compounding during multiple layer additions in paint sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.5.2
+- **FIX**(main-editor): Prevent layer scale from compounding (layers shrinking) when a single paint session adds multiple layers. Shared layer instances reused across history entries are now rescaled at most once per resize/import recalculation.
+
 ## 12.5.1
 - **FEAT**(main-editor): Add `interactiveViewerClipBehavior` option to `MainEditorConfigs` (default `Clip.hardEdge`) to control clipping of the editor's interactive content area.
 

--- a/lib/features/main_editor/services/main_editor_state_history_service.dart
+++ b/lib/features/main_editor/services/main_editor_state_history_service.dart
@@ -108,8 +108,16 @@ class MainEditorStateHistoryService {
   }
 
   void _recalculateSizeAndPosition(ImportStateHistory import) {
+    // A single layer instance can be shared across multiple history entries.
+    // Mutating it in place once per entry would compound the scale factor, so
+    // track processed instances by object identity and rescale each at most
+    // once. `Layer.==` is content-based, hence `Set<Layer>.identity()` to keep
+    // independent-but-equal copies distinct.
+    final processed = Set<Layer>.identity();
+
     for (EditorStateHistory el in import.stateHistory) {
       for (Layer layer in el.layers) {
+        if (!processed.add(layer)) continue;
         if (import.configs.recalculateSizeAndPosition) {
           Size currentImageSize = sizesManager.decodedImageSize;
           Size lastRenderedImgSize = import.lastRenderedImgSize;

--- a/lib/features/main_editor/services/sizes_manager.dart
+++ b/lib/features/main_editor/services/sizes_manager.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/history/state_history.dart';
+import '/core/models/layers/layer.dart';
 import '/shared/widgets/screen_resize_detector.dart';
 
 /// A helper class for managing screen size and padding calculations.
@@ -129,6 +130,16 @@ class SizesManager {
       }
     }
 
+    // A single layer instance can be shared across multiple history entries
+    // (e.g. layers added in one paint session reuse the same pre-existing
+    // instances — see `openPaintEditor`). Rescaling in place would otherwise
+    // mutate that instance once per entry, compounding the scale factor. Track
+    // processed instances by object identity so each is rescaled at most once.
+    //
+    // `Layer.==` is content-based, so independent-but-equal copies must remain
+    // distinct here — a plain `Set<Layer>` would wrongly collapse them.
+    final processed = Set<Layer>.identity();
+
     for (int i = 0; i < history.length; i++) {
       var el = history[i];
 
@@ -157,6 +168,7 @@ class SizesManager {
       );
       if (scaleFactor != 0) {
         for (var layer in el.layers) {
+          if (!processed.add(layer)) continue;
           layer
             ..scale /= scaleFactor
             ..offset /= scaleFactor;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.5.2-dev.1
+version: 12.5.2
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.5.1
+version: 12.5.2-dev.1
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/features/main_editor/sizes_manager_test.dart
+++ b/test/features/main_editor/sizes_manager_test.dart
@@ -1,0 +1,185 @@
+// Flutter imports:
+import 'package:flutter/material.dart';
+
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
+import 'package:pro_image_editor/features/main_editor/services/sizes_manager.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_image_editor/shared/widgets/screen_resize_detector.dart';
+
+void main() {
+  const configs = ProImageEditorConfigs();
+
+  // A square decoded image plus a 2x content shrink yields a resize
+  // `scaleFactor` of exactly 2, so every distinct layer is rescaled by 1/2.
+  const decodedImageSize = Size(100, 100);
+  const resizeEvent = ResizeEvent(
+    oldContentSize: Size(200, 200),
+    newContentSize: Size(100, 100),
+  );
+  const scaleFactor = 2.0;
+  const initialScale = 2.0;
+  const initialOffset = Offset(40, 60);
+
+  TextLayer buildTextLayer() => TextLayer(
+    text: 'Hello',
+    scale: initialScale,
+    offset: initialOffset,
+  );
+
+  PaintLayer buildPaintLayer() => PaintLayer(
+    scale: 1.0,
+    offset: Offset.zero,
+    rawSize: const Size(10, 10),
+    opacity: 1.0,
+    item: PaintedModel(
+      mode: PaintMode.line,
+      offsets: const [Offset(0, 0), Offset(5, 5)],
+      erasedOffsets: const [],
+      color: const Color(0xFF000000),
+      strokeWidth: 2,
+      opacity: 1,
+    ),
+  );
+
+  /// Reproduces the shared-instance history shape produced by
+  /// `MainEditor.openPaintEditor`: pre-existing layers are deep-copied ONCE and
+  /// the very same instances are then reused (via `List<Layer>.of`) across
+  /// every per-stroke history entry. The supplied [textLayer] instance
+  /// therefore appears in all `paintLayerCount + 1` entries.
+  List<EditorStateHistory> buildPaintSessionHistory({
+    required TextLayer textLayer,
+    required int paintLayerCount,
+  }) {
+    final runningLayers = <Layer>[textLayer];
+    final history = <EditorStateHistory>[
+      EditorStateHistory(layers: List<Layer>.of(runningLayers)),
+    ];
+    for (var i = 0; i < paintLayerCount; i++) {
+      runningLayers.add(buildPaintLayer());
+      history.add(
+        EditorStateHistory(layers: List<Layer>.of(runningLayers)),
+      );
+    }
+    return history;
+  }
+
+  /// Builds a [SizesManager] wired up for `recalculateLayerPosition`.
+  Future<SizesManager> buildSizesManager(WidgetTester tester) async {
+    late SizesManager sizesManager;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            sizesManager = SizesManager(context: context, configs: configs)
+              ..decodedImageSize = decodedImageSize;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    return sizesManager;
+  }
+
+  group('SizesManager.recalculateLayerPosition', () {
+    testWidgets(
+      'rescales a layer shared across many history entries exactly once',
+      (tester) async {
+        final sizesManager = await buildSizesManager(tester);
+
+        final textLayer = buildTextLayer();
+        sizesManager.recalculateLayerPosition(
+          history: buildPaintSessionHistory(
+            textLayer: textLayer,
+            paintLayerCount: 10,
+          ),
+          resizeEvent: resizeEvent,
+        );
+
+        // Rescaled once (scale / scaleFactor), NOT once-per-entry which would
+        // compound to scale / scaleFactor^11 and shrink the layer to nothing.
+        expect(textLayer.scale, closeTo(initialScale / scaleFactor, 1e-9));
+        expect(
+          textLayer.offset.dx,
+          closeTo(initialOffset.dx / scaleFactor, 1e-9),
+        );
+        expect(
+          textLayer.offset.dy,
+          closeTo(initialOffset.dy / scaleFactor, 1e-9),
+        );
+
+        const compounded = initialScale / (scaleFactor * scaleFactor);
+        expect(
+          textLayer.scale,
+          isNot(lessThanOrEqualTo(compounded)),
+          reason: 'scale must not compound across shared history entries',
+        );
+      },
+    );
+
+    testWidgets(
+      'final scale is independent of the number of layers in the session',
+      (tester) async {
+        final sizesManager = await buildSizesManager(tester);
+
+        final singleSessionLayer = buildTextLayer();
+        final manySessionLayer = buildTextLayer();
+
+        sizesManager
+          ..recalculateLayerPosition(
+            history: buildPaintSessionHistory(
+              textLayer: singleSessionLayer,
+              paintLayerCount: 1,
+            ),
+            resizeEvent: resizeEvent,
+          )
+          ..recalculateLayerPosition(
+            history: buildPaintSessionHistory(
+              textLayer: manySessionLayer,
+              paintLayerCount: 25,
+            ),
+            resizeEvent: resizeEvent,
+          );
+
+        expect(
+          manySessionLayer.scale,
+          closeTo(singleSessionLayer.scale, 1e-9),
+        );
+        expect(
+          manySessionLayer.scale,
+          closeTo(initialScale / scaleFactor, 1e-9),
+        );
+      },
+    );
+
+    testWidgets(
+      'still rescales every distinct copy in the normal per-entry-copy case',
+      (tester) async {
+        final sizesManager = await buildSizesManager(tester);
+
+        // Independent-but-content-equal copies, as produced by the normal
+        // `copyLayerList` per-entry invariant (`copyWith` preserves the id, so
+        // the copies compare equal). Because `Layer.==` is content-based these
+        // are equal, so the identity-dedup guard must keep them distinct and
+        // rescale each one.
+        final copyA = buildTextLayer();
+        final copyB = copyA.copyWith();
+        expect(copyA == copyB, isTrue);
+        expect(identical(copyA, copyB), isFalse);
+
+        sizesManager.recalculateLayerPosition(
+          history: [
+            EditorStateHistory(layers: [copyA]),
+            EditorStateHistory(layers: [copyB]),
+          ],
+          resizeEvent: resizeEvent,
+        );
+
+        expect(copyA.scale, closeTo(initialScale / scaleFactor, 1e-9));
+        expect(copyB.scale, closeTo(initialScale / scaleFactor, 1e-9));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

Prevent layer scale from compounding (layers shrinking) when a single paint session adds multiple layers. Shared layer instances reused across history entries are now rescaled at most once per resize/import recalculation.

**Related Issue:** Closes #

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

