### PR TITLE
fix(layers): anchor timeline scale animation on layer visual center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 12.11.1
+- **FIX**(layers): Anchor the video-timeline `scale` layer animation on the layer's visual center. Combining `scale` with a `slide` (e.g. slide-in from the top) previously drifted the layer in diagonally instead of straight, because scaling used the layout-box center while the layer content is painted off-center.
+
 ## 12.11.0
 - **FEAT**(crop-rotate): Add perspective tilt/skew (#525). New `CropRotateTool.tilt` with rotate/horizontal/vertical rulers (`TiltConfigs`); the crop stays inside the tilted image via auto-zoom, and tilt is hidden in the video editor by default.
 

--- a/lib/shared/widgets/layer/layer_timeline_visibility.dart
+++ b/lib/shared/widgets/layer/layer_timeline_visibility.dart
@@ -40,7 +40,7 @@ class LayerTimelineVisibility extends StatefulWidget {
     required this.configs,
     required this.canvasSize,
     required this.layerCenter,
-    required this.layerFractionalOffset,
+    this.layerFractionalOffset = const Offset(-0.5, -0.5),
     required this.child,
   });
 
@@ -66,7 +66,7 @@ class LayerTimelineVisibility extends StatefulWidget {
   final Offset layerCenter;
 
   /// The fractional offset used to position the layer content within its
-  /// layout box (typically `Offset(-0.5, -0.5)`, centering the content).
+  /// layout box (defaults to `Offset(-0.5, -0.5)`, centering the content).
   ///
   /// The [child] paints its visible content shifted by this fraction, so the
   /// layer's visual center is *not* the layout box center. The scale animation
@@ -290,9 +290,11 @@ class _LayerTimelineVisibilityState extends State<LayerTimelineVisibility> {
         child: result,
       );
     }
