### PR TITLE
feat(editors): support onKeyboardEvent & enableKeyboardShortcuts in sub-editors (#837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.9.0
+- **FEAT**(editors): Support keyboard handling in the sub-editors, not just the main editor (#837). The `onKeyboardEvent` callback is now available on every standalone editor's callbacks (crop-rotate, paint, filter, tune, blur) via `StandaloneEditorCallbacks`; returning `true` consumes the event and skips the built-in shortcut. The crop-rotate and paint editors additionally gain an `enableKeyboardShortcuts` option (default `true`) to disable their built-in shortcuts (e.g. `R`/`F` in the crop-rotate editor). Previously these callbacks and the option only affected the main editor, so the crop-rotate `R`/`F` shortcuts could not be intercepted or disabled.
+
 ## 12.8.2
 - **FIX**(crop-rotate): Honor `initAspectRatio` for the oval cropper in the main editor's initial state. Opening the editor directly in `CropMode.oval` with a fixed `initAspectRatio` (e.g. `1.0`) previously rendered and exported an ellipse stretched to the full image bounds for non-square images, because the initial (un-transformed) state never consulted `initAspectRatio` and fell back to the full image aspect ratio. The initial oval mask now uses a centered crop of the requested ratio in the overlay, the capture overlay and the export clip (so `1.0` produces a circle), while a free (`-1`) or original (`0.0`) ratio keeps the previous full-image behavior.
 

--- a/lib/core/mixins/standalone_editor.dart
+++ b/lib/core/mixins/standalone_editor.dart
@@ -1,11 +1,12 @@
 // Dart imports:
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/models/complete_parameters.dart';
+import '/core/models/editor_callbacks/standalone_editor_callbacks.dart';
 import '/features/filter_editor/types/filter_matrix.dart';
 import '/features/tune_editor/models/tune_adjustment_matrix.dart';
 import '/shared/controllers/video_controller.dart';
@@ -287,6 +288,41 @@ mixin StandaloneEditorState<
     );
   }
 
+  /// Whether the editor's built-in keyboard shortcuts are enabled.
+  ///
+  /// Editors that expose an `enableKeyboardShortcuts` option override this.
+  /// When `false`, neither the built-in shortcuts nor the
+  /// [standaloneEditorCallbacks]' `onKeyboardEvent` are invoked.
+  @protected
+  bool get enableKeyboardShortcuts => true;
+
+  /// The standalone callbacks of the concrete editor, used to forward keyboard
+  /// events to [StandaloneEditorCallbacks.onKeyboardEvent].
+  ///
+  /// Editors override this to return their specific callbacks (e.g.
+  /// `filterEditorCallbacks`). Returns `null` by default, which disables the
+  /// keyboard callback for that editor.
+  @protected
+  StandaloneEditorCallbacks? get standaloneEditorCallbacks => null;
+
+  /// Hook for editor-specific built-in keyboard shortcuts.
+  ///
+  /// Called only when [enableKeyboardShortcuts] is `true` and the event was not
+  /// already consumed by `onKeyboardEvent`. Returns `true` when the event was
+  /// handled and should stop propagating.
+  @protected
+  bool onCustomKeyEvent(KeyEvent event) => false;
+
+  bool _handleStandaloneKeyEvent(KeyEvent event) {
+    if (!enableKeyboardShortcuts) return false;
+
+    if (standaloneEditorCallbacks?.handleKeyboardEvent(event) ?? false) {
+      return true;
+    }
+
+    return onCustomKeyEvent(event);
+  }
+
   @override
   @mustCallSuper
   void initState() {
@@ -297,11 +333,13 @@ mixin StandaloneEditorState<
       ignoreGeneration: !initConfigs.convertToUint8List,
     );
     rebuildController = StreamController.broadcast();
