### PR TITLE
feat: Add per-layer animations support for PaintLayer, TextLayer, and WidgetLayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.7.0
+- **FEAT**(layers): Add first-class per-layer enter/leave animations for the video timeline. A new `LayerAnimation` model (`type` fade/slide/scale, `phase` animateIn/animateOut/animateInOut, `duration`, `curve`, optional `slideDirection` and `scaleFrom`) can be attached to any layer via the new `Layer.animations` list (or set on an existing layer through `ProImageEditor.setLayerTimeline(animations: …)`), mirroring the `pro_video_editor` model so the in-editor preview matches the exported result. The video-layer-timeline preview is now phase-aware: it composes fade (opacity), slide (per-direction translation) and scale effects across a layer's enter and exit windows, so the enter and leave phases can use distinct animation types. The legacy `enterDuration` / `exitDuration` / `enterCurve` / `exitCurve` fade fields are kept as a back-compat convenience and can be read as a unified animation list via `Layer.effectiveAnimations`. `animations` is serialized in `toMap` / `fromMap` and carried through `copyWith`, equality and layer cloning. Non-breaking, additive change.
+
 ## 12.6.0
 - **FEAT**(import-export): Add optional `widgetLoader` (and `widgetRecords`) parameters to `CompleteParameters.fromMap` and `CompleteParameters.fromJson` so widget/sticker layers exported with an `exportConfigs.id` can be reconstructed. This is a non-breaking, additive change; existing callers are unaffected.
 

--- a/lib/core/models/layers/emoji_layer.dart
+++ b/lib/core/models/layers/emoji_layer.dart
@@ -44,6 +44,7 @@ class EmojiLayer extends Layer {
     super.enterCurve,
     super.exitCurve,
     super.transitionBuilder,
+    super.animations,
   });
 
   /// Factory constructor for creating an EmojiLayer instance from a Layer
@@ -73,6 +74,7 @@ class EmojiLayer extends Layer {
       exitDuration: layer.exitDuration,
       enterCurve: layer.enterCurve,
       exitCurve: layer.exitCurve,
+      animations: layer.animations,
       emoji: map[keyConverter('emoji')],
       boxConstraints: layer.boxConstraints,
     );
@@ -137,6 +139,7 @@ class EmojiLayer extends Layer {
     Curve? enterCurve,
     Curve? exitCurve,
     LayerTimelineTransitionBuilder? transitionBuilder,
+    List<LayerAnimation>? animations,
   }) {
     return EmojiLayer(
       emoji: emoji ?? this.emoji,
@@ -157,6 +160,7 @@ class EmojiLayer extends Layer {
       enterCurve: enterCurve ?? this.enterCurve,
       exitCurve: exitCurve ?? this.exitCurve,
       transitionBuilder: transitionBuilder ?? this.transitionBuilder,
+      animations: animations ?? this.animations,
     );
   }
 

--- a/lib/core/models/layers/layer.dart
+++ b/lib/core/models/layers/layer.dart
@@ -17,6 +17,7 @@ import '/shared/services/content_recorder/controllers/content_recorder_controlle
 import '/shared/services/import_export/types/widget_loader.dart';
 import '/shared/services/import_export/utils/key_minifier.dart';
 import '/shared/utils/map_utils.dart';
+import '/shared/utils/parser/animation_curve_parser.dart';
 import '/shared/utils/parser/bool_parser.dart';
 import '/shared/utils/parser/curve_parser.dart';
 import '/shared/utils/parser/double_parser.dart';
@@ -24,6 +25,7 @@ import '/shared/utils/unique_id_generator.dart';
 import '../editor_image.dart';
 import 'emoji_layer.dart';
 import 'exported_layer.dart';
+import 'layer_animation.dart';
 import 'layer_interaction.dart';
 import 'paint_layer.dart';
 import 'text_layer.dart';
@@ -32,6 +34,7 @@ import 'widget_layer.dart';
 export '/core/models/editor_configs/video/layer_timeline_configs.dart'
     show LayerTimelineTransitionBuilder;
 export 'emoji_layer.dart';
+export 'layer_animation.dart';
 export 'paint_layer.dart';
 export 'text_layer.dart';
 export 'widget_layer.dart';
@@ -58,11 +61,13 @@ class Layer {
     this.enterCurve,
     this.exitCurve,
     this.transitionBuilder,
+    List<LayerAnimation>? animations,
   }) : key = key ??= GlobalKey(),
        keyInternalSize = GlobalKey(),
        repaintBoundaryKey = GlobalKey(),
        id = id ?? generateUniqueId(),
-       interaction = interaction ?? LayerInteraction();
+       interaction = interaction ?? LayerInteraction(),
+       animations = animations ?? <LayerAnimation>[];
 
   /// Factory constructor for creating a Layer instance from a map and a list
   /// of stickers.
@@ -124,6 +129,11 @@ class Layer {
           : null,
       enterCurve: parseCurve(map[keyConverter('enterCurve')] as String?),
       exitCurve: parseCurve(map[keyConverter('exitCurve')] as String?),
+      animations: (map[keyConverter('animations')] as List<dynamic>?)
+          ?.map(
+            (e) => LayerAnimation.fromMap(Map<String, dynamic>.from(e as Map)),
+          )
+          .toList(),
     );
 
     /// Determines the layer type from the map and returns the appropriate
@@ -195,7 +205,60 @@ class Layer {
   /// A builder that wraps this layer with an animated transition.
   ///
   /// When `null`, falls back to [LayerTimelineConfigs.transitionBuilder].
+  ///
+  /// Only used as the legacy fade convenience when [animations] is empty. When
+  /// [animations] is not empty, the phase-aware fade/slide/scale composition
+  /// takes over and this builder is ignored.
   LayerTimelineTransitionBuilder? transitionBuilder;
+
+  /// Per-layer enter/leave animations for the video timeline.
+  ///
+  /// Each [LayerAnimation] drives a fade, slide, or scale effect during the
+  /// layer's enter window (`[startTime, startTime + duration]`) and/or exit
+  /// window (`[endTime - duration, endTime]`). Multiple animations can be
+  /// combined on the same phase (e.g. a slide-in together with a fade-in).
+  ///
+  /// When empty, the layer falls back to the legacy fade convenience driven by
+  /// [enterDuration] / [exitDuration] / [enterCurve] / [exitCurve] and
+  /// [transitionBuilder].
+  ///
+  /// Mirrors the `animations` model in the sister package `pro_video_editor`
+  /// so the in-editor preview matches the exported result.
+  List<LayerAnimation> animations;
+
+  /// The animations effectively applied to this layer, deriving a fade from the
+  /// legacy [enterDuration] / [exitDuration] when [animations] is empty.
+  ///
+  /// Returns [animations] unchanged when it is not empty. Otherwise synthesizes
+  /// fade [AnimationPhase.animateIn] / [AnimationPhase.animateOut] entries from
+  /// the legacy fade fields, so callers (e.g. exporters bridging to
+  /// `pro_video_editor`) get a single, unified animation list.
+  ///
+  /// When [enterCurve] / [exitCurve] are `null`, the synthesized fades fall back
+  /// to the same defaults the in-editor preview uses
+  /// ([LayerTimelineConfigs.enterCurve] `Curves.easeIn` /
+  /// [LayerTimelineConfigs.exitCurve] `Curves.easeOut`), so the exported result
+  /// matches the preview for the common legacy case.
+  List<LayerAnimation> get effectiveAnimations {
+    if (animations.isNotEmpty) return animations;
+
+    return [
+      if (enterDuration != null && enterDuration! > Duration.zero)
+        LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateIn,
+          duration: enterDuration!,
+          curve: animationCurveFromCurve(enterCurve ?? Curves.easeIn),
+        ),
+      if (exitDuration != null && exitDuration! > Duration.zero)
+        LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateOut,
+          duration: exitDuration!,
+          curve: animationCurveFromCurve(exitCurve ?? Curves.easeOut),
+        ),
+    ];
+  }
 
   /// Global key associated with the Layer instance, used for accessing the
   /// widget tree.