-    // The fractional part must wrap the already-scaled child so the ±0.5
-    // fraction applies to the layer's displayed (scaled) size; the absolute
-    // part is a plain pixel translation on top.
+    // The fractional part is applied outside the scale, so it translates by a
+    // fraction of the layer's base (unscaled) size. This mirrors the native
+    // renderer, which derives the slide from the unscaled layer half-size
+    // (`halfNormW`/`halfNormH` in ApplyAnimation) and applies scale
+    // independently. The absolute part is a plain pixel translation on top.
     if (frame.slideFractional != Offset.zero) {
       result = FractionalTranslation(
         translation: frame.slideFractional,

--- a/lib/shared/widgets/layer/layer_timeline_visibility.dart
+++ b/lib/shared/widgets/layer/layer_timeline_visibility.dart
@@ -25,7 +25,10 @@ import '/shared/utils/timeline_progress.dart';
 /// express. The slide effect is edge-aware: using [canvasSize] and
 /// [layerCenter] it pushes the layer just past the nearest canvas edge (rather
 /// than by its own size), so even an off-center layer leaves the visible area
-/// completely. When [Layer.animations] is empty, the legacy fade convenience
+/// completely. The scale effect is anchored on the layer's visual center (via
+/// [layerFractionalOffset]) so that a combined slide + scale enters straight
+/// instead of drifting diagonally. When [Layer.animations] is empty, the
+/// legacy fade convenience
 /// driven by [Layer.enterDuration] / [Layer.exitDuration] and the
 /// [LayerTimelineConfigs.transitionBuilder] is used instead.
 class LayerTimelineVisibility extends StatefulWidget {
@@ -37,6 +40,7 @@ class LayerTimelineVisibility extends StatefulWidget {
     required this.configs,
     required this.canvasSize,
     required this.layerCenter,
+    required this.layerFractionalOffset,
     required this.child,
   });
 
@@ -60,6 +64,16 @@ class LayerTimelineVisibility extends StatefulWidget {
   /// Combined with [canvasSize] this lets the slide animation translate the
   /// layer just far enough for its edge to leave (or enter from) the canvas.
   final Offset layerCenter;
+
+  /// The fractional offset used to position the layer content within its
+  /// layout box (typically `Offset(-0.5, -0.5)`, centering the content).
+  ///
+  /// The [child] paints its visible content shifted by this fraction, so the
+  /// layer's visual center is *not* the layout box center. The scale animation
+  /// uses this to anchor scaling on the visual center; otherwise scaling would
+  /// pull the layer toward the box center (down-right for the default offset),
+  /// making a combined slide + scale drift in diagonally instead of straight.
+  final Offset layerFractionalOffset;
 
   /// The layer widget to show/hide.
   final Widget child;
@@ -264,7 +278,17 @@ class _LayerTimelineVisibilityState extends State<LayerTimelineVisibility> {
 
     Widget result = child;
     if (frame.scale != 1.0) {
-      result = Transform.scale(scale: frame.scale, child: result);
+      // Anchor scaling on the layer's visual center rather than the layout
+      // box center. The child paints its content shifted by
+      // [layerFractionalOffset], so a fraction of (0.5 + fo) maps to
+      // Alignment(2 * fo). Without this the scale would drag the layer toward
+      // the box center as it shrinks.
+      final fo = widget.layerFractionalOffset;
+      result = Transform.scale(
+        scale: frame.scale,
+        alignment: Alignment(2 * fo.dx, 2 * fo.dy),
+        child: result,
+      );
     }
     // The fractional part must wrap the already-scaled child so the ±0.5
     // fraction applies to the layer's displayed (scaled) size; the absolute

--- a/lib/shared/widgets/layer/layer_widget.dart
+++ b/lib/shared/widgets/layer/layer_widget.dart
@@ -353,6 +353,7 @@ class _LayerWidgetState extends State<LayerWidget>
         configs: configs.videoEditor.layerTimeline,
         canvasSize: widget.editorBodySize,
         layerCenter: Offset(offsetX, offsetY),
+        layerFractionalOffset: _fractionalOffset,
         child: content,
       );
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 12.11.0
+version: 12.11.1
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/shared/widgets/layer_timeline_visibility_test.dart
+++ b/test/shared/widgets/layer_timeline_visibility_test.dart
@@ -14,6 +14,7 @@ void main() {
     Layer layer, {
     Size canvas = canvasSize,
     Offset center = layerCenter,
+    Offset fractionalOffset = const Offset(-0.5, -0.5),
   }) async {
     // Start before any layer's time range so the first seek registers as a
     // real change on the [ValueNotifier].
@@ -30,6 +31,7 @@ void main() {
             configs: const LayerTimelineConfigs(),
             canvasSize: canvas,
             layerCenter: center,
+            layerFractionalOffset: fractionalOffset,
             child: const SizedBox(key: childKey, width: 100, height: 50),
           ),
         ),
@@ -234,6 +236,10 @@ void main() {
       return transform.storage[0];
     }
 
+    AlignmentGeometry? scaleAlignment(WidgetTester tester) {
+      return tester.widget<Transform>(find.byType(Transform)).alignment;
+    }
+
     testWidgets('scales from scaleFrom up to 1', (tester) async {
       final notifier = await pumpVisibility(tester, layer);
 
@@ -245,6 +251,30 @@ void main() {
 
       await seek(tester, notifier, const Duration(seconds: 5));
       expect(find.byType(Transform), findsNothing);
+    });
+
+    testWidgets('anchors scale on the layer visual center, not the box '
+        'center', (tester) async {
+      // Default fractional offset (-0.5, -0.5) paints the layer's visual
+      // center at the box top-left, so scaling must anchor there. Otherwise a
+      // combined slide + scale drifts diagonally instead of entering straight.
+      final notifier = await pumpVisibility(tester, layer);
+      await seek(tester, notifier, Duration.zero);
+      expect(scaleAlignment(tester), Alignment.topLeft);
+    });
+
+    testWidgets('anchors scale on the box center for a centered offset', (
+      tester,
+    ) async {
+      // A fractional offset of (0, 0) leaves the visual center at the box
+      // center, so scaling anchors there.
+      final notifier = await pumpVisibility(
+        tester,
+        layer,
+        fractionalOffset: Offset.zero,
+      );
+      await seek(tester, notifier, Duration.zero);
+      expect(scaleAlignment(tester), Alignment.center);
     });
   });
 


### PR DESCRIPTION
## Problem

A layer whose video-timeline animation combines a **slide-in** (e.g. from the top) with a **scale-in** did not enter straight — it drifted in diagonally, appearing to come "from the top-right".

## Root cause

The scale was applied with `Transform.scale`'s default `alignment: Alignment.center`, which scales around the **layout-box center**. But the layer content is painted shifted by `_fractionalOffset` (default `(-0.5, -0.5)`), so the layer's *visual* center actually sits at the box's **top-left corner**. Scaling around the box center pulls the shrunk layer toward the center — down and to the right — decaying to zero as scale reaches 1. Combined with the slide-from-top, this reads as entering from the top-right instead of straight down.

This also meant the in-editor preview disagreed with the natively rendered export, which scales around the true center.

## Fix

Anchor the scale on the layer's visual center. With fractional offset `fo`, the visual center is at box fraction `(0.5+fo.dx, 0.5+fo.dy)`, i.e. `Transform.scale` alignment `Alignment(2·fo.dx, 2·fo.dy)` — `Alignment.topLeft` for the default `(-0.5,-0.5)`. The layer's fractional offset is plumbed into `LayerTimelineVisibility`.

With the anchor fixed, scaling introduces no horizontal (or vertical) drift, so a slide-from-top brings the layer straight down.

## Tests

Two regression tests added covering the scale anchor for the default `(-0.5,-0.5)` offset (→ `topLeft`) and a centered `(0,0)` offset (→ `center`). All 14 tests in the suite pass and `dart analyze` is clean.