### PR TITLE
fix(crop-rotate): cover image edge with crop overlay when panned (#776)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.8.1
+- **FIX**(crop-rotate): Cover the image edge with the crop overlay when the image is panned. The darkened overlay is painted on top of the image and its outer rectangle matched the rendered image bounds exactly, so when an image edge floated inside the viewport (e.g. the image pushed to the bottom) anti-aliasing along that shared edge left a ~1px partially-transparent seam that revealed a thin line of the image. The overlay rectangle is now slightly overscanned beyond the image bounds so the seam falls on the surrounding background where it is invisible.
+
 ## 12.8.0
 - **FIX**(layers): Make the video-timeline `slide` layer animation edge-aware. Previously the layer was only translated by its own width/height (a single layer size), so a layer that did not sit against the canvas edge stayed partially visible while sliding in/out. The slide now uses the layer's center and the canvas size to push the layer's nearest edge exactly onto (or off) the canvas border, so off-center layers leave the visible area completely. The preview math mirrors the matching native renderer change in `pro_video_editor` (`ApplyAnimation.kt` / `ApplyAnimation.swift`). **Use this together with the corresponding `pro_video_editor` release** so the in-editor preview keeps matching the exported video. Prerelease.
 

--- a/lib/features/crop_rotate_editor/widgets/crop_corner_painter.dart
+++ b/lib/features/crop_rotate_editor/widgets/crop_corner_painter.dart
@@ -7,6 +7,17 @@ import 'package:flutter/material.dart';
 // Project imports:
 import '/core/models/styles/crop_rotate_editor_style.dart';
 
+/// Screen-space margin (in logical pixels) by which the darkened overlay is
+/// expanded beyond the image bounds.
+///
+/// The overlay is painted on top of the image and its outer edge is
+/// mathematically identical to the rendered image edge. When the image is
+/// panned so that one of its edges floats inside the viewport, anti-aliasing
+/// along that shared edge leaves a ~1px partially-transparent seam that reveals
+/// a thin line of the image (see #776). A small overscan moves that seam off
+/// the image and onto the surrounding background, where it is invisible.
+const double _kOverlayEdgeOverscan = 1;
+
 /// A custom painter for drawing crop corners and interaction elements.
 ///
 /// This class extends [CustomPainter] and is used to draw the crop corners,
@@ -139,6 +150,13 @@ class CropCornerPainter extends CustomPainter {
     double cropWidth = _cropOffsetRight - _cropOffsetLeft;
     double cropHeight = _cropOffsetBottom - _cropOffsetTop;
 
+    /// Convert the fixed screen-space overscan into the painter's local space
+    /// (which is scaled by [rotationScaleFactor] before being rendered) so the
+    /// margin stays visually constant regardless of zoom.
+    final double overscan = rotationScaleFactor.abs() > 0.001
+        ? _kOverlayEdgeOverscan / rotationScaleFactor.abs()
+        : _kOverlayEdgeOverscan;
+
     Path path = Path()
       // FillType "evenOdd" is important for the canvas web renderer
       ..fillType = PathFillType.evenOdd
@@ -150,7 +168,7 @@ class CropCornerPainter extends CustomPainter {
           ),
           width: size.width * scaleFactor,
           height: size.height * scaleFactor,
-        ),
+        ).inflate(overscan),
       );
     if (drawCircle) {
       /// Create a path for the current rectangle

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.8.0
+version: 12.8.1
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/features/crop_rotate_editor/widgets/crop_corner_painter_test.dart
+++ b/test/features/crop_rotate_editor/widgets/crop_corner_painter_test.dart
@@ -1,3 +1,6 @@
+// Dart imports:
+import 'dart:ui' as ui;
+
 // Flutter imports:
 import 'package:flutter/material.dart';
 
@@ -41,5 +44,57 @@ void main() {
 
       expect(painter1.shouldRepaint(painter2), isTrue);
     });
+
+    test(
+      'Darken overlay fully covers the image top edge when panned (#776)',
+      () async {
+        TestWidgetsFlutterBinding.ensureInitialized();
+
+        const Size canvasSize = Size(400, 600);
+        const Rect cropRect = Rect.fromLTWH(100, 200, 200, 200);
+
+        /// Pan the image down by a fractional offset so its top edge lands on
+        /// a sub-pixel boundary - the situation that previously left an
+        /// anti-aliased seam revealing a thin line of the image.
+        const Offset offset = Offset(0, 80.5);
+
+        final painter = CropCornerPainter(
+          cropRect: cropRect,
+          viewRect: const Rect.fromLTWH(0, 0, 400, 600),
+          screenSize: canvasSize,
+          style: const CropRotateEditorStyle(
+            cropOverlayColor: Color(0xFF000000),
+            cropOverlayOpacity: 1,
+            cropOverlayInteractionOpacity: 0,
+          ),
+          drawCircle: false,
+          offset: offset,
+          interactionOpacity: 0,
+          fadeInOpacity: 1,
+          rotationScaleFactor: 1.0,
+          scaleFactor: 1.0,
+        );
+
+        final recorder = ui.PictureRecorder();
+        painter.paint(Canvas(recorder), canvasSize);
+        final ui.Image image = await recorder.endRecording().toImage(
+          canvasSize.width.toInt(),
+          canvasSize.height.toInt(),
+        );
+        final byteData = await image.toByteData(
+          format: ui.ImageByteFormat.rawRgba,
+        );
+        final bytes = byteData!.buffer.asUint8List();
+
+        int alphaAt(int x, int y) =>
+            bytes[(y * canvasSize.width.toInt() + x) * 4 + 3];
+
+        /// The image's top edge sits at y = 80.5. The pixel row at y = 80 is
+        /// the seam that used to show through; with the overscan it must be
+        /// fully opaque, just like a clearly interior row.
+        expect(alphaAt(200, 80), greaterThanOrEqualTo(250));
+        expect(alphaAt(200, 100), 255);
+      },
+    );
   });
 }


### PR DESCRIPTION
Fixes #776

## Problem

In the `CropRotateEditor`, when the image is panned so one of its edges floats inside the viewport (e.g. the image pushed to the bottom, bringing its top edge into view), a thin line of the image was visible at that edge even with `cropOverlayOpacity: 1`.

## Root cause

The darkened crop overlay is painted **on top of** the image, and its outer rectangle was computed to be *mathematically identical* to the rendered image bounds (verified numerically — the edges match to within ~1e-13). Because the overlay's edge coincides exactly with the image's edge, anti-aliasing along that shared boundary leaves a ~1px partially-transparent seam (alpha ≈ 128 instead of 255), revealing the image underneath. At the viewport's own edges the seam is clipped away, which is why it only appeared on the panned-in edge.

## Fix

Overscan the outer overlay rectangle by a small screen-space margin (`1` logical px) so its edge lands just *outside* the image, on the surrounding background where the seam is invisible. The margin is divided by `rotationScaleFactor` to convert it from screen space into the painter's local space, keeping it visually constant across zoom levels — mirroring how the corner-thickness code already scales itself. The subtracted crop hole is untouched, so the crop area is unaffected.

## Test

Added a regression test that rasterizes the overlay with a fractional pan offset and asserts the image's top-edge row is fully opaque. It fails before the fix (alpha = 128) and passes after (255).