@@ -291,6 +354,8 @@ class Layer {
       if (exitDuration != null) 'exitDuration': exitDuration!.inMilliseconds,
       if (enterCurve != null) 'enterCurve': curveToString(enterCurve!),
       if (exitCurve != null) 'exitCurve': curveToString(exitCurve!),
+      if (animations.isNotEmpty)
+        'animations': animations.map((a) => a.toMap()).toList(),
     };
   }
 
@@ -335,6 +400,8 @@ class Layer {
       if (layer.enterCurve != enterCurve)
         'enterCurve': curveToString(enterCurve!),
       if (layer.exitCurve != exitCurve) 'exitCurve': curveToString(exitCurve!),
+      if (!listEquals(layer.animations, animations))
+        'animations': animations.map((a) => a.toMap()).toList(),
     };
   }
 
@@ -633,6 +700,7 @@ class Layer {
         other.enterCurve == enterCurve &&
         other.exitCurve == exitCurve &&
         other.transitionBuilder == transitionBuilder &&
+        listEquals(other.animations, animations) &&
         mapIsEqual(other.meta, meta);
   }
 
@@ -654,7 +722,8 @@ class Layer {
         exitDuration.hashCode ^
         enterCurve.hashCode ^
         exitCurve.hashCode ^
-        transitionBuilder.hashCode;
+        transitionBuilder.hashCode ^
+        Object.hashAll(animations);
   }
 
   /// Creates a copy of this [Layer] with the given fields replaced with
@@ -677,6 +746,7 @@ class Layer {
     Curve? enterCurve,
     Curve? exitCurve,
     LayerTimelineTransitionBuilder? transitionBuilder,
+    List<LayerAnimation>? animations,
   }) {
     return Layer(
       id: id ?? this.id,
@@ -696,6 +766,7 @@ class Layer {
       enterCurve: enterCurve ?? this.enterCurve,
       exitCurve: exitCurve ?? this.exitCurve,
       transitionBuilder: transitionBuilder ?? this.transitionBuilder,
+      animations: animations ?? this.animations,
     );
   }
 
@@ -730,6 +801,7 @@ class Layer {
           'transitionBuilder',
           transitionBuilder,
         ),
-      );
+      )
+      ..add(IterableProperty<LayerAnimation>('animations', animations));
   }
 }

--- a/lib/core/models/layers/layer_animation.dart
+++ b/lib/core/models/layers/layer_animation.dart
@@ -1,0 +1,247 @@
+/// The type of animation to apply to a [Layer].
+enum LayerAnimationType {
+  /// Fade opacity from 0 to 1 (in) or 1 to 0 (out).
+  fade,
+
+  /// Slide the layer in/out from a direction.
+  slide,
+
+  /// Scale the layer from small to full size (in) or full to small (out).
+  scale,
+}
+
+/// Slide direction for slide animations.
+enum SlideDirection {
+  /// Slide from/to the left edge.
+  left,
+
+  /// Slide from/to the right edge.
+  right,
+
+  /// Slide from/to the top edge.
+  top,
+
+  /// Slide from/to the bottom edge.
+  bottom,
+}
+
+/// Easing curve for animation timing.
+enum AnimationCurve {
+  /// Constant speed from start to end.
+  linear,
+
+  /// Starts slow, accelerates (quadratic).
+  easeIn,
+
+  /// Starts fast, decelerates (quadratic).
+  easeOut,
+
+  /// Starts slow, accelerates, then decelerates (quadratic).
+  easeInOut,
+
+  /// Starts slow, accelerates (cubic – smoother than [easeIn]).
+  easeInCubic,
+
+  /// Starts fast, decelerates (cubic – smoother than [easeOut]).
+  easeOutCubic,
+
+  /// Starts slow, accelerates, then decelerates (cubic).
+  easeInOutCubic,
+
+  /// Bounces at the start before settling.
+  bounceIn,
+
+  /// Bounces at the end like a ball hitting the ground.
+  bounceOut,
+
+  /// Bounces at both the start and end.
+  bounceInOut,
+
+  /// Overshoots at the start and springs forward.
+  elasticIn,
+
+  /// Overshoots the target and springs back.
+  elasticOut,
+
+  /// Elastic spring effect at both start and end.
+  elasticInOut,
+}
+
+/// Whether the animation plays at the start, end, or both ends of the layer's
+/// time range.
+enum AnimationPhase {
+  /// Animation plays at the beginning of the layer's visible range.
+  animateIn,
+
+  /// Animation plays at the end of the layer's visible range.
+  animateOut,
+
+  /// Animation plays at both the beginning and end using the same duration.
+  animateInOut,
+}
+
+/// A single animation applied to a [Layer] on the video timeline.
+///
+/// Multiple animations can be combined on one layer, e.g. a [fade] in together
+/// with a [slide] in from the left. This model mirrors the `LayerAnimation`
+/// model in the sister package `pro_video_editor`, so the in-editor video
+/// timeline preview matches the exported result.
+///
+/// Example:
+/// ```dart
+/// WidgetLayer(
+///   widget: myWidget,
+///   startTime: Duration.zero,
+///   endTime: const Duration(seconds: 10),
+///   animations: const [
+///     LayerAnimation(
+///       type: LayerAnimationType.slide,
+///       phase: AnimationPhase.animateIn,
+///       duration: Duration(milliseconds: 400),
+///       slideDirection: SlideDirection.left,
+///       curve: AnimationCurve.easeOut,
+///     ),
+///     LayerAnimation(
+///       type: LayerAnimationType.fade,
+///       phase: AnimationPhase.animateOut,
+///       duration: Duration(milliseconds: 300),
+///     ),
+///   ],
+/// )
+/// ```
+class LayerAnimation {
+  /// Creates a [LayerAnimation].
+  const LayerAnimation({
+    required this.type,
+    required this.phase,
+    required this.duration,
+    this.curve = AnimationCurve.linear,
+    this.slideDirection,
+    this.scaleFrom,
+  }) : assert(
+         type != LayerAnimationType.slide || slideDirection != null,
+         'slideDirection is required for slide animations',
+       );
+
+  /// Creates a [LayerAnimation] from a serialized [map].
+  ///
+  /// Parsing is lenient: unknown or missing enum names fall back to a sensible
+  /// default ([LayerAnimationType.fade], [AnimationPhase.animateIn],
+  /// [AnimationCurve.linear]) and a missing `durationUs` becomes
+  /// [Duration.zero], so importing data produced by a newer version (or
+  /// hand-edited JSON) degrades gracefully instead of throwing.
+  factory LayerAnimation.fromMap(Map<String, dynamic> map) {
+    return LayerAnimation(
+      type:
+          _enumByName(LayerAnimationType.values, map['type']) ??
+          LayerAnimationType.fade,
+      phase:
+          _enumByName(AnimationPhase.values, map['phase']) ??
+          AnimationPhase.animateIn,
+      duration: Duration(
+        microseconds: (map['durationUs'] as num?)?.toInt() ?? 0,
+      ),
+      curve:
+          _enumByName(AnimationCurve.values, map['curve']) ??
+          AnimationCurve.linear,
+      slideDirection: _enumByName(SlideDirection.values, map['slideDirection']),
+      scaleFrom: (map['scaleFrom'] as num?)?.toDouble(),
+    );
+  }
+
+  /// Returns the enum value from [values] whose name matches [name], or `null`
+  /// when [name] is not a [String] or has no match.
+  static T? _enumByName<T extends Enum>(List<T> values, Object? name) {
+    if (name is! String) return null;
+    for (final value in values) {
+      if (value.name == name) return value;
+    }
+    return null;
+  }
+
+  /// The kind of animation (fade, slide, scale).
+  final LayerAnimationType type;
+
+  /// Whether this animation plays at the start, end, or both ends of the
+  /// layer's visible range.
+  final AnimationPhase phase;
+
+  /// How long the animation lasts in **video time**.
+  final Duration duration;
+
+  /// The easing curve for the animation.
+  ///
+  /// Defaults to [AnimationCurve.linear].
+  final AnimationCurve curve;
+
+  /// The direction for [LayerAnimationType.slide] animations.
+  ///
+  /// Required when [type] is [LayerAnimationType.slide].
+  final SlideDirection? slideDirection;
+
+  /// The starting scale factor for [LayerAnimationType.scale] animations.
+  ///
+  /// Defaults to `0.0` (invisible) when not set. A value of `0.5` means the
+  /// layer starts at half size.
+  final double? scaleFrom;
+
+  /// Serializes this animation to a map.
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'type': type.name,
+      'phase': phase.name,
+      'durationUs': duration.inMicroseconds,
+      'curve': curve.name,
+      'slideDirection': slideDirection?.name,
+      'scaleFrom': scaleFrom,
+    };
+  }
+
+  /// Creates a copy of this [LayerAnimation] with the given fields replaced.
+  LayerAnimation copyWith({
+    LayerAnimationType? type,
+    AnimationPhase? phase,
+    Duration? duration,
+    AnimationCurve? curve,
+    SlideDirection? slideDirection,
+    double? scaleFrom,
+  }) {
+    return LayerAnimation(
+      type: type ?? this.type,
+      phase: phase ?? this.phase,
+      duration: duration ?? this.duration,
+      curve: curve ?? this.curve,
+      slideDirection: slideDirection ?? this.slideDirection,
+      scaleFrom: scaleFrom ?? this.scaleFrom,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'LayerAnimation(type: $type, phase: $phase, '
+        'duration: $duration, curve: $curve'
+        '${slideDirection != null ? ', slideDirection: $slideDirection' : ''}'
+        '${scaleFrom != null ? ', scaleFrom: $scaleFrom' : ''})';
+  }
+
+  @override
+  bool operator ==(covariant LayerAnimation other) {
+    if (identical(this, other)) return true;
+    return other.type == type &&
+        other.phase == phase &&
+        other.duration == duration &&
+        other.curve == curve &&
+        other.slideDirection == slideDirection &&
+        other.scaleFrom == scaleFrom;
+  }
+
+  @override
+  int get hashCode {
+    return type.hashCode ^
+        phase.hashCode ^
+        duration.hashCode ^
+        curve.hashCode ^
+        slideDirection.hashCode ^
+        scaleFrom.hashCode;
+  }
+}