+    ServicesBinding.instance.keyboard.addHandler(_handleStandaloneKeyEvent);
   }
 
   @override
   @mustCallSuper
   void dispose() {
+    ServicesBinding.instance.keyboard.removeHandler(_handleStandaloneKeyEvent);
     screenshotCtrl.destroy();
     rebuildController.close();
     super.dispose();

--- a/lib/core/models/editor_callbacks/blur_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/blur_editor_callbacks.dart
@@ -15,6 +15,7 @@ class BlurEditorCallbacks extends StandaloneEditorCallbacks {
     super.onUpdateUI,
     super.onDone,
     super.onCloseEditor,
+    super.onKeyboardEvent,
   });
 
   /// A callback function that is triggered when the blur factor changes.
@@ -54,11 +55,13 @@ class BlurEditorCallbacks extends StandaloneEditorCallbacks {
     Function()? onUpdateUI,
     Function()? onDone,
     Function()? onCloseEditor,
+    bool Function(KeyEvent event)? onKeyboardEvent,
   }) {
     return BlurEditorCallbacks(
       onBlurFactorChange: onBlurFactorChange ?? this.onBlurFactorChange,
       onBlurFactorChangeEnd:
           onBlurFactorChangeEnd ?? this.onBlurFactorChangeEnd,
+      onKeyboardEvent: onKeyboardEvent ?? this.onKeyboardEvent,
       onInit: onInit ?? this.onInit,
       onAfterViewInit: onAfterViewInit ?? this.onAfterViewInit,
       onUpdateUI: onUpdateUI ?? this.onUpdateUI,

--- a/lib/core/models/editor_callbacks/crop_rotate_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/crop_rotate_editor_callbacks.dart
@@ -27,6 +27,7 @@ class CropRotateEditorCallbacks extends StandaloneEditorCallbacks {
     super.onDone,
     super.onCloseEditor,
     super.onUpdateUI,
+    super.onKeyboardEvent,
   });
 
   /// A callback function that is triggered when a rotation gesture starts.
@@ -173,9 +174,11 @@ class CropRotateEditorCallbacks extends StandaloneEditorCallbacks {
     Function()? onRedo,
     Function()? onUndo,
     Function()? onCloseEditor,
+    bool Function(KeyEvent event)? onKeyboardEvent,
     Function(CompleteParameters parameters)? onTransformUpdateEnd,
   }) {
     return CropRotateEditorCallbacks(
+      onKeyboardEvent: onKeyboardEvent ?? this.onKeyboardEvent,
       onRotateStart: onRotateStart ?? this.onRotateStart,
       onRotateEnd: onRotateEnd ?? this.onRotateEnd,
       onFlip: onFlip ?? this.onFlip,

--- a/lib/core/models/editor_callbacks/filter_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/filter_editor_callbacks.dart
@@ -17,6 +17,7 @@ class FilterEditorCallbacks extends StandaloneEditorCallbacks {
     super.onUpdateUI,
     super.onDone,
     super.onCloseEditor,
+    super.onKeyboardEvent,
   });
 
   /// A callback function that is triggered when the filter factor changes.
@@ -71,12 +72,14 @@ class FilterEditorCallbacks extends StandaloneEditorCallbacks {
     Function()? onUpdateUI,
     Function()? onDone,
     Function()? onCloseEditor,
+    bool Function(KeyEvent event)? onKeyboardEvent,
   }) {
     return FilterEditorCallbacks(
       onFilterFactorChange: onFilterFactorChange ?? this.onFilterFactorChange,
       onFilterFactorChangeEnd:
           onFilterFactorChangeEnd ?? this.onFilterFactorChangeEnd,
       onFilterChanged: onFilterChanged ?? this.onFilterChanged,
+      onKeyboardEvent: onKeyboardEvent ?? this.onKeyboardEvent,
       onInit: onInit ?? this.onInit,
       onAfterViewInit: onAfterViewInit ?? this.onAfterViewInit,
       onUpdateUI: onUpdateUI ?? this.onUpdateUI,

--- a/lib/core/models/editor_callbacks/main_editor/main_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/main_editor/main_editor_callbacks.dart
@@ -32,7 +32,6 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
     this.onEditorZoomScaleUpdate,
     this.onEditorZoomScaleEnd,
     this.onEscapeButton,
-    this.onKeyboardEvent,
     this.helperLines = const HelperLinesCallbacks(),
     this.onSelectedLayerChanged,
     this.onSelectedLayersChanged,
@@ -53,6 +52,7 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
     super.onDone,
     super.onRedo,
     super.onUndo,
+    super.onKeyboardEvent,
   });
 
   /// Callback triggered when a layer receives a tap down event.
