### PR TITLE
fix(crop-rotate): honor initAspectRatio for the initial oval cropper (#828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.8.2
+- **FIX**(crop-rotate): Honor `initAspectRatio` for the oval cropper in the main editor's initial state. Opening the editor directly in `CropMode.oval` with a fixed `initAspectRatio` (e.g. `1.0`) previously rendered and exported an ellipse stretched to the full image bounds for non-square images, because the initial (un-transformed) state never consulted `initAspectRatio` and fell back to the full image aspect ratio. The initial oval mask now uses a centered crop of the requested ratio in the overlay, the capture overlay and the export clip (so `1.0` produces a circle), while a free (`-1`) or original (`0.0`) ratio keeps the previous full-image behavior.
+
 ## 12.8.1
 - **FIX**(crop-rotate): Cover the image edge with the crop overlay when the image is panned. The darkened overlay is painted on top of the image and its outer rectangle matched the rendered image bounds exactly, so when an image edge floated inside the viewport (e.g. the image pushed to the bottom) anti-aliasing along that shared edge left a ~1px partially-transparent seam that revealed a thin line of the image. The overlay rectangle is now slightly overscanned beyond the image bounds so the seam falls on the surrounding background where it is invisible.
 

--- a/lib/core/models/editor_configs/crop_rotate_editor_configs.dart
+++ b/lib/core/models/editor_configs/crop_rotate_editor_configs.dart
@@ -185,6 +185,22 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
   /// For free aspect ratio use `-1` and for original aspect ratio use `0.0`.
   final double? initAspectRatio;
 
+  /// The fixed aspect ratio that applies to the oval mask in the editor's
+  /// initial state, before any crop/rotate transform has been performed, or
+  /// `null` when the mask should span the full image.
+  ///
+  /// This honors [initAspectRatio] for the initial oval cropper so that opening
+  /// the editor directly with e.g. a `1.0` ratio renders a circle instead of an
+  /// ellipse stretched to the full image bounds (see issue #828). It returns
+  /// `null` for a free (`-1`) or original (`0.0`) ratio, or when
+  /// [initialCropMode] is not [CropMode.oval], so callers fall back to the
+  /// full image aspect ratio.
+  double? get initialOvalCropAspectRatio {
+    if (initialCropMode != CropMode.oval) return null;
+    final ratio = initAspectRatio;
+    return (ratio != null && ratio > 0) ? ratio : null;
+  }
+
   /// The maximum scale allowed for the view.
   final double maxScale;
 

--- a/lib/features/main_editor/widgets/main_editor_interactive_content.dart
+++ b/lib/features/main_editor/widgets/main_editor_interactive_content.dart
@@ -264,7 +264,8 @@ class MainEditorInteractiveContent extends StatelessWidget {
       backgroundColor: configs.mainEditor.style.background,
       imgRatio: hasTransformChanges
           ? transformConfigs.cropRect.size.aspectRatio
-          : sizesManager.decodedImageSize.aspectRatio,
+          : configs.cropRotateEditor.initialOvalCropAspectRatio ??
+                sizesManager.decodedImageSize.aspectRatio,
       isRoundCropper: cropMode == CropMode.oval,
       is90DegRotated: transformConfigs.is90DegRotated,
       interactiveViewerScale:

--- a/lib/shared/widgets/layer/layer_stack.dart
+++ b/lib/shared/widgets/layer/layer_stack.dart
@@ -132,6 +132,7 @@ class LayerStack extends StatelessWidget {
   CustomPainter _buildCropPainter() {
     final imgRatio =
         _transformConfigs?.cropRect.size.aspectRatio ??
+        configs.cropRotateEditor.initialOvalCropAspectRatio ??
         transformHelper.mainImageSize.aspectRatio;
     final isRoundCropper =
         _transformConfigs?.isOvalCropper ??

--- a/lib/shared/widgets/transform/transformed_content_generator.dart
+++ b/lib/shared/widgets/transform/transformed_content_generator.dart
@@ -151,6 +151,8 @@ class TransformedContentGenerator extends StatelessWidget {
     final clipper = CutOutsideArea(
       configs: _transformConfigs,
       cropMode: effectiveCropMode,
+      initialOvalCropAspectRatio:
+          configs.cropRotateEditor.initialOvalCropAspectRatio,
     );
 
     if (effectiveCropMode == CropMode.oval) {
@@ -231,7 +233,11 @@ class TransformedContentGenerator extends StatelessWidget {
 /// configurations.
 class CutOutsideArea extends CustomClipper<Rect> {
   /// Creates an instance of [CutOutsideArea] with the given [configs].
-  CutOutsideArea({required this.configs, required this.cropMode});
+  CutOutsideArea({
+    required this.configs,
+    required this.cropMode,
+    this.initialOvalCropAspectRatio,
+  });
 
   /// Defines the cropping shape to apply to an image or video.
   final CropMode cropMode;
@@ -239,11 +245,19 @@ class CutOutsideArea extends CustomClipper<Rect> {
   /// The configuration object that provides the crop rectangle.
   final TransformConfigs configs;
 
+  /// The fixed aspect ratio for the initial oval mask, used while no transform
+  /// has been applied yet.
+  ///
+  /// Without this, the empty-config oval mask spans the full image bounds and
+  /// exports an ellipse for non-square images even when a fixed ratio such as
+  /// `1.0` was requested (see issue #828). `null` keeps the full image bounds.
+  final double? initialOvalCropAspectRatio;
+
   @override
   Rect getClip(Size size) {
     Rect cropRect = configs.cropRect;
     if (configs.isEmpty && cropMode == CropMode.oval) {
-      cropRect = Rect.fromLTWH(0, 0, size.width, size.height);
+      cropRect = _initialOvalCropRect(size);
     }
 
     return Rect.fromCenter(
@@ -253,10 +267,32 @@ class CutOutsideArea extends CustomClipper<Rect> {
     );
   }
 
+  /// Builds the centered crop rect for the initial oval mask, honoring
+  /// [initialOvalCropAspectRatio] when set and otherwise spanning the full
+  /// image.
+  Rect _initialOvalCropRect(Size size) {
+    final ratio = initialOvalCropAspectRatio;
+    if (ratio == null || ratio <= 0) {
+      return Rect.fromLTWH(0, 0, size.width, size.height);
+    }
+
+    final double width;
+    final double height;
+    if (size.aspectRatio > ratio) {
+      height = size.height;
+      width = size.height * ratio;
+    } else {
+      width = size.width;
+      height = size.width / ratio;
+    }
+    return Rect.fromLTWH(0, 0, width, height);
+  }
+
   @override
   bool shouldReclip(covariant CustomClipper<Rect> oldClipper) {
     return oldClipper is! CutOutsideArea ||
         oldClipper.configs != configs ||
-        oldClipper.cropMode != cropMode;
+        oldClipper.cropMode != cropMode ||
+        oldClipper.initialOvalCropAspectRatio != initialOvalCropAspectRatio;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.8.1
+version: 12.8.2
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/shared/widgets/transform/cut_outside_area_test.dart
+++ b/test/shared/widgets/transform/cut_outside_area_test.dart
@@ -1,0 +1,93 @@
+// Flutter imports:
+import 'package:flutter/widgets.dart';
+
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_image_editor/core/models/editor_configs/crop_rotate_editor_configs.dart';
+import 'package:pro_image_editor/features/crop_rotate_editor/enums/crop_mode.enum.dart';
+import 'package:pro_image_editor/shared/widgets/transform/transformed_content_generator.dart';
+
+void main() {
+  group('CropRotateEditorConfigs.initialOvalCropAspectRatio', () {
+    test('returns the ratio for an oval cropper with a fixed ratio', () {
+      const configs = CropRotateEditorConfigs(
+        initialCropMode: CropMode.oval,
+        initAspectRatio: 1.0,
+      );
+      expect(configs.initialOvalCropAspectRatio, 1.0);
+    });
+
+    test('is null for a free (-1) or original (0) ratio', () {
+      expect(
+        const CropRotateEditorConfigs(
+          initialCropMode: CropMode.oval,
+          initAspectRatio: -1,
+        ).initialOvalCropAspectRatio,
+        isNull,
+      );
+      expect(
+        const CropRotateEditorConfigs(
+          initialCropMode: CropMode.oval,
+          initAspectRatio: 0,
+        ).initialOvalCropAspectRatio,
+        isNull,
+      );
+    });
+
+    test('is null for the rectangular cropper', () {
+      expect(
+        const CropRotateEditorConfigs(
+          initAspectRatio: 1.0,
+        ).initialOvalCropAspectRatio,
+        isNull,
+      );
+    });
+  });
+
+  group('CutOutsideArea.getClip (initial oval mask)', () {
+    final emptyConfigs = TransformConfigs.empty();
+
+    test(
+      'clips a non-square image to a centered square for a 1:1 ratio (circle)',
+      () {
+        final clipper = CutOutsideArea(
+          configs: emptyConfigs,
+          cropMode: CropMode.oval,
+          initialOvalCropAspectRatio: 1.0,
+        );
+
+        final rect = clipper.getClip(const Size(400, 800));
+
+        // A 1:1 mask must be a circle, i.e. a square clip rect.
+        expect(rect.width, rect.height);
+        expect(rect.width, 400);
+        expect(rect.center, const Offset(200, 400));
+      },
+    );
+
+    test('keeps the full image bounds without a fixed ratio (ellipse)', () {
+      final clipper = CutOutsideArea(
+        configs: emptyConfigs,
+        cropMode: CropMode.oval,
+      );
+
+      final rect = clipper.getClip(const Size(400, 800));
+
+      expect(rect.width, 400);
+      expect(rect.height, 800);
+    });
+
+    test('honors a wide ratio by fitting the width', () {
+      final clipper = CutOutsideArea(
+        configs: emptyConfigs,
+        cropMode: CropMode.oval,
+        initialOvalCropAspectRatio: 16 / 9,
+      );
+
+      final rect = clipper.getClip(const Size(400, 800));
+
+      expect(rect.width, 400);
+      expect(rect.height, closeTo(400 / (16 / 9), 0.001));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #828

## Problem

Opening `ProImageEditor` directly in the oval cropper with a fixed `initAspectRatio` (e.g. `1.0`) renders and exports an **ellipse** stretched to the full image bounds for any non-square image, instead of a circle.

## Root cause

The main editor initializes its history with an empty transform that only carries the crop mode:

```dart
transformConfigs: TransformConfigs.empty().copyWith(
  cropMode: cropRotateEditorConfigs.initialCropMode,
),
```

`initAspectRatio` is never consulted for the initial state, so every consumer that derives the oval mask falls back to the **full image aspect ratio**:

- the main editor capture overlay (`main_editor_interactive_content.dart`)
- the shared layer-stack overlay (`layer_stack.dart`)
- the export clip (`CutOutsideArea` in `transformed_content_generator.dart`)

If the user exports without first entering the crop sub-editor, the result is an ellipse.

## Fix

Add `CropRotateEditorConfigs.initialOvalCropAspectRatio`, which returns the fixed ratio for the initial oval state and `null` when the full image should be used (free `-1`, original `0.0`, or a non-oval initial crop mode). All three consumers now use it as the fallback before the full-image aspect ratio, and `CutOutsideArea` builds a centered crop rect of that ratio for the initial oval mask.

Result: a `1.0` ratio renders/exports a **circle**; free (`-1`) and original (`0.0`) ratios keep the previous full-image behavior. The fix is scoped to the oval cropper so rectangular crops are unaffected (they still only crop once the user confirms in the crop sub-editor).

## Tests

Added `cut_outside_area_test.dart` covering the new getter (oval+fixed ratio → ratio; free/original/rectangular → null) and `CutOutsideArea.getClip` (non-square image → centered square for 1:1, full bounds without a fixed ratio, width-fit for a wide ratio).