--- a/lib/core/models/layers/paint_layer.dart
+++ b/lib/core/models/layers/paint_layer.dart
@@ -53,6 +53,7 @@ class PaintLayer extends Layer {
     super.enterCurve,
     super.exitCurve,
     super.transitionBuilder,
+    super.animations,
   });
 
   /// Factory constructor for creating a PaintLayer instance from a
@@ -80,6 +81,7 @@ class PaintLayer extends Layer {
       endTime: layer.endTime,
       enterDuration: layer.enterDuration,
       exitDuration: layer.exitDuration,
+      animations: layer.animations,
       opacity: safeParseDouble(map[keyConverter('opacity')], fallback: 1.0),
       rawSize: Size(
         safeParseDouble(map[keyConverter('rawSize')]?['w'], fallback: 0),
@@ -182,6 +184,7 @@ class PaintLayer extends Layer {
     Curve? enterCurve,
     Curve? exitCurve,
     LayerTimelineTransitionBuilder? transitionBuilder,
+    List<LayerAnimation>? animations,
   }) {
     return PaintLayer(
       item: item ?? this.item,
@@ -204,6 +207,7 @@ class PaintLayer extends Layer {
       enterCurve: enterCurve ?? this.enterCurve,
       exitCurve: exitCurve ?? this.exitCurve,
       transitionBuilder: transitionBuilder ?? this.transitionBuilder,
+      animations: animations ?? this.animations,
     );
   }
 

--- a/lib/core/models/layers/text_layer.dart
+++ b/lib/core/models/layers/text_layer.dart
@@ -54,6 +54,7 @@ class TextLayer extends Layer {
     super.enterCurve,
     super.exitCurve,
     super.transitionBuilder,
+    super.animations,
   });
 
   /// Factory constructor for creating a TextLayer instance from a Layer
@@ -144,6 +145,7 @@ class TextLayer extends Layer {
       endTime: layer.endTime,
       enterDuration: layer.enterDuration,
       exitDuration: layer.exitDuration,
+      animations: layer.animations,
       text: map[keyConverter('text')] ?? '-',
       fontScale: fontScale,
       maxTextWidth: tryParseDouble(map[keyConverter('maxTextWidth')]),
@@ -354,6 +356,7 @@ class TextLayer extends Layer {
     Curve? enterCurve,
     Curve? exitCurve,
     LayerTimelineTransitionBuilder? transitionBuilder,
+    List<LayerAnimation>? animations,
   }) {
     return TextLayer(
       text: text ?? this.text,
@@ -383,6 +386,7 @@ class TextLayer extends Layer {
       enterCurve: enterCurve ?? this.enterCurve,
       exitCurve: exitCurve ?? this.exitCurve,
       transitionBuilder: transitionBuilder ?? this.transitionBuilder,
+      animations: animations ?? this.animations,
     );
   }
 

--- a/lib/core/models/layers/widget_layer.dart
+++ b/lib/core/models/layers/widget_layer.dart
@@ -52,6 +52,7 @@ class WidgetLayer extends Layer {
     super.enterCurve,
     super.exitCurve,
     super.transitionBuilder,
+    super.animations,
   });
 
   /// Factory constructor for creating a WidgetLayer instance from a
@@ -139,6 +140,7 @@ class WidgetLayer extends Layer {
       endTime: layer.endTime,
       enterDuration: layer.enterDuration,
       exitDuration: layer.exitDuration,
+      animations: layer.animations,
       widget: widget,
       width: layerWidth != null ? safeParseDouble(layerWidth) : null,
       exportConfigs: exportConfigs,
@@ -231,6 +233,7 @@ class WidgetLayer extends Layer {
     Curve? enterCurve,
     Curve? exitCurve,
     LayerTimelineTransitionBuilder? transitionBuilder,
+    List<LayerAnimation>? animations,
   }) {
     return WidgetLayer(
       widget: widget ?? this.widget,
@@ -253,6 +256,7 @@ class WidgetLayer extends Layer {
       enterCurve: enterCurve ?? this.enterCurve,
       exitCurve: exitCurve ?? this.exitCurve,
       transitionBuilder: transitionBuilder ?? this.transitionBuilder,
+      animations: animations ?? this.animations,
     );
   }
 

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -842,6 +842,10 @@ class ProImageEditorState extends State<ProImageEditor>
   /// Both [startTime] and [endTime] are optional. Only non-null values are
   /// applied. This is primarily used by the video editor to define when a
   /// layer is visible on the timeline.
+  ///
+  /// Pass [animations] to set the per-layer enter/leave animations (fade /
+  /// slide / scale). When non-empty, they take over from the legacy
+  /// [enterDuration] / [exitDuration] fade convenience.
   void setLayerTimeline({
     required int index,
     Duration? startTime,
@@ -851,6 +855,7 @@ class ProImageEditorState extends State<ProImageEditor>
     Curve? enterCurve,
     Curve? exitCurve,
     LayerTimelineTransitionBuilder? transitionBuilder,
+    List<LayerAnimation>? animations,
     Map<String, dynamic>? meta,
     bool skipUpdateHistory = false,
   }) {
@@ -865,6 +870,8 @@ class ProImageEditorState extends State<ProImageEditor>
         (exitCurve == null || exitCurve == current.exitCurve) &&
         (transitionBuilder == null ||
             transitionBuilder == current.transitionBuilder) &&
+        (animations == null ||
+            listEquals(animations, current.animations)) &&
         meta == null) {
       return;
     }
@@ -888,6 +895,9 @@ class ProImageEditorState extends State<ProImageEditor>
     if (enterCurve != null) layer.enterCurve = enterCurve;
     if (exitCurve != null) layer.exitCurve = exitCurve;
     if (transitionBuilder != null) layer.transitionBuilder = transitionBuilder;
+    if (animations != null) {
+      layer.animations = List<LayerAnimation>.of(animations);
+    }
     if (meta != null) layer.meta = {...layer.meta ?? {}, ...meta};
 
     if (!skipUpdateHistory) {

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -870,8 +870,7 @@ class ProImageEditorState extends State<ProImageEditor>
         (exitCurve == null || exitCurve == current.exitCurve) &&
         (transitionBuilder == null ||
             transitionBuilder == current.transitionBuilder) &&
-        (animations == null ||
-            listEquals(animations, current.animations)) &&
+        (animations == null || listEquals(animations, current.animations)) &&
         meta == null) {
       return;
     }

--- a/lib/features/main_editor/services/layer_copy_manager.dart
+++ b/lib/features/main_editor/services/layer_copy_manager.dart
@@ -141,6 +141,7 @@ class LayerCopyManager {
       enterCurve: layer.enterCurve,
       exitCurve: layer.exitCurve,
       transitionBuilder: layer.transitionBuilder,
+      animations: List<LayerAnimation>.of(layer.animations),
     )..groupId = layer.groupId;
   }
 
@@ -170,6 +171,7 @@ class LayerCopyManager {
       enterCurve: layer.enterCurve,
       exitCurve: layer.exitCurve,
       transitionBuilder: layer.transitionBuilder,
+      animations: List<LayerAnimation>.of(layer.animations),
     )..groupId = layer.groupId;
   }
 