@@ -186,24 +186,6 @@ class MainEditorCallbacks extends StandaloneEditorCallbacks {
   /// This function is called when the ESC key is pressed.
   /// By default it is null, which runs the default "close" behavior.
   final Function()? onEscapeButton;
-
-  /// Callback invoked when a keyboard event occurs.
-  ///
-  /// If this function returns `true`, the keyboard event will be consumed and
-  /// not propagated further. Returning `false` or `null` allows the event to
-  /// continue propagating.
-  ///
-  /// Example usage:
-  /// ```dart
-  /// onKeyboardEvent: (event) {
-  ///   if (event.logicalKey == LogicalKeyboardKey.escape) {
-  ///     // Handle Escape key and consume the event.
-  ///     return true;
-  ///   }
-  ///   return false; // Let other keys propagate.
-  /// },
-  /// ```
-  final bool Function(KeyEvent event)? onKeyboardEvent;
 
   /// Callback triggered when the import of the editor's history starts.
   ///

--- a/lib/core/models/editor_callbacks/paint_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/paint_editor_callbacks.dart
@@ -29,6 +29,7 @@ class PaintEditorCallbacks extends StandaloneEditorCallbacks {
     super.onDone,
     super.onCloseEditor,
     super.onUpdateUI,
+    super.onKeyboardEvent,
   });
 
   /// A callback function that is triggered when the line width changes.
