### PR TITLE
feat(import-export): add optional widgetLoader and widgetRecords parameters to CompleteParameters for improved layer reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.6.0
+- **FEAT**(import-export): Add optional `widgetLoader` (and `widgetRecords`) parameters to `CompleteParameters.fromMap` and `CompleteParameters.fromJson` so widget/sticker layers exported with an `exportConfigs.id` can be reconstructed. This is a non-breaking, additive change; existing callers are unaffected.
+
 ## 12.5.3
 - **CHORE**(main-editor): Refactor the layer-scale regression test for readability.
 

--- a/lib/core/models/complete_parameters.dart
+++ b/lib/core/models/complete_parameters.dart
@@ -8,6 +8,7 @@ import '/features/clips_editor/models/video_clip.dart';
 import '/features/filter_editor/types/filter_state.dart';
 import '/features/filter_editor/utils/combine_color_matrix_utils.dart';
 import '/features/tune_editor/models/tune_adjustment_matrix.dart';
+import '/shared/services/import_export/types/widget_loader.dart';
 import 'layers/exported_layer.dart';
 import 'layers/layer.dart';
 
@@ -19,7 +20,17 @@ class CompleteParameters {
   /// Creates a [CompleteParameters] instance from a [Map].
   ///
   /// Useful for deserialization from storage or network responses.
-  factory CompleteParameters.fromMap(Map<String, dynamic> map) {
+  ///
+  /// The optional [widgetLoader] is required to rebuild any [WidgetLayer] that
+  /// was exported with an `exportConfigs.id`. Without it, deserializing such a
+  /// layer throws.
+  ///
+  /// {@macro widgetLoader}
+  factory CompleteParameters.fromMap(
+    Map<String, dynamic> map, {
+    WidgetLoader? widgetLoader,
+    List<Uint8List>? widgetRecords,
+  }) {
     return CompleteParameters(
       blur: map['blur']?.toDouble() ?? 0.0,
       matrixFilterList: List<List<double>>.from(
@@ -45,7 +56,14 @@ class CompleteParameters {
       image: Uint8List.fromList(List<int>.from(map['image'] ?? [])),
       isTransformed: map['isTransformed'] ?? false,
       layers: List<Layer>.from(
-        map['layers']?.map((x) => Layer.fromMap(x)) ?? [],
+        map['layers']?.map(
+              (x) => Layer.fromMap(
+                x,
+                widgetLoader: widgetLoader,
+                widgetRecords: widgetRecords,
+              ),
+            ) ??
+            [],
       ),
       originalImageSize: map['originalImageSize'] != null
           ? Size(
@@ -76,8 +94,20 @@ class CompleteParameters {
   }
 
   /// Creates a [CompleteParameters] instance from a JSON string.
-  factory CompleteParameters.fromJson(String source) =>
-      CompleteParameters.fromMap(json.decode(source));
+  ///
+  /// The optional [widgetLoader] is forwarded to [fromMap] to rebuild any
+  /// [WidgetLayer] that was exported with an `exportConfigs.id`.
+  ///
+  /// {@macro widgetLoader}
+  factory CompleteParameters.fromJson(
+    String source, {
+    WidgetLoader? widgetLoader,
+    List<Uint8List>? widgetRecords,
+  }) => CompleteParameters.fromMap(
+    json.decode(source),
+    widgetLoader: widgetLoader,
+    widgetRecords: widgetRecords,
+  );
 
   /// Creates a [CompleteParameters] instance with all required values.
   CompleteParameters({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.5.3
+version: 12.6.0
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/core/models/complete_parameters_test.dart
+++ b/test/core/models/complete_parameters_test.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_image_editor/core/models/complete_parameters.dart';
+import 'package:pro_image_editor/core/models/layers/layer.dart';
+
+void main() {
+  CompleteParameters buildParameters({required List<Layer> layers}) {
+    return CompleteParameters(
+      blur: 0,
+      matrixFilterList: const [],
+      matrixTuneAdjustmentsList: const [],
+      startTime: null,
+      endTime: null,
+      cropWidth: null,
+      cropHeight: null,
+      rotateTurns: 0,
+      cropX: null,
+      cropY: null,
+      flipX: false,
+      flipY: false,
+      image: Uint8List.fromList(const [1, 2, 3]),
+      isTransformed: false,
+      layers: layers,
+      originalImageSize: const Size(100, 100),
+      temporaryDecodedImageSize: const Size(100, 100),
+      bodySize: const Size(100, 100),
+      editorSize: const Size(100, 100),
+    );
+  }
+
+  group('CompleteParameters id-based widget layer import', () {
+    test(
+      'fromMap without a widgetLoader fails for an id-based widget layer',
+      () {
+        final params = buildParameters(
+          layers: [
+            WidgetLayer(
+              widget: const SizedBox(),
+              exportConfigs: const WidgetLayerExportConfigs(
+                id: 'x',
+                meta: {'foo': 'bar'},
+              ),
+            ),
+          ],
+        );
+
+        final map =
+            json.decode(json.encode(params.toMap())) as Map<String, dynamic>;
+
+        expect(() => CompleteParameters.fromMap(map), throwsAssertionError);
+      },
+    );
+
+    test('fromMap with a widgetLoader rebuilds the id-based widget layer', () {
+      String? loadedId;
+      Map<String, dynamic>? loadedMeta;
+
+      final params = buildParameters(
+        layers: [
+          WidgetLayer(
+            widget: const SizedBox(),
+            exportConfigs: const WidgetLayerExportConfigs(
+              id: 'x',
+              meta: {'foo': 'bar'},
+            ),
+          ),
+        ],
+      );
+
+      final map =
+          json.decode(json.encode(params.toMap())) as Map<String, dynamic>;
+
+      const loaderWidget = SizedBox();
+      final restored = CompleteParameters.fromMap(
+        map,
+        widgetLoader: (String id, {Map<String, dynamic>? meta}) {
+          loadedId = id;
+          loadedMeta = meta;
+          return loaderWidget;
+        },
+      );
+
+      expect(restored.layers, hasLength(1));
+      final layer = restored.layers.first;
+      expect(layer, isA<WidgetLayer>());
+      expect((layer as WidgetLayer).widget, same(loaderWidget));
+      expect(layer.exportConfigs.id, 'x');
+      expect(loadedId, 'x');
+      expect(loadedMeta, {'foo': 'bar'});
+    });
+
+    test(
+      'fromMap deserializes identically with and without a loader when there '
+      'are no widget layers',
+      () {
+        final params = buildParameters(
+          layers: [
+            Layer(offset: const Offset(5, 6), rotation: 0.25, scale: 1.5),
+          ],
+        );
+
+        final map =
+            json.decode(json.encode(params.toMap())) as Map<String, dynamic>;
+
+        final withoutLoader = CompleteParameters.fromMap(map);
+        final withLoader = CompleteParameters.fromMap(
+          map,
+          widgetLoader: (String id, {Map<String, dynamic>? meta}) =>
+              const SizedBox(),
+        );
+
+        // The base `Layer` regenerates a random `id` on each import, so compare
+        // the serialized form (which omits the id) to assert identical results.
+        expect(withoutLoader.layers, hasLength(1));
+        expect(withLoader.layers, hasLength(1));
+        expect(
+          withoutLoader.layers.first.toMap(),
+          withLoader.layers.first.toMap(),
+        );
+        expect(withoutLoader.layers.first.offset, const Offset(5, 6));
+      },
+    );
+  });
+}


### PR DESCRIPTION


## Description

Enhance the `CompleteParameters` class by introducing optional `widgetLoader` and `widgetRecords` parameters to support the reconstruction of widget layers exported with an `exportConfigs.id`. This change maintains backward compatibility for existing functionality.

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