@@ -201,6 +203,7 @@ class LayerCopyManager {
       enterCurve: layer.enterCurve,
       exitCurve: layer.exitCurve,
       transitionBuilder: layer.transitionBuilder,
+      animations: List<LayerAnimation>.of(layer.animations),
     )..groupId = layer.groupId;
   }
 
@@ -232,6 +235,7 @@ class LayerCopyManager {
       enterCurve: layer.enterCurve,
       exitCurve: layer.exitCurve,
       transitionBuilder: layer.transitionBuilder,
+      animations: List<LayerAnimation>.of(layer.animations),
     )..groupId = layer.groupId;
   }
 }

--- a/lib/shared/services/import_export/constants/minified_keys.dart
+++ b/lib/shared/services/import_export/constants/minified_keys.dart
@@ -65,6 +65,7 @@ const Map<String, String> kMinifiedLayerKeys = {
   'exitDuration': 'xd',
   'enterCurve': 'ev',
   'exitCurve': 'xv',
+  'animations': 'an',
 
   /// Only in version < 8.0.0
   'enableInteraction': 'ei',

--- a/lib/shared/utils/parser/animation_curve_parser.dart
+++ b/lib/shared/utils/parser/animation_curve_parser.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/animation.dart';
+
+import '/core/models/layers/layer_animation.dart';
+
+/// Maps an [AnimationCurve] enum value to the equivalent Flutter [Curve].
+///
+/// Used to drive the in-editor video-timeline preview with the same easing the
+/// exported result uses.
+Curve curveFromAnimationCurve(AnimationCurve curve) {
+  switch (curve) {
+    case AnimationCurve.linear:
+      return Curves.linear;
+    case AnimationCurve.easeIn:
+      return Curves.easeIn;
+    case AnimationCurve.easeOut:
+      return Curves.easeOut;
+    case AnimationCurve.easeInOut:
+      return Curves.easeInOut;
+    case AnimationCurve.easeInCubic:
+      return Curves.easeInCubic;
+    case AnimationCurve.easeOutCubic:
+      return Curves.easeOutCubic;
+    case AnimationCurve.easeInOutCubic:
+      return Curves.easeInOutCubic;
+    case AnimationCurve.bounceIn:
+      return Curves.bounceIn;
+    case AnimationCurve.bounceOut:
+      return Curves.bounceOut;
+    case AnimationCurve.bounceInOut:
+      return Curves.bounceInOut;
+    case AnimationCurve.elasticIn:
+      return Curves.elasticIn;
+    case AnimationCurve.elasticOut:
+      return Curves.elasticOut;
+    case AnimationCurve.elasticInOut:
+      return Curves.elasticInOut;
+  }
+}
+
+/// Maps a Flutter [Curve] back to the closest [AnimationCurve] enum value.
+///
+/// Returns [AnimationCurve.linear] for `null` or any curve without a direct
+/// [AnimationCurve] equivalent.
+AnimationCurve animationCurveFromCurve(Curve? curve) {
+  if (curve == Curves.easeIn) return AnimationCurve.easeIn;
+  if (curve == Curves.easeOut) return AnimationCurve.easeOut;
+  if (curve == Curves.easeInOut) return AnimationCurve.easeInOut;
+  if (curve == Curves.easeInCubic) return AnimationCurve.easeInCubic;
+  if (curve == Curves.easeOutCubic) return AnimationCurve.easeOutCubic;
+  if (curve == Curves.easeInOutCubic) return AnimationCurve.easeInOutCubic;
+  if (curve == Curves.bounceIn) return AnimationCurve.bounceIn;
+  if (curve == Curves.bounceOut) return AnimationCurve.bounceOut;
+  if (curve == Curves.bounceInOut) return AnimationCurve.bounceInOut;
+  if (curve == Curves.elasticIn) return AnimationCurve.elasticIn;
+  if (curve == Curves.elasticOut) return AnimationCurve.elasticOut;
+  if (curve == Curves.elasticInOut) return AnimationCurve.elasticInOut;
+  return AnimationCurve.linear;
+}

--- a/lib/shared/widgets/layer/layer_timeline_visibility.dart
+++ b/lib/shared/widgets/layer/layer_timeline_visibility.dart
@@ -1,8 +1,12 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/rendering.dart' show RenderProxyBox;
 import 'package:flutter/widgets.dart';
 
 import '/core/models/editor_configs/video/layer_timeline_configs.dart';
 import '/core/models/layers/layer.dart';
+import '/shared/utils/parser/animation_curve_parser.dart';
 import '/shared/utils/timeline_progress.dart';
 
 /// Controls layer visibility based on [Layer.startTime] / [Layer.endTime]
@@ -11,6 +15,16 @@ import '/shared/utils/timeline_progress.dart';
 /// The animation progress is derived directly from the video position so that
 /// seeking immediately reflects the correct transition state (e.g. seeking to
 /// the middle of a 5 s fade-in shows the layer at 50 %).
+///
+/// When [Layer.animations] is not empty, the transition is phase-aware: each
+/// animation drives a fade, slide, or scale during the layer's enter window
+/// (`[startTime, startTime + duration]`) and/or exit window
+/// (`[endTime - duration, endTime]`). Multiple animations are composed, so the
+/// enter and leave phases can use distinct animation types — something the
+/// single `(child, animation)` [LayerTimelineConfigs.transitionBuilder] cannot
+/// express. When [Layer.animations] is empty, the legacy fade convenience
+/// driven by [Layer.enterDuration] / [Layer.exitDuration] and the
+/// [LayerTimelineConfigs.transitionBuilder] is used instead.
 class LayerTimelineVisibility extends StatefulWidget {
   /// Creates a [LayerTimelineVisibility].
   const LayerTimelineVisibility({
@@ -38,16 +52,13 @@ class LayerTimelineVisibility extends StatefulWidget {
       _LayerTimelineVisibilityState();
 }
 
-class _LayerTimelineVisibilityState extends State<LayerTimelineVisibility>
-    with SingleTickerProviderStateMixin {
-  late final AnimationController _controller;
+class _LayerTimelineVisibilityState extends State<LayerTimelineVisibility> {
+  late _TimelineFrame _frame;
 
   @override
   void initState() {
     super.initState();
-    _controller = AnimationController(vsync: this);
-
-    _controller.value = _computeProgress(widget.playTimeNotifier.value);
+    _frame = _computeFrame(widget.playTimeNotifier.value);
     widget.playTimeNotifier.addListener(_onTimeChanged);
   }
 
@@ -64,22 +75,28 @@ class _LayerTimelineVisibilityState extends State<LayerTimelineVisibility>
         oldWidget.layer.enterDuration != widget.layer.enterDuration ||
         oldWidget.layer.exitDuration != widget.layer.exitDuration ||
         oldWidget.layer.enterCurve != widget.layer.enterCurve ||
-        oldWidget.layer.exitCurve != widget.layer.exitCurve;
+        oldWidget.layer.exitCurve != widget.layer.exitCurve ||
+        !listEquals(oldWidget.layer.animations, widget.layer.animations);
     if (changed) {
-      final progress = _computeProgress(widget.playTimeNotifier.value);
-      _controller.value = progress;
+      _frame = _computeFrame(widget.playTimeNotifier.value);
     }
   }
 
   @override
   void dispose() {
     widget.playTimeNotifier.removeListener(_onTimeChanged);
-    _controller.dispose();
     super.dispose();
   }
 
-  /// Computes a curved progress value (0.0 – 1.0) based on [currentTime].
-  double _computeProgress(Duration currentTime) {
+  void _onTimeChanged() {
+    final next = _computeFrame(widget.playTimeNotifier.value);
+    if (next != _frame) {
+      setState(() => _frame = next);
+    }
+  }
+
+  /// Computes a curved progress value (0.0 – 1.0) for the legacy fade path.
+  double _computeLegacyProgress(Duration currentTime) {
     return computeTimelineProgress(
       currentTime: currentTime,
       startTime: widget.layer.startTime,
@@ -93,28 +110,188 @@ class _LayerTimelineVisibilityState extends State<LayerTimelineVisibility>
     );
   }
 
-  void _onTimeChanged() {
-    final progress = _computeProgress(widget.playTimeNotifier.value);
-    if (_controller.value != progress) {
-      _controller.value = progress;
+  /// Computes the visual transform for [currentTime].
+  ///
+  /// Mirrors the native renderer in `pro_video_editor` so the preview matches
+  /// the exported result: each animation's progress is evaluated for its
+  /// enter and/or exit phase, the most-visible (minimum) progress wins for an
+  /// `animateInOut` animation, and the effects are composed (opacity
+  /// multiplies, slide offsets accumulate, scale multiplies).
+  _TimelineFrame _computeFrame(Duration currentTime) {
+    final layer = widget.layer;
+    final start = layer.startTime;
+    final end = layer.endTime;
+
+    final outside =
+        (start != null && currentTime < start) ||
+        (end != null && currentTime > end);
+    if (outside) {
+      return const _TimelineFrame.hidden();
     }
+
+    if (layer.animations.isEmpty) {
+      return _TimelineFrame.legacy(_computeLegacyProgress(currentTime));
+    }
+
+    final effectiveStart = start ?? Duration.zero;
+    double opacity = 1;
+    double scale = 1;
+    Offset slide = Offset.zero;
+
+    for (final anim in layer.animations) {
+      final durationUs = anim.duration.inMicroseconds;
+      if (durationUs <= 0) continue;
+      final curve = curveFromAnimationCurve(anim.curve);
+
+      double? inProgress;
+      double? outProgress;
+
+      if (anim.phase == AnimationPhase.animateIn ||
+          anim.phase == AnimationPhase.animateInOut) {
+        final elapsed = (currentTime - effectiveStart).inMicroseconds;
+        if (elapsed < durationUs) {
+          inProgress = curve.transform((elapsed / durationUs).clamp(0.0, 1.0));
+        }
+      }
+
+      if ((anim.phase == AnimationPhase.animateOut ||
+              anim.phase == AnimationPhase.animateInOut) &&
+          end != null) {
+        final remaining = (end - currentTime).inMicroseconds;
+        if (remaining < durationUs) {
+          outProgress = curve.transform(
+            (remaining / durationUs).clamp(0.0, 1.0),
+          );
+        }
+      }
+
+      final double? progress;
+      if (inProgress != null && outProgress != null) {
+        progress = math.min(inProgress, outProgress);
+      } else {
+        progress = inProgress ?? outProgress;
+      }
+      if (progress == null) continue;
+
+      switch (anim.type) {
+        case LayerAnimationType.fade:
+          opacity *= progress;
+        case LayerAnimationType.slide:
+          final direction = anim.slideDirection;
+          if (direction == null) break;
+          final invP = 1.0 - progress;
+          switch (direction) {
+            case SlideDirection.left:
+              slide = slide.translate(-invP, 0);
+            case SlideDirection.right:
+              slide = slide.translate(invP, 0);
+            case SlideDirection.top:
+              slide = slide.translate(0, -invP);
+            case SlideDirection.bottom:
+              slide = slide.translate(0, invP);
+          }
+        case LayerAnimationType.scale:
+          final from = anim.scaleFrom ?? 0.0;
+          scale *= from + (1.0 - from) * progress;
+      }
+    }
+
+    return _TimelineFrame(
+      opacity: opacity.clamp(0.0, 1.0),
+      slide: slide,
+      scale: math.max(0.0, scale),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: _controller,
-      builder: (context, child) {
-        if (_controller.isDismissed) {
-          return IgnorePointer(child: _InvisibleButPainted(child: child!));
-        }
-        final builder =
-            widget.layer.transitionBuilder ?? widget.configs.transitionBuilder;
-        return builder(child!, _controller);
-      },
-      child: widget.child,
-    );
+    final child = widget.child;
+    final frame = _frame;
+
+    if (frame.hidden) {
+      return IgnorePointer(child: _InvisibleButPainted(child: child));
+    }
+
+    if (widget.layer.animations.isEmpty) {
+      final progress = frame.legacyProgress;
+      if (progress <= 0) {
+        return IgnorePointer(child: _InvisibleButPainted(child: child));
+      }
+      final builder =
+          widget.layer.transitionBuilder ?? widget.configs.transitionBuilder;
+      return builder(child, AlwaysStoppedAnimation<double>(progress));
+    }
+
+    if (frame.opacity <= 0) {
+      return IgnorePointer(child: _InvisibleButPainted(child: child));
+    }
+
+    Widget result = child;
+    if (frame.scale != 1.0) {
+      result = Transform.scale(scale: frame.scale, child: result);
+    }
+    if (frame.slide != Offset.zero) {
+      result = FractionalTranslation(translation: frame.slide, child: result);
+    }
+    if (frame.opacity < 1.0) {
+      result = Opacity(opacity: frame.opacity, child: result);
+    }
+    return result;
   }
+}
+
+/// The composed visual state of a layer at a single point in video time.
+class _TimelineFrame {
+  const _TimelineFrame({
+    required this.opacity,
+    required this.slide,
+    required this.scale,
+  }) : hidden = false,
+       legacyProgress = 1;
+
+  const _TimelineFrame.hidden()
+    : hidden = true,
+      opacity = 0,
+      slide = Offset.zero,
+      scale = 1,
+      legacyProgress = 0;
+
+  const _TimelineFrame.legacy(this.legacyProgress)
+    : hidden = false,
+      opacity = 1,
+      slide = Offset.zero,
+      scale = 1;
+
+  /// Whether the layer is outside its visible time range and should be hidden.
+  final bool hidden;
+
+  /// The composed opacity (phase-aware path).
+  final double opacity;
+
+  /// The composed slide offset as a fraction of the layer's own size
+  /// (phase-aware path).
+  final Offset slide;
+
+  /// The composed scale factor (phase-aware path).
+  final double scale;
+
+  /// The curved progress (0–1) used by the legacy fade path.
+  final double legacyProgress;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is _TimelineFrame &&
+        other.hidden == hidden &&
+        other.opacity == opacity &&
+        other.slide == slide &&
+        other.scale == scale &&
+        other.legacyProgress == legacyProgress;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(hidden, opacity, slide, scale, legacyProgress);
 }
 
 /// Renders its child into the render tree (so [RepaintBoundary.toImage] works)

--- a/lib/shared/widgets/layer/layer_widget.dart
+++ b/lib/shared/widgets/layer/layer_widget.dart
@@ -344,7 +344,9 @@ class _LayerWidgetState extends State<LayerWidget>
 
     final playTime = widget.playTimeNotifier;
     if (playTime != null &&
-        (_layer.startTime != null || _layer.endTime != null)) {
+        (_layer.startTime != null ||
+            _layer.endTime != null ||
+            _layer.animations.isNotEmpty)) {
       content = LayerTimelineVisibility(
         layer: _layer,
         playTimeNotifier: playTime,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.6.0
+version: 12.7.0
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/core/models/layers/layer_animation_test.dart
+++ b/test/core/models/layers/layer_animation_test.dart
@@ -1,0 +1,398 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_image_editor/core/models/layers/layer_animation.dart';
+
+void main() {
+  group('LayerAnimation', () {
+    group('constructor', () {
+      test('creates fade animation with defaults', () {
+        const anim = LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+        );
+
+        expect(anim.type, LayerAnimationType.fade);
+        expect(anim.phase, AnimationPhase.animateIn);
+        expect(anim.duration, const Duration(milliseconds: 500));
+        expect(anim.curve, AnimationCurve.linear);
+        expect(anim.slideDirection, isNull);
+        expect(anim.scaleFrom, isNull);
+      });
+
+      test('creates slide animation with direction', () {
+        const anim = LayerAnimation(
+          type: LayerAnimationType.slide,
+          phase: AnimationPhase.animateOut,
+          duration: Duration(milliseconds: 300),
+          slideDirection: SlideDirection.left,
+          curve: AnimationCurve.easeOut,
+        );
+
+        expect(anim.type, LayerAnimationType.slide);
+        expect(anim.slideDirection, SlideDirection.left);
+        expect(anim.curve, AnimationCurve.easeOut);
+      });
+
+      test('creates scale animation with scaleFrom', () {
+        const anim = LayerAnimation(
+          type: LayerAnimationType.scale,
+          phase: AnimationPhase.animateInOut,
+          duration: Duration(milliseconds: 400),
+          scaleFrom: 0.5,
+        );
+
+        expect(anim.type, LayerAnimationType.scale);
+        expect(anim.phase, AnimationPhase.animateInOut);
+        expect(anim.scaleFrom, 0.5);
+      });
+    });
+
+    group('toMap', () {
+      test('serializes fade animation', () {
+        const anim = LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+        );
+        final map = anim.toMap();
+
+        expect(map['type'], 'fade');
+        expect(map['phase'], 'animateIn');
+        expect(map['durationUs'], 500000);
+        expect(map['curve'], 'linear');
+        expect(map['slideDirection'], isNull);
+        expect(map['scaleFrom'], isNull);
+      });
+
+      test('serializes slide animation with all fields', () {
+        const anim = LayerAnimation(
+          type: LayerAnimationType.slide,
+          phase: AnimationPhase.animateOut,
+          duration: Duration(seconds: 1),
+          curve: AnimationCurve.easeInOut,
+          slideDirection: SlideDirection.bottom,
+        );
+        final map = anim.toMap();
+
+        expect(map['type'], 'slide');
+        expect(map['phase'], 'animateOut');
+        expect(map['durationUs'], 1000000);
+        expect(map['curve'], 'easeInOut');
+        expect(map['slideDirection'], 'bottom');
+      });
+
+      test('serializes scale animation with scaleFrom', () {
+        const anim = LayerAnimation(
+          type: LayerAnimationType.scale,
+          phase: AnimationPhase.animateInOut,
+          duration: Duration(milliseconds: 250),
+          scaleFrom: 0.3,
+        );
+        final map = anim.toMap();
+
+        expect(map['scaleFrom'], 0.3);
+      });
+    });
+
+    group('fromMap', () {
+      test('deserializes fade animation', () {
+        final map = <String, dynamic>{
+          'type': 'fade',
+          'phase': 'animateIn',
+          'durationUs': 500000,
+          'curve': 'linear',
+          'slideDirection': null,
+          'scaleFrom': null,
+        };
+        final anim = LayerAnimation.fromMap(map);
+
+        expect(anim.type, LayerAnimationType.fade);
+        expect(anim.phase, AnimationPhase.animateIn);
+        expect(anim.duration, const Duration(milliseconds: 500));
+        expect(anim.curve, AnimationCurve.linear);
+        expect(anim.slideDirection, isNull);
+        expect(anim.scaleFrom, isNull);
+      });
+
+      test('deserializes slide animation', () {
+        final map = <String, dynamic>{
+          'type': 'slide',
+          'phase': 'animateOut',
+          'durationUs': 300000,
+          'curve': 'easeOut',
+          'slideDirection': 'right',
+          'scaleFrom': null,
+        };
+        final anim = LayerAnimation.fromMap(map);
+
+        expect(anim.type, LayerAnimationType.slide);
+        expect(anim.slideDirection, SlideDirection.right);
+        expect(anim.curve, AnimationCurve.easeOut);
+      });
+
+      test('defaults curve to linear when missing', () {
+        final map = <String, dynamic>{
+          'type': 'fade',
+          'phase': 'animateIn',
+          'durationUs': 100000,
+        };
+        final anim = LayerAnimation.fromMap(map);
+
+        expect(anim.curve, AnimationCurve.linear);
+      });
+
+      test('deserializes animateInOut phase', () {
+        final map = <String, dynamic>{
+          'type': 'scale',
+          'phase': 'animateInOut',
+          'durationUs': 400000,
+          'scaleFrom': 0.5,
+        };
+        final anim = LayerAnimation.fromMap(map);
+
+        expect(anim.phase, AnimationPhase.animateInOut);
+        expect(anim.scaleFrom, 0.5);
+      });
+
+      test('falls back to defaults for unknown enum names', () {
+        // Simulates data from a newer version with an unknown type/curve, or
+        // hand-edited JSON: parsing must degrade gracefully instead of
+        // throwing.
+        final map = <String, dynamic>{
+          'type': 'rotate',
+          'phase': 'animateLater',
+          'durationUs': 100000,
+          'curve': 'easeInQuart',
+          'slideDirection': 'diagonal',
+        };
+        final anim = LayerAnimation.fromMap(map);
+
+        expect(anim.type, LayerAnimationType.fade);
+        expect(anim.phase, AnimationPhase.animateIn);
+        expect(anim.curve, AnimationCurve.linear);
+        expect(anim.slideDirection, isNull);
+      });
+
+      test('defaults duration to zero when durationUs is missing', () {
+        final map = <String, dynamic>{
+          'type': 'fade',
+          'phase': 'animateIn',
+        };
+        final anim = LayerAnimation.fromMap(map);
+
+        expect(anim.duration, Duration.zero);
+      });
+    });
+
+    group('roundtrip toMap/fromMap', () {
+      test('fade roundtrip preserves data', () {
+        const original = LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+          curve: AnimationCurve.easeIn,
+        );
+        final restored = LayerAnimation.fromMap(original.toMap());
+        expect(restored, original);
+      });
+
+      test('slide roundtrip preserves data', () {
+        const original = LayerAnimation(
+          type: LayerAnimationType.slide,
+          phase: AnimationPhase.animateOut,
+          duration: Duration(milliseconds: 300),
+          curve: AnimationCurve.easeOut,
+          slideDirection: SlideDirection.top,
+        );
+        final restored = LayerAnimation.fromMap(original.toMap());
+        expect(restored, original);
+      });
+
+      test('scale roundtrip preserves data', () {
+        const original = LayerAnimation(
+          type: LayerAnimationType.scale,
+          phase: AnimationPhase.animateInOut,
+          duration: Duration(milliseconds: 250),
+          scaleFrom: 0.2,
+        );
+        final restored = LayerAnimation.fromMap(original.toMap());
+        expect(restored, original);
+      });
+    });
+
+    group('copyWith', () {
+      test('returns an equal copy when no fields are provided', () {
+        const original = LayerAnimation(
+          type: LayerAnimationType.slide,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 400),
+          curve: AnimationCurve.easeOut,
+          slideDirection: SlideDirection.left,
+        );
+
+        expect(original.copyWith(), original);
+      });
+
+      test('overrides only the provided fields', () {
+        const original = LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+        );
+
+        final updated = original.copyWith(
+          phase: AnimationPhase.animateOut,
+          duration: const Duration(milliseconds: 300),
+          curve: AnimationCurve.easeInOut,
+        );
+
+        expect(updated.type, LayerAnimationType.fade);
+        expect(updated.phase, AnimationPhase.animateOut);
+        expect(updated.duration, const Duration(milliseconds: 300));
+        expect(updated.curve, AnimationCurve.easeInOut);
+      });
+    });
+
+    group('equality', () {
+      test('identical animations are equal', () {
+        const a = LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+        );
+        const b = LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+        );
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+      });
+
+      test('different type makes unequal', () {
+        const a = LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+        );
+        const b = LayerAnimation(
+          type: LayerAnimationType.scale,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+        );
+        expect(a, isNot(b));
+      });
+
+      test('different slideDirection makes unequal', () {
+        const a = LayerAnimation(
+          type: LayerAnimationType.slide,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+          slideDirection: SlideDirection.left,
+        );
+        const b = LayerAnimation(
+          type: LayerAnimationType.slide,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+          slideDirection: SlideDirection.right,
+        );
+        expect(a, isNot(b));
+      });
+
+      test('different scaleFrom makes unequal', () {
+        const a = LayerAnimation(
+          type: LayerAnimationType.scale,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+          scaleFrom: 0.0,
+        );
+        const b = LayerAnimation(
+          type: LayerAnimationType.scale,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+          scaleFrom: 0.5,
+        );
+        expect(a, isNot(b));
+      });
+    });
+
+    group('toString', () {
+      test('contains class name and fields', () {
+        const anim = LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+        );
+        final str = anim.toString();
+
+        expect(str, contains('LayerAnimation'));
+        expect(str, contains('fade'));
+        expect(str, contains('animateIn'));
+      });
+
+      test('includes slideDirection when present', () {
+        const anim = LayerAnimation(
+          type: LayerAnimationType.slide,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+          slideDirection: SlideDirection.left,
+        );
+        expect(anim.toString(), contains('slideDirection'));
+      });
+
+      test('excludes scaleFrom when null', () {
+        const anim = LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 500),
+        );
+        expect(anim.toString(), isNot(contains('scaleFrom')));
+      });
+    });
+  });
+
+  group('Enum values', () {
+    test('LayerAnimationType has expected values', () {
+      expect(LayerAnimationType.values, [
+        LayerAnimationType.fade,
+        LayerAnimationType.slide,
+        LayerAnimationType.scale,
+      ]);
+    });
+
+    test('SlideDirection has expected values', () {
+      expect(SlideDirection.values, [
+        SlideDirection.left,
+        SlideDirection.right,
+        SlideDirection.top,
+        SlideDirection.bottom,
+      ]);
+    });
+
+    test('AnimationCurve has expected values', () {
+      expect(AnimationCurve.values, [
+        AnimationCurve.linear,
+        AnimationCurve.easeIn,
+        AnimationCurve.easeOut,
+        AnimationCurve.easeInOut,
+        AnimationCurve.easeInCubic,
+        AnimationCurve.easeOutCubic,
+        AnimationCurve.easeInOutCubic,
+        AnimationCurve.bounceIn,
+        AnimationCurve.bounceOut,
+        AnimationCurve.bounceInOut,
+        AnimationCurve.elasticIn,
+        AnimationCurve.elasticOut,
+        AnimationCurve.elasticInOut,
+      ]);
+    });
+
+    test('AnimationPhase has expected values', () {
+      expect(AnimationPhase.values, [
+        AnimationPhase.animateIn,
+        AnimationPhase.animateOut,
+        AnimationPhase.animateInOut,
+      ]);
+    });
+  });
+}