@@ -294,9 +295,11 @@ class PaintEditorCallbacks extends StandaloneEditorCallbacks {
     Function()? onRedo,
     Function()? onUndo,
     Function()? onCloseEditor,
+    bool Function(KeyEvent event)? onKeyboardEvent,
     Future<PaintLayer?> Function(PaintLayer layer)? onEditLayer,
   }) {
     return PaintEditorCallbacks(
+      onKeyboardEvent: onKeyboardEvent ?? this.onKeyboardEvent,
       onLineWidthChanged: onLineWidthChanged ?? this.onLineWidthChanged,
       onPaintModeChanged: onPaintModeChanged ?? this.onPaintModeChanged,
       onToggleFill: onToggleFill ?? this.onToggleFill,

--- a/lib/core/models/editor_callbacks/standalone_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/standalone_editor_callbacks.dart
@@ -14,6 +14,7 @@ abstract class StandaloneEditorCallbacks {
     this.onCloseEditor,
     this.onInit,
     this.onAfterViewInit,
+    this.onKeyboardEvent,
   });
 
   /// A callback function that can be used to update the UI from custom widgets.
@@ -43,6 +44,24 @@ abstract class StandaloneEditorCallbacks {
   /// The framework will call this method exactly once for each [State] object
   /// it creates.
   final Function()? onAfterViewInit;
+
+  /// Callback invoked when a keyboard event occurs in the editor.
+  ///
+  /// If this function returns `true`, the event is consumed and the editor's
+  /// built-in keyboard shortcuts are skipped for it. Returning `false` or
+  /// `null` allows the default shortcut handling to continue.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// onKeyboardEvent: (event) {
+  ///   if (event.logicalKey == LogicalKeyboardKey.keyR) {
+  ///     // Prevent the built-in rotate shortcut.
+  ///     return true;
+  ///   }
+  ///   return false;
+  /// },
+  /// ```
+  final bool Function(KeyEvent event)? onKeyboardEvent;
 
   /// Handles the undo action.
   ///
@@ -82,5 +101,13 @@ abstract class StandaloneEditorCallbacks {
   /// This method calls the [onUpdateUI] callback.
   void handleUpdateUI() {
     onUpdateUI?.call();
+  }
+
+  /// Handles a keyboard event by forwarding it to [onKeyboardEvent].
+  ///
+  /// Returns `true` when the event was consumed by the callback, signaling that
+  /// the editor's built-in shortcut handling should be skipped.
+  bool handleKeyboardEvent(KeyEvent event) {
+    return onKeyboardEvent?.call(event) ?? false;
   }
 }

--- a/lib/core/models/editor_callbacks/tune_editor_callbacks.dart
+++ b/lib/core/models/editor_callbacks/tune_editor_callbacks.dart
@@ -18,6 +18,7 @@ class TuneEditorCallbacks extends StandaloneEditorCallbacks {
     super.onRedo,
     super.onUndo,
     super.onCloseEditor,
+    super.onKeyboardEvent,
   });
 
   /// A callback function that is triggered when the tune factor changes.
@@ -75,12 +76,14 @@ class TuneEditorCallbacks extends StandaloneEditorCallbacks {
     Function()? onRedo,
     Function()? onUndo,
     Function()? onCloseEditor,
+    bool Function(KeyEvent event)? onKeyboardEvent,
   }) {
     return TuneEditorCallbacks(
       onTuneFactorChange: onTuneFactorChange ?? this.onTuneFactorChange,
       onTuneFactorChangeEnd:
           onTuneFactorChangeEnd ?? this.onTuneFactorChangeEnd,
       onTuneChanged: onTuneChanged ?? this.onTuneChanged,
+      onKeyboardEvent: onKeyboardEvent ?? this.onKeyboardEvent,
       onInit: onInit ?? this.onInit,
       onAfterViewInit: onAfterViewInit ?? this.onAfterViewInit,
       onUpdateUI: onUpdateUI ?? this.onUpdateUI,

--- a/lib/core/models/editor_configs/crop_rotate_editor_configs.dart
+++ b/lib/core/models/editor_configs/crop_rotate_editor_configs.dart
@@ -57,6 +57,7 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
     this.enableDoubleTap = true,
     this.enableFlipAnimation = true,
     this.enableKeepAspectRatioOnRotate = false,
+    this.enableKeyboardShortcuts = true,
     this.showLayers = true,
     this.initAspectRatio,
     this.rotateAnimationCurve = Curves.decelerate,
@@ -133,6 +134,17 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
   /// For the free and original ratio the current crop frame orientation is
   /// kept.
   final bool enableKeepAspectRatioOnRotate;
+
+  /// Whether physical keyboard shortcuts are enabled in the crop-rotate editor.
+  ///
+  /// When `true` (default), keys such as `R` (rotate), `F` (flip), the arrow
+  /// keys (translate), `+`/`-` (zoom) and `Ctrl`/`Cmd`+`Z` (undo/redo) control
+  /// the editor. Set it to `false` to disable all built-in shortcuts, e.g. to
+  /// reserve those keys for your own handling.
+  ///
+  /// Individual events can also be intercepted with
+  /// [CropRotateEditorCallbacks.onKeyboardEvent].
+  final bool enableKeyboardShortcuts;
 
   /// Determines if the mouse scroll direction should be inverted.
   final bool invertMouseScroll;
@@ -295,6 +307,7 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
     bool? enableDoubleTap,
     bool? enableFlipAnimation,
     bool? enableKeepAspectRatioOnRotate,
+    bool? enableKeyboardShortcuts,
     bool? invertMouseScroll,
     bool? invertDragDirection,
     CropMode? initialCropMode,
@@ -333,6 +346,8 @@ class CropRotateEditorConfigs implements BaseSubEditorConfigs {
       enableFlipAnimation: enableFlipAnimation ?? this.enableFlipAnimation,
       enableKeepAspectRatioOnRotate:
           enableKeepAspectRatioOnRotate ?? this.enableKeepAspectRatioOnRotate,
+      enableKeyboardShortcuts:
+          enableKeyboardShortcuts ?? this.enableKeyboardShortcuts,
       invertMouseScroll: invertMouseScroll ?? this.invertMouseScroll,
       invertDragDirection: invertDragDirection ?? this.invertDragDirection,
       initialCropMode: initialCropMode ?? this.initialCropMode,

--- a/lib/core/models/editor_configs/paint_editor/paint_editor_configs.dart
+++ b/lib/core/models/editor_configs/paint_editor/paint_editor_configs.dart
@@ -42,6 +42,7 @@ class PaintEditorConfigs extends ZoomConfigs
     this.layerFractionalOffset = const Offset(-0.5, -0.5),
     this.enableGesturePop = true,
     this.enableEdit = true,
+    this.enableKeyboardShortcuts = true,
     this.tools = const [
       PaintMode.moveAndZoom,
       PaintMode.freeStyle,
@@ -125,6 +126,15 @@ class PaintEditorConfigs extends ZoomConfigs
 
   /// Indicating whether created layers can be edited.
   final bool enableEdit;
+
+  /// Whether physical keyboard shortcuts are enabled in the paint editor.
+  ///
+  /// When `true` (default), `Ctrl`/`Cmd`+`Z` controls undo/redo. Set it to
+  /// `false` to disable the built-in shortcuts.
+  ///
+  /// Individual events can also be intercepted with
+  /// [PaintEditorCallbacks.onKeyboardEvent].
+  final bool enableKeyboardShortcuts;
 
   /// Defines which paint tools are available in the editor.
   ///
@@ -296,6 +306,7 @@ class PaintEditorConfigs extends ZoomConfigs
     Offset? layerFractionalOffset,
     bool? enableGesturePop,
     bool? enableEdit,
+    bool? enableKeyboardShortcuts,
     bool? showToggleFillButton,
     bool? showLineWidthAdjustmentButton,
     bool? showOpacityAdjustmentButton,
@@ -340,6 +351,8 @@ class PaintEditorConfigs extends ZoomConfigs
           layerFractionalOffset ?? this.layerFractionalOffset,
       enableGesturePop: enableGesturePop ?? this.enableGesturePop,
       enableEdit: enableEdit ?? this.enableEdit,
+      enableKeyboardShortcuts:
+          enableKeyboardShortcuts ?? this.enableKeyboardShortcuts,
       tools: tools ?? this.tools,
       showToggleFillButton: showToggleFillButton ?? this.showToggleFillButton,
       showLineWidthAdjustmentButton:

--- a/lib/features/blur_editor/blur_editor.dart
+++ b/lib/features/blur_editor/blur_editor.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import '/core/mixins/converted_callbacks.dart';
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/standalone_editor.dart';
+import '/core/models/editor_callbacks/blur_editor_callbacks.dart';
 import '/core/models/editor_image.dart';
 import '/core/models/init_configs/blur_editor_init_configs.dart';
 import '/core/models/transform_helper.dart';
@@ -177,6 +178,9 @@ class BlurEditorState extends State<BlurEditor>
   set blurFactor(double value) {
     _blurFactor.value = value;
   }
+
+  @override
+  BlurEditorCallbacks? get standaloneEditorCallbacks => blurEditorCallbacks;
 
   @override
   void initState() {

--- a/lib/features/crop_rotate_editor/crop_rotate_editor.dart
+++ b/lib/features/crop_rotate_editor/crop_rotate_editor.dart
@@ -428,7 +428,6 @@ class CropRotateEditorState extends State<CropRotateEditor>
     _desktopInteractionManager = CropDesktopInteractionManager(
       context: context,
     );
-    ServicesBinding.instance.keyboard.addHandler(_onKeyEvent);
 
     // Initialize image and layers
     _imageNeedDecode = mainImageSize == null;
@@ -543,7 +542,6 @@ class CropRotateEditorState extends State<CropRotateEditor>
     _bottomBarScrollCtrl.dispose();
     rotateCtrl.dispose();
     scaleCtrl.dispose();
-    ServicesBinding.instance.keyboard.removeHandler(_onKeyEvent);
     super.dispose();
   }
 
@@ -687,7 +685,16 @@ class CropRotateEditorState extends State<CropRotateEditor>
     _updateAllStates();
   }
 
-  bool _onKeyEvent(KeyEvent event) {
+  @override
+  bool get enableKeyboardShortcuts =>
+      cropRotateEditorConfigs.enableKeyboardShortcuts;
+
+  @override
+  CropRotateEditorCallbacks? get standaloneEditorCallbacks =>
+      cropRotateEditorCallbacks;
+
+  @override
+  bool onCustomKeyEvent(KeyEvent event) {
     return _desktopInteractionManager.onKey(
       event,
       onRotate: rotate,

--- a/lib/features/filter_editor/filter_editor.dart
+++ b/lib/features/filter_editor/filter_editor.dart
@@ -187,6 +187,9 @@ class FilterEditorState extends State<FilterEditor>
   }
 
   @override
+  FilterEditorCallbacks? get standaloneEditorCallbacks => filterEditorCallbacks;
+
+  @override
   void initState() {
     super.initState();
     _uiFilterStream = StreamController.broadcast();

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -314,7 +314,6 @@ class PaintEditorState extends State<PaintEditor>
     _desktopInteractionManager = PaintDesktopInteractionManager(
       context: context,
     );
-    ServicesBinding.instance.keyboard.addHandler(_onKeyEvent);
 
     /// Important to set state after view init to set action icons
     paintEditorCallbacks?.onInit?.call();
@@ -339,7 +338,6 @@ class PaintEditorState extends State<PaintEditor>
     _uiAppbarStream.close();
     _layerStackStream.close();
     screenshotCtrl.destroy();
-    ServicesBinding.instance.keyboard.removeHandler(_onKeyEvent);
     super.dispose();
   }
 
@@ -516,8 +514,16 @@ class PaintEditorState extends State<PaintEditor>
     _layerStackStream.stream.listen((_) => rebuildController.add(null));
   }
 
+  @override
+  bool get enableKeyboardShortcuts =>
+      paintEditorConfigs.enableKeyboardShortcuts;
+
+  @override
+  PaintEditorCallbacks? get standaloneEditorCallbacks => paintEditorCallbacks;
+
   /// Handle keyboard events
-  bool _onKeyEvent(KeyEvent event) {
+  @override
+  bool onCustomKeyEvent(KeyEvent event) {
     return _desktopInteractionManager.onKey(
       event,
       onUndoRedo: (undo) {

--- a/lib/features/tune_editor/tune_editor.dart
+++ b/lib/features/tune_editor/tune_editor.dart
@@ -209,6 +209,9 @@ class TuneEditorState extends State<TuneEditor>
   bool get canRedo => _redoStack.isNotEmpty;
 
   @override
+  TuneEditorCallbacks? get standaloneEditorCallbacks => tuneEditorCallbacks;
+
+  @override
   void initState() {
     super.initState();
     uiStream = StreamController.broadcast();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.8.2
+version: 12.9.0
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/features/crop_rotate_editor/crop_rotate_editor_test.dart
+++ b/test/features/crop_rotate_editor/crop_rotate_editor_test.dart
@@ -2,9 +2,11 @@
 
 // Flutter imports:
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:network_image_mock/network_image_mock.dart';
+import 'package:pro_image_editor/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import 'package:pro_image_editor/core/models/editor_configs/pro_image_editor_configs.dart';
 import 'package:pro_image_editor/core/models/init_configs/crop_rotate_editor_init_configs.dart';
 import 'package:pro_image_editor/features/crop_rotate_editor/crop_rotate_editor.dart';
@@ -407,6 +409,91 @@ void main() {
 
       // Ensure to draw ratios
       expect(find.text('16*9'), findsOneWidget);
+    });
+  });
+
+  group('Keyboard shortcuts', () {
+    const fastConfig = CropRotateEditorConfigs(
+      animationDuration: Duration.zero,
+      cropDragAnimationDuration: Duration.zero,
+      fadeInOutsideCropAreaAnimationDuration: Duration.zero,
+      opacityOutsideCropAreaDuration: Duration.zero,
+    );
+
+    Future<GlobalKey<CropRotateEditorState>> pumpWith(
+      WidgetTester tester, {
+      required CropRotateEditorConfigs cropConfigs,
+      ProImageEditorCallbacks callbacks = const ProImageEditorCallbacks(),
+    }) async {
+      final editorKey = GlobalKey<CropRotateEditorState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CropRotateEditor.memory(
+              mockMemoryImage,
+              key: editorKey,
+              initConfigs: CropRotateEditorInitConfigs(
+                theme: ThemeData.light(),
+                enableFakeHero: false,
+                callbacks: callbacks,
+                configs: ProImageEditorConfigs(
+                  cropRotateEditor: cropConfigs,
+                  imageGeneration: const ImageGenerationConfigs(
+                    enableBackgroundGeneration: false,
+                    enableIsolateGeneration: false,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return editorKey;
+    }
+
+    testWidgets('rotate the image with the R key by default', (tester) async {
+      final editorKey = await pumpWith(tester, cropConfigs: fastConfig);
+      expect(editorKey.currentState!.rotationCount, 0);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyR);
+      await tester.pumpAndSettle();
+
+      expect(editorKey.currentState!.rotationCount, 1);
+    });
+
+    testWidgets('ignore the R key when shortcuts are disabled', (tester) async {
+      final editorKey = await pumpWith(
+        tester,
+        cropConfigs: fastConfig.copyWith(enableKeyboardShortcuts: false),
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyR);
+      await tester.pumpAndSettle();
+
+      expect(editorKey.currentState!.rotationCount, 0);
+    });
+
+    testWidgets('onKeyboardEvent can consume the R key (#837)', (tester) async {
+      var receivedEvent = false;
+      final editorKey = await pumpWith(
+        tester,
+        cropConfigs: fastConfig,
+        callbacks: ProImageEditorCallbacks(
+          cropRotateEditorCallbacks: CropRotateEditorCallbacks(
+            onKeyboardEvent: (event) {
+              receivedEvent = true;
+              return true;
+            },
+          ),
+        ),
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyR);
+      await tester.pumpAndSettle();
+
+      expect(receivedEvent, isTrue);
+      expect(editorKey.currentState!.rotationCount, 0);
     });
   });
 }


### PR DESCRIPTION
Fixes #837

## Problem

`MainEditorCallbacks.onKeyboardEvent` and `MainEditorConfigs.enableKeyboardShortcuts` only affected the **main editor**. In sub-editors there was no way to intercept or disable keyboard shortcuts — e.g. the `R`/`F` keys in the crop-rotate editor always triggered rotate/flip and `onKeyboardEvent` was never called.

## Changes

**Shared callback (`onKeyboardEvent`)**
- Moved `onKeyboardEvent` into the shared `StandaloneEditorCallbacks` base (plus a `handleKeyboardEvent` helper). Every standalone editor's callbacks (crop-rotate, paint, filter, tune, blur) now exposes it, and `MainEditorCallbacks` inherits it (no behavior change for the main editor).

**Centralized handling (`StandaloneEditorState`)**
- The mixin now registers a single keyboard handler that:
  1. returns early when `enableKeyboardShortcuts` is `false`,
  2. forwards the event to the editor's `onKeyboardEvent` (consumes it when that returns `true`),
  3. otherwise delegates to an overridable `onCustomKeyEvent` hook for built-in shortcuts.

**Per-editor wiring**
- **Crop-rotate** & **paint**: built-in shortcuts moved into `onCustomKeyEvent`; their own `addHandler`/`removeHandler` registration was removed; new `enableKeyboardShortcuts` config option added (default `true`).
- **Filter**, **tune**, **blur**: forward keyboard events to their callbacks (they have no built-in shortcuts).

## Usage

```dart
ProImageEditorConfigs(
  cropRotateEditor: CropRotateEditorConfigs(
    enableKeyboardShortcuts: false, // disable R/F/arrows/zoom shortcuts
  ),
)

ProImageEditorCallbacks(
  cropRotateEditorCallbacks: CropRotateEditorCallbacks(
    onKeyboardEvent: (event) {
      if (event.logicalKey == LogicalKeyboardKey.keyR) return true; // consume
      return false;
    },
  ),
)
```

## Tests

Added a `Keyboard shortcuts` group to the crop-rotate editor tests: `R` rotates by default, `enableKeyboardShortcuts: false` ignores it, and an `onKeyboardEvent` returning `true` consumes it (no rotation). Full suite (431 tests) passes and `dart analyze lib` is clean.