--- a/test/core/models/layers/layer_animation_test.dart
+++ b/test/core/models/layers/layer_animation_test.dart
@@ -174,10 +174,7 @@ void main() {
       });
 
       test('defaults duration to zero when durationUs is missing', () {
-        final map = <String, dynamic>{
-          'type': 'fade',
-          'phase': 'animateIn',
-        };
+        final map = <String, dynamic>{'type': 'fade', 'phase': 'animateIn'};
         final anim = LayerAnimation.fromMap(map);
 
         expect(anim.duration, Duration.zero);

--- a/test/core/models/layers/layer_test.dart
+++ b/test/core/models/layers/layer_test.dart
@@ -243,4 +243,138 @@ void main() {
       expect(recreated, equals(original));
     });
   });
+
+  group('Layer animations', () {
+    const acceptanceAnimations = [
+      LayerAnimation(
+        type: LayerAnimationType.slide,
+        phase: AnimationPhase.animateIn,
+        duration: Duration(milliseconds: 400),
+        slideDirection: SlideDirection.left,
+        curve: AnimationCurve.easeOut,
+      ),
+      LayerAnimation(
+        type: LayerAnimationType.fade,
+        phase: AnimationPhase.animateOut,
+        duration: Duration(milliseconds: 300),
+      ),
+    ];
+
+    test('toMap serializes animations only when non-empty', () {
+      expect(Layer().toMap().containsKey('animations'), isFalse);
+
+      final map = Layer(animations: acceptanceAnimations).toMap();
+      expect(map['animations'], isA<List<dynamic>>());
+      expect(map['animations'], hasLength(2));
+      expect(map['animations'][0]['type'], 'slide');
+      expect(map['animations'][0]['slideDirection'], 'left');
+      expect(map['animations'][0]['curve'], 'easeOut');
+      expect(map['animations'][1]['type'], 'fade');
+      expect(map['animations'][1]['phase'], 'animateOut');
+    });
+
+    test('base Layer round-trips animations', () {
+      final original = Layer(
+        id: 'anim-id',
+        startTime: const Duration(seconds: 1),
+        endTime: const Duration(seconds: 5),
+        animations: acceptanceAnimations,
+      );
+
+      final recreated = Layer.fromMap(original.toMap(), id: original.id);
+
+      expect(recreated.animations, acceptanceAnimations);
+      expect(recreated, equals(original));
+    });
+
+    test('WidgetLayer round-trips animations', () {
+      final original = WidgetLayer(
+        id: 'widget-anim-id',
+        widget: Container(),
+        startTime: const Duration(seconds: 1),
+        endTime: const Duration(seconds: 5),
+        exportConfigs: const WidgetLayerExportConfigs(networkUrl: 'Test-Url'),
+        animations: const [
+          LayerAnimation(
+            type: LayerAnimationType.scale,
+            phase: AnimationPhase.animateInOut,
+            duration: Duration(milliseconds: 250),
+            scaleFrom: 0.4,
+          ),
+        ],
+      );
+
+      final recreated = Layer.fromMap(original.toMap(), id: original.id);
+
+      expect(recreated, isA<WidgetLayer>());
+      expect(recreated.animations, original.animations);
+    });
+
+    test('copyWith carries and overrides animations', () {
+      final layer = TextLayer(text: 'hi', animations: acceptanceAnimations);
+
+      expect(layer.copyWith().animations, acceptanceAnimations);
+      expect(layer.copyWith(animations: const []).animations, isEmpty);
+    });
+
+    test('effectiveAnimations returns explicit animations when present', () {
+      final layer = Layer(
+        enterDuration: const Duration(milliseconds: 500),
+        animations: acceptanceAnimations,
+      );
+
+      expect(layer.effectiveAnimations, acceptanceAnimations);
+    });
+
+    test('effectiveAnimations derives fades from legacy duration fields', () {
+      final layer = Layer(
+        enterDuration: const Duration(milliseconds: 500),
+        exitDuration: const Duration(milliseconds: 300),
+        enterCurve: Curves.easeOut,
+      );
+
+      final derived = layer.effectiveAnimations;
+      expect(derived, hasLength(2));
+      expect(derived[0].type, LayerAnimationType.fade);
+      expect(derived[0].phase, AnimationPhase.animateIn);
+      expect(derived[0].duration, const Duration(milliseconds: 500));
+      expect(derived[0].curve, AnimationCurve.easeOut);
+      expect(derived[1].type, LayerAnimationType.fade);
+      expect(derived[1].phase, AnimationPhase.animateOut);
+      expect(derived[1].duration, const Duration(milliseconds: 300));
+    });
+
+    test('effectiveAnimations is empty when nothing is configured', () {
+      expect(Layer().effectiveAnimations, isEmpty);
+    });
+
+    test('effectiveAnimations defaults curves to the preview defaults', () {
+      // No explicit curve → must mirror the preview defaults
+      // (LayerTimelineConfigs.enterCurve easeIn / exitCurve easeOut) instead of
+      // falling back to linear, so the export matches the in-editor preview.
+      final layer = Layer(
+        enterDuration: const Duration(milliseconds: 500),
+        exitDuration: const Duration(milliseconds: 300),
+      );
+
+      final derived = layer.effectiveAnimations;
+      expect(derived[0].curve, AnimationCurve.easeIn);
+      expect(derived[1].curve, AnimationCurve.easeOut);
+    });
+
+    test('default animations list is growable and mutable', () {
+      final layer = Layer();
+      expect(
+        () => layer.animations.add(
+          const LayerAnimation(
+            type: LayerAnimationType.fade,
+            phase: AnimationPhase.animateIn,
+            duration: Duration(milliseconds: 200),
+          ),
+        ),
+        returnsNormally,
+      );
+      expect(layer.animations, hasLength(1));
+    });
+  });
 }

--- a/test/shared/widgets/layer_timeline_visibility_test.dart
+++ b/test/shared/widgets/layer_timeline_visibility_test.dart
@@ -24,11 +24,7 @@ void main() {
             layer: layer,
             playTimeNotifier: notifier,
             configs: const LayerTimelineConfigs(),
-            child: const SizedBox(
-              key: childKey,
-              width: 100,
-              height: 50,
-            ),
+            child: const SizedBox(key: childKey, width: 100, height: 50),
           ),
         ),
       ),
@@ -104,9 +100,7 @@ void main() {
       final notifier = await pumpVisibility(tester, layer);
       await seek(tester, notifier, const Duration(milliseconds: 9850));
 
-      final opacity = tester
-          .widget<Opacity>(find.byType(Opacity))
-          .opacity;
+      final opacity = tester.widget<Opacity>(find.byType(Opacity)).opacity;
       expect(opacity, closeTo(0.5, 1e-6));
       // The slide animation only plays on enter, so no translation here.
       expect(find.byType(FractionalTranslation), findsNothing);

--- a/test/shared/widgets/layer_timeline_visibility_test.dart
+++ b/test/shared/widgets/layer_timeline_visibility_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_image_editor/core/models/editor_configs/video/layer_timeline_configs.dart';
+import 'package:pro_image_editor/core/models/layers/layer.dart';
+import 'package:pro_image_editor/shared/widgets/layer/layer_timeline_visibility.dart';
+
+void main() {
+  const childKey = Key('layer-child');
+
+  Future<ValueNotifier<Duration>> pumpVisibility(
+    WidgetTester tester,
+    Layer layer,
+  ) async {
+    // Start before any layer's time range so the first seek registers as a
+    // real change on the [ValueNotifier].
+    final notifier = ValueNotifier<Duration>(const Duration(milliseconds: -1));
+    addTearDown(notifier.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: LayerTimelineVisibility(
+            layer: layer,
+            playTimeNotifier: notifier,
+            configs: const LayerTimelineConfigs(),
+            child: const SizedBox(
+              key: childKey,
+              width: 100,
+              height: 50,
+            ),
+          ),
+        ),
+      ),
+    );
+    return notifier;
+  }
+
+  Future<void> seek(
+    WidgetTester tester,
+    ValueNotifier<Duration> notifier,
+    Duration time,
+  ) async {
+    notifier.value = time;
+    await tester.pump();
+  }
+
+  group('LayerTimelineVisibility phase-aware preview', () {
+    final layer = Layer(
+      startTime: const Duration(seconds: 1),
+      endTime: const Duration(seconds: 10),
+      animations: const [
+        LayerAnimation(
+          type: LayerAnimationType.slide,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 400),
+          slideDirection: SlideDirection.left,
+          curve: AnimationCurve.easeOut,
+        ),
+        LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateOut,
+          duration: Duration(milliseconds: 300),
+        ),
+      ],
+    );
+
+    testWidgets('slides in fully offset at the enter window start', (
+      tester,
+    ) async {
+      final notifier = await pumpVisibility(tester, layer);
+      await seek(tester, notifier, const Duration(seconds: 1));
+
+      final translation = tester
+          .widget<FractionalTranslation>(find.byType(FractionalTranslation))
+          .translation;
+      expect(translation, const Offset(-1, 0));
+      // No fade-out yet, so no Opacity wrapper.
+      expect(find.byType(Opacity), findsNothing);
+    });
+
+    testWidgets('slides partway through the enter window', (tester) async {
+      final notifier = await pumpVisibility(tester, layer);
+      await seek(tester, notifier, const Duration(milliseconds: 1200));
+
+      final translation = tester
+          .widget<FractionalTranslation>(find.byType(FractionalTranslation))
+          .translation;
+      expect(translation.dx, greaterThan(-1));
+      expect(translation.dx, lessThan(0));
+      expect(translation.dy, 0);
+    });
+
+    testWidgets('settles with no transform once entered', (tester) async {
+      final notifier = await pumpVisibility(tester, layer);
+      await seek(tester, notifier, const Duration(seconds: 5));
+
+      expect(find.byType(FractionalTranslation), findsNothing);
+      expect(find.byType(Opacity), findsNothing);
+      expect(find.byKey(childKey), findsOneWidget);
+    });
+
+    testWidgets('fades out during the exit window', (tester) async {
+      final notifier = await pumpVisibility(tester, layer);
+      await seek(tester, notifier, const Duration(milliseconds: 9850));
+
+      final opacity = tester
+          .widget<Opacity>(find.byType(Opacity))
+          .opacity;
+      expect(opacity, closeTo(0.5, 1e-6));
+      // The slide animation only plays on enter, so no translation here.
+      expect(find.byType(FractionalTranslation), findsNothing);
+    });
+
+    testWidgets('hides before start and after end', (tester) async {
+      final notifier = await pumpVisibility(tester, layer);
+
+      await seek(tester, notifier, const Duration(milliseconds: 500));
+      expect(find.byType(IgnorePointer), findsOneWidget);
+
+      await seek(tester, notifier, const Duration(seconds: 11));
+      expect(find.byType(IgnorePointer), findsOneWidget);
+    });
+  });
+
+  group('LayerTimelineVisibility scale animation', () {
+    final layer = Layer(
+      startTime: Duration.zero,
+      endTime: const Duration(seconds: 10),
+      animations: const [
+        LayerAnimation(
+          type: LayerAnimationType.scale,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 400),
+          scaleFrom: 0.5,
+        ),
+      ],
+    );
+
+    double currentScale(WidgetTester tester) {
+      // storage[0] is the x-scale entry of the Transform.scale matrix.
+      final transform = tester
+          .widget<Transform>(find.byType(Transform))
+          .transform;
+      return transform.storage[0];
+    }
+
+    testWidgets('scales from scaleFrom up to 1', (tester) async {
+      final notifier = await pumpVisibility(tester, layer);
+
+      await seek(tester, notifier, Duration.zero);
+      expect(currentScale(tester), closeTo(0.5, 1e-6));
+
+      await seek(tester, notifier, const Duration(milliseconds: 200));
+      expect(currentScale(tester), closeTo(0.75, 1e-6));
+
+      await seek(tester, notifier, const Duration(seconds: 5));
+      expect(find.byType(Transform), findsNothing);
+    });
+  });
+
+  group('LayerTimelineVisibility legacy fade path', () {
+    testWidgets('uses the transitionBuilder when animations is empty', (
+      tester,
+    ) async {
+      final layer = Layer(
+        startTime: Duration.zero,
+        endTime: const Duration(seconds: 10),
+        enterDuration: const Duration(milliseconds: 400),
+      );
+      final notifier = await pumpVisibility(tester, layer);
+
+      // Halfway through the fade-in window.
+      await seek(tester, notifier, const Duration(milliseconds: 200));
+      expect(find.byType(FadeTransition), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Enhance PaintLayer, TextLayer, and WidgetLayer to support per-layer animations, allowing for more dynamic visual effects in the editor. Update constructors and methods to accommodate the new animations parameter, ensuring backward compatibility with existing layer properties. Introduce a mapping for animation curves to align with Flutter's animation system.

**Related Issue:** Closes #

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

