### PR TITLE
feat: combine paint layers + flatten filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 13.2.0
+- **FEAT**(paint): Combine several selected paint layers into one via `mergeSelectedLayers()` / `canMergeSelectedLayers`. `PaintLayer` now holds multiple `items`, baking each source transform into a shared frame so the drawing looks identical after merging.
+
 ## 13.1.0
 - **CHORE**(android): Migrate the Android module to Flutter's built-in Kotlin (drop the manual Kotlin Gradle Plugin apply) so the plugin no longer triggers the KGP deprecation warning and stays AGP 9+ compatible. Now requires Flutter 3.44+.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 13.2.0
 - **FEAT**(paint): Combine several selected paint layers into one via `mergeSelectedLayers()` / `canMergeSelectedLayers`. `PaintLayer` now holds multiple `items`, baking each source transform into a shared frame so the drawing looks identical after merging.
+- **FEAT**(filter): Flatten the active filter stack into a single `FilterState` via `mergeFilters()` / `canMergeFilters` (appearance-identical; skipped for video-timeline filters).
 
 ## 13.1.0
 - **CHORE**(android): Migrate the Android module to Flutter's built-in Kotlin (drop the manual Kotlin Gradle Plugin apply) so the plugin no longer triggers the KGP deprecation warning and stays AGP 9+ compatible. Now requires Flutter 3.44+.

--- a/example/lib/features/layer/layer_grouping_example.dart
+++ b/example/lib/features/layer/layer_grouping_example.dart
@@ -188,6 +188,15 @@ class _LayerGroupingExampleState extends State<LayerGroupingExample>
               onPressed: editor.unselectAllLayers,
               child: const Text('Unselect All'),
             ),
+            FilledButton(
+              // Combine the selected paint layers into a single paint layer.
+              // Disabled unless at least two non-censor paint layers are
+              // selected.
+              onPressed: editor.canMergeSelectedLayers
+                  ? () => editor.mergeSelectedLayers()
+                  : null,
+              child: const Text('Combine Paint Layers'),
+            ),
           ],
         ),
       ),

--- a/lib/core/models/layers/paint_layer.dart
+++ b/lib/core/models/layers/paint_layer.dart
@@ -12,9 +12,11 @@ import 'layer_interaction.dart';
 /// A class representing a layer with custom paint content.
 ///
 /// PaintLayer is a subclass of [Layer] that allows you to display
-/// custom-painted content on a canvas. You can specify the painted item and
-/// its raw size, along with optional properties like offset, rotation,
-/// scale, and more.
+/// custom-painted content on a canvas. A single layer can hold one or more
+/// [PaintedModel] strokes (see [items]); a freshly drawn layer holds exactly
+/// one stroke while a layer produced by merging several paint layers holds
+/// several. You can specify the painted item(s) and their raw size, along with
+/// optional properties like offset, rotation, scale, and more.
 ///
 /// Example usage:
 /// ```dart
@@ -29,10 +31,13 @@ import 'layer_interaction.dart';
 class PaintLayer extends Layer {
   /// Creates an instance of PaintLayer.
   ///
-  /// The [item] and [rawSize] parameters are required, and other properties
-  /// are optional.
+  /// Provide either a single [item] (the common case, a single stroke) or a
+  /// list of [items] (a merged layer holding several strokes). Exactly one of
+  /// them must be supplied. [rawSize] and [opacity] are required, and the other
+  /// properties are optional.
   PaintLayer({
-    required this.item,
+    PaintedModel? item,
+    List<PaintedModel>? items,
     required this.rawSize,
     required this.opacity,
     super.offset,
@@ -54,7 +59,11 @@ class PaintLayer extends Layer {
     super.exitCurve,
     super.transitionBuilder,
     super.animations,
-  });
+  }) : assert(
+         item != null || (items != null && items.isNotEmpty),
+         'Provide either `item` or a non-empty `items` list.',
+       ),
+       items = items != null ? List<PaintedModel>.of(items) : [item!];
 
   /// Factory constructor for creating a PaintLayer instance from a
   /// Layer and a map.
@@ -64,6 +73,32 @@ class PaintLayer extends Layer {
     EditorKeyMinifier? minifier,
   }) {
     var keyConverter = minifier?.convertLayerKey ?? (String key) => key;
+    var paintKeyConverter = minifier?.convertPaintKey;
+
+    /// Reads the list of painted strokes.
+    ///
+    /// New payloads store every stroke in an `items` array. Legacy payloads
+    /// (and payloads written by older versions for a single stroke) only carry
+    /// a single `item` map, which is read as a one-element list.
+    final rawItems = map[keyConverter('items')];
+    final List<PaintedModel> items;
+    if (rawItems is List && rawItems.isNotEmpty) {
+      items = rawItems
+          .map(
+            (el) => PaintedModel.fromMap(
+              Map<String, dynamic>.from(el as Map),
+              keyConverter: paintKeyConverter,
+            ),
+          )
+          .toList();
+    } else {
+      items = [
+        PaintedModel.fromMap(
+          map[keyConverter('item')] ?? {},
+          keyConverter: paintKeyConverter,
+        ),
+      ];
+    }
 
     /// Constructs and returns a PaintLayer instance with properties
     /// derived from the layer and map.
@@ -87,16 +122,31 @@ class PaintLayer extends Layer {
         safeParseDouble(map[keyConverter('rawSize')]?['w'], fallback: 0),
         safeParseDouble(map[keyConverter('rawSize')]?['h'], fallback: 0),
       ),
-      item: PaintedModel.fromMap(
-        map[keyConverter('item')] ?? {},
-        keyConverter: minifier?.convertPaintKey,
-      ),
+      items: items,
       boxConstraints: layer.boxConstraints,
     );
   }
 
-  /// The custom-painted item to display on the layer.
-  PaintedModel item;
+  /// The custom-painted strokes to display on the layer.
+  ///
+  /// Always holds at least one entry. A layer drawn in the paint editor has a
+  /// single entry; a layer produced by [mergeSelectedLayers] holds every
+  /// baked-in stroke, each with its own color/mode/strokeWidth/opacity and
+  /// erased offsets.
+  List<PaintedModel> items;
+
+  /// The primary painted item.
+  ///
+  /// Back-compat accessor mapping to the first entry of [items]. Existing code
+  /// that constructs, reads or mutates a single `item` keeps working unchanged.
+  PaintedModel get item => items.first;
+  set item(PaintedModel value) {
+    if (items.isEmpty) {
+      items.add(value);
+    } else {
+      items[0] = value;
+    }
+  }
 
   /// The raw size of the painted item before applying scaling.
   final Size rawSize;
@@ -106,6 +156,21 @@ class PaintLayer extends Layer {
 
   /// Returns the size of the layer after applying the scaling factor.
   Size get size => Size(rawSize.width * scale, rawSize.height * scale);
+
+  /// Whether any stroke of this layer is currently marked as hit (hovered /
+  /// pressed).
+  bool get isHit => items.any((item) => item.hit);
+
+  /// Resets the hit state of every stroke.
+  void resetHit() {
+    for (final item in items) {
+      item.hit = false;
+    }
+  }
+
+  /// Whether this layer represents a censor area (blur / pixelate). A censor
+  /// layer always holds a single censor stroke.
+  bool get isCensor => items.any((item) => item.isCensorArea);
 
   @override
   bool get isPaintLayer => true;
@@ -120,10 +185,24 @@ class PaintLayer extends Layer {
         maxDecimalPlaces: maxDecimalPlaces,
         enableMinify: enableMinify,
       ),
-      'item': item.toMap(
+
+      /// The first stroke is always written under the legacy `item` key so
+      /// older readers keep rendering (at least) the first stroke.
+      'item': items.first.toMap(
         maxDecimalPlaces: maxDecimalPlaces,
         enableMinify: enableMinify,
       ),
+
+      /// Multi-stroke (merged) layers additionally serialize the full list.
+      if (items.length > 1)
+        'items': items
+            .map(
+              (item) => item.toMap(
+                maxDecimalPlaces: maxDecimalPlaces,
+                enableMinify: enableMinify,
+              ),
+            )
+            .toList(),
       'rawSize': {
         'w': rawSize.width.roundSmart(maxDecimalPlaces),
         'h': rawSize.height.roundSmart(maxDecimalPlaces),
@@ -140,17 +219,29 @@ class PaintLayer extends Layer {
     bool enableMinify = false,
   }) {
     var paintLayer = layer as PaintLayer;
+
+    final bool itemsChanged = !_listEquals(paintLayer.items, items);
+
     return {
       ...super.toMapFromReference(
         layer,
         maxDecimalPlaces: maxDecimalPlaces,
         enableMinify: enableMinify,
       ),
-      if (paintLayer.item != item)
-        'item': item.toMap(
+      if (itemsChanged)
+        'item': items.first.toMap(
           maxDecimalPlaces: maxDecimalPlaces,
           enableMinify: enableMinify,
         ),
+      if (itemsChanged && items.length > 1)
+        'items': items
+            .map(
+              (item) => item.toMap(
+                maxDecimalPlaces: maxDecimalPlaces,
+                enableMinify: enableMinify,
+              ),
+            )
+            .toList(),
       if (paintLayer.rawSize != rawSize)
         'rawSize': {
           'w': rawSize.width.roundSmart(maxDecimalPlaces),
@@ -160,11 +251,20 @@ class PaintLayer extends Layer {
     };
   }
 
+  bool _listEquals(List<PaintedModel> a, List<PaintedModel> b) {
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+
   /// Creates a copy of this [PaintLayer] with the given fields replaced with
   /// new values.
   @override
   PaintLayer copyWith({
     PaintedModel? item,
+    List<PaintedModel>? items,
     Size? rawSize,
     double? opacity,
     Offset? offset,
@@ -187,7 +287,7 @@ class PaintLayer extends Layer {
     List<LayerAnimation>? animations,
   }) {
     return PaintLayer(
-      item: item ?? this.item,
+      items: items ?? (item != null ? [item] : this.items),
       rawSize: rawSize ?? this.rawSize,
       opacity: opacity ?? this.opacity,
       offset: offset ?? this.offset,
@@ -217,7 +317,10 @@ class PaintLayer extends Layer {
     properties
       ..add(DoubleProperty('opacity', opacity))
       ..add(DiagnosticsProperty<Size>('rawSize', rawSize))
-      ..add(DiagnosticsProperty<Size>('size', size));
-    item.debugFillProperties(properties);
+      ..add(DiagnosticsProperty<Size>('size', size))
+      ..add(IntProperty('itemsCount', items.length));
+    for (final item in items) {
+      item.debugFillProperties(properties);
+    }
   }
 }

--- a/lib/features/filter_editor/utils/merge_filter_states.dart
+++ b/lib/features/filter_editor/utils/merge_filter_states.dart
@@ -29,6 +29,9 @@ bool canMergeFilterStates(List<FilterState> filters) {
 /// pure color matrices and the editor already renders them as one combined
 /// `ColorFilter.matrix`. Tune adjustments are intentionally excluded so they
 /// keep composing on top of the merged filter unchanged.
+///
+/// The metadata of every source filter is carried over into the merged state
+/// (later filters win on key conflicts) so host-attached data is not lost.
 FilterState mergeFilterStates(
   List<FilterState> filters, {
   String name = 'merged',
@@ -37,5 +40,9 @@ FilterState mergeFilterStates(
     filterList: filters.expand((filter) => filter.matrices).toList(),
     tuneAdjustmentList: const [],
   );
-  return FilterState(name: name, matrices: [combined]);
+  final mergedMeta = <String, dynamic>{};
+  for (final filter in filters) {
+    mergedMeta.addAll(filter.meta);
+  }
+  return FilterState(name: name, matrices: [combined], meta: mergedMeta);
 }

--- a/lib/features/filter_editor/utils/merge_filter_states.dart
+++ b/lib/features/filter_editor/utils/merge_filter_states.dart
@@ -1,0 +1,41 @@
+import '../types/filter_state.dart';
+import 'combine_color_matrix_utils.dart';
+
+/// Whether [filters] carries video-timeline scheduling metadata.
+///
+/// A flattened static color matrix cannot reproduce a filter that is only
+/// active during part of the timeline, so such filters are excluded from
+/// merging.
+bool _hasTimeline(FilterState filter) =>
+    filter.startTime != null ||
+    filter.endTime != null ||
+    filter.enterDuration != null ||
+    filter.exitDuration != null;
+
+/// Whether [filters] can be flattened into a single [FilterState] without
+/// changing the rendered result.
+///
+/// Requires at least two states and none carrying video-timeline metadata.
+bool canMergeFilterStates(List<FilterState> filters) {
+  if (filters.length < 2) return false;
+  return filters.every((filter) => !_hasTimeline(filter));
+}
+
+/// Flattens [filters] into a single [FilterState] whose one matrix is the exact
+/// composition of every source matrix, in the same order the renderer applies
+/// them (see [mergeColorMatrices]).
+///
+/// The result is appearance-identical to the original stack because filters are
+/// pure color matrices and the editor already renders them as one combined
+/// `ColorFilter.matrix`. Tune adjustments are intentionally excluded so they
+/// keep composing on top of the merged filter unchanged.
+FilterState mergeFilterStates(
+  List<FilterState> filters, {
+  String name = 'merged',
+}) {
+  final combined = mergeColorMatrices(
+    filterList: filters.expand((filter) => filter.matrices).toList(),
+    tuneAdjustmentList: const [],
+  );
+  return FilterState(name: name, matrices: [combined]);
+}

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -1050,8 +1050,7 @@ class ProImageEditorState extends State<ProImageEditor>
   /// True when at least two filters are active and none carry video-timeline
   /// scheduling metadata (which a static combined matrix cannot reproduce).
   /// Host apps can use this to enable/disable a "Combine filters" action.
-  bool get canMergeFilters =>
-      canMergeFilterStates(stateManager.activeFilters);
+  bool get canMergeFilters => canMergeFilterStates(stateManager.activeFilters);
 
   /// Flattens all active filters into a single [FilterState] and records it as
   /// a single history entry.

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -3099,7 +3099,11 @@ class ProImageEditorState extends State<ProImageEditor>
     // stroke stacking order is preserved inside the merged layer.
     final List<PaintLayer> sources = activeLayers
         .whereType<PaintLayer>()
-        .where((layer) => selectedIds.contains(layer.id) && !layer.isCensor)
+        .where(
+          (layer) =>
+              selectedIds.contains(layer.id) &&
+              PaintLayerMergeManager.isMergeable(layer),
+        )
         .toList();
 
     if (sources.length < 2) return null;

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -35,6 +35,7 @@ import '../audio_editor/models/audio_editor_response.dart';
 import '../audio_editor/widgets/audio_main_bottom_bar.dart';
 import '../clips_editor/models/video_clip_editor_response.dart';
 import '../clips_editor/pages/clips_editor_page.dart';
+import '../filter_editor/utils/merge_filter_states.dart';
 import '../filter_editor/widgets/filter_generator.dart';
 import '../paint_editor/models/paint_editor_response_model.dart';
 import '../paint_editor/widgets/paint_editor_layer_editor.dart';
@@ -1042,6 +1043,33 @@ class ProImageEditorState extends State<ProImageEditor>
   void clearFilters() {
     addHistory(filters: []);
     setState(() {});
+  }
+
+  /// Whether the active filters can be flattened into a single [FilterState].
+  ///
+  /// True when at least two filters are active and none carry video-timeline
+  /// scheduling metadata (which a static combined matrix cannot reproduce).
+  /// Host apps can use this to enable/disable a "Combine filters" action.
+  bool get canMergeFilters =>
+      canMergeFilterStates(stateManager.activeFilters);
+
+  /// Flattens all active filters into a single [FilterState] and records it as
+  /// a single history entry.
+  ///
+  /// Filters are pure color matrices that the editor already renders as one
+  /// combined `ColorFilter.matrix`, so the merged result is appearance-
+  /// identical to the original stack. Tune adjustments are left untouched and
+  /// keep composing on top unchanged. Returns the merged [FilterState], or
+  /// `null` when [canMergeFilters] is `false`.
+  FilterState? mergeFilters() {
+    final filters = stateManager.activeFilters;
+    if (!canMergeFilterStates(filters)) return null;
+
+    final merged = mergeFilterStates(filters);
+    addHistory(filters: [merged]);
+    setState(() {});
+
+    return merged;
   }
 
   /// Updates the timeline properties and/or metadata of the filter at the

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -46,6 +46,7 @@ import 'services/layer_copy_manager.dart';
 import 'services/layer_drag_selection_service.dart';
 import 'services/layer_interaction_manager.dart';
 import 'services/main_editor_state_history_service.dart';
+import 'services/paint_layer_merge_manager.dart';
 import 'services/sizes_manager.dart';
 import 'widgets/main_editor_interactive_content.dart';
 
@@ -1687,7 +1688,7 @@ class ProImageEditorState extends State<ProImageEditor>
   ///
   /// - [layer]: The existing [PaintLayer] to edit.
   void editPaintLayer(PaintLayer layer) async {
-    if (layer.isPaintLayer && layer.item.isCensorArea) return;
+    if (layer.isPaintLayer && layer.isCensor) return;
 
     PaintLayer? result =
         await (callbacks.paintEditorCallbacks?.onEditLayer?.call(layer) ??
@@ -3039,6 +3040,69 @@ class ProImageEditorState extends State<ProImageEditor>
   void unselectAllLayers() {
     layerInteractionManager.clearSelectedLayers();
     _controllers.uiLayerCtrl.add(null);
+  }
+
+  /// Whether the current selection can be combined into a single paint layer.
+  ///
+  /// Returns `true` when at least two of the selected layers are non-censor
+  /// [PaintLayer]s. Host apps can use this to enable/disable a "Combine"
+  /// action. See [mergeSelectedLayers].
+  bool get canMergeSelectedLayers =>
+      PaintLayerMergeManager.canMerge(selectedLayers);
+
+  /// Combines the currently selected non-censor paint layers into a single
+  /// [PaintLayer].
+  ///
+  /// Every selected [PaintLayer] that is not a censor area is baked (offset,
+  /// scale, rotation, flip and layer opacity) into one merged layer that keeps
+  /// each stroke's own color/mode/stroke width/opacity, so the drawing looks
+  /// identical before and after merging. The merged layer is inserted at the
+  /// z-index of the top-most source layer, the originals are removed, the new
+  /// layer is selected and the whole operation is recorded as a single
+  /// undo entry.
+  ///
+  /// Non-paint and censor layers in the selection are ignored. Returns the
+  /// merged [PaintLayer], or `null` when fewer than two mergeable layers are
+  /// selected.
+  PaintLayer? mergeSelectedLayers() {
+    final selectedIds = layerInteractionManager.selectedLayerIds;
+
+    // Collect the mergeable source layers in z-order (bottom-most first) so the
+    // stroke stacking order is preserved inside the merged layer.
+    final List<PaintLayer> sources = activeLayers
+        .whereType<PaintLayer>()
+        .where((layer) => selectedIds.contains(layer.id) && !layer.isCensor)
+        .toList();
+
+    if (sources.length < 2) return null;
+
+    final PaintLayer mergedLayer = PaintLayerMergeManager.merge(sources);
+
+    final Set<String> sourceIds = sources.map((layer) => layer.id).toSet();
+    final String topMostSourceId = sources.last.id;
+
+    // Rebuild the layer list: drop every source and drop the merged layer in at
+    // the position the top-most source occupied. All other layers are copied so
+    // the previous history entry keeps its own instances (clean undo).
+    final List<Layer> newLayers = [];
+    for (final layer in activeLayers) {
+      if (layer.id == topMostSourceId) {
+        newLayers.add(mergedLayer);
+      } else if (sourceIds.contains(layer.id)) {
+        // Skip the remaining source layers.
+        continue;
+      } else {
+        newLayers.add(_layerCopyManager.copyLayer(layer));
+      }
+    }
+
+    layerInteractionManager.clearSelectedLayers();
+    addHistory(layers: newLayers);
+    layerInteractionManager.addSelectedLayer(mergedLayer.id);
+    _controllers.uiLayerCtrl.add(null);
+    setState(() {});
+
+    return mergedLayer;
   }
 
   @override

--- a/lib/features/main_editor/services/layer_copy_manager.dart
+++ b/lib/features/main_editor/services/layer_copy_manager.dart
@@ -223,7 +223,7 @@ class LayerCopyManager {
       flipX: layer.flipX,
       flipY: layer.flipY,
       meta: layer.meta,
-      item: layer.item.copy(),
+      items: layer.items.map((item) => item.copy()).toList(),
       rawSize: layer.rawSize,
       opacity: layer.opacity,
       interaction: layer.interaction.copyWith(),

--- a/lib/features/main_editor/services/layer_interaction_manager.dart
+++ b/lib/features/main_editor/services/layer_interaction_manager.dart
@@ -362,7 +362,7 @@ class LayerInteractionManager {
     } else if (originalLayer is PaintLayer) {
       return PaintLayer(
         id: originalLayer.id,
-        item: originalLayer.item,
+        items: [...originalLayer.items],
         rawSize: originalLayer.rawSize,
         opacity: originalLayer.opacity,
         key: originalLayer.key,

--- a/lib/features/main_editor/services/main_editor_layers_service.dart
+++ b/lib/features/main_editor/services/main_editor_layers_service.dart
@@ -313,6 +313,24 @@ class MainEditorLayersService {
     }
   }
 
+  /// Whether the current selection can be merged into a single paint layer.
+  bool get canMergeSelectedLayers => state.canMergeSelectedLayers;
+
+  /// Merges the currently selected non-censor paint layers into a single
+  /// [PaintLayer] and refreshes the UI.
+  ///
+  /// The heavy lifting (geometry baking + history) lives in
+  /// [ProImageEditorState.mergeSelectedLayers]; this wrapper triggers the
+  /// editor UI updates, mirroring [handleGroupLayers].
+  void handleMergeLayers() {
+    final mergedLayer = state.mergeSelectedLayers();
+
+    if (mergedLayer != null) {
+      callbacks.mainEditorCallbacks?.handleUpdateUI();
+      onUpdateState();
+    }
+  }
+
   /// Handles ungrouping of the specified layer.
   void handleUngroupLayers(Layer layer) {
     final wasUngrouped = layerInteraction.ungroupLayer(layer, _activeLayers, (
@@ -331,7 +349,7 @@ class MainEditorLayersService {
   /// Handles mouse hover events to change the cursor style
   void handleMouseHover(PointerHoverEvent event) {
     final bool hasHit = _activeLayers.any(
-      (element) => element is PaintLayer && element.item.hit,
+      (element) => element is PaintLayer && element.isHit,
     );
 
     final activeCursor = mouseCursorsKey.currentState!.currentCursor;

--- a/lib/features/main_editor/services/paint_layer_merge_manager.dart
+++ b/lib/features/main_editor/services/paint_layer_merge_manager.dart
@@ -16,16 +16,27 @@ import '/features/paint_editor/models/painted_model.dart';
 class PaintLayerMergeManager {
   const PaintLayerMergeManager._();
 
-  /// Returns the mergeable (non-censor) paint layers contained in [layers],
-  /// preserving their original order (bottom-most first).
-  static List<PaintLayer> mergeableLayers(Iterable<Layer> layers) {
-    return layers
-        .whereType<PaintLayer>()
-        .where((layer) => !layer.isCensor)
-        .toList();
+  /// Whether [layer] can take part in a merge.
+  ///
+  /// A censor layer is excluded because its blur/pixelate effect cannot be
+  /// baked into a shared frame. A layer that carries video-timeline scheduling
+  /// ([Layer.startTime] / [Layer.endTime]) or [Layer.animations] is excluded
+  /// too, because a single static merged layer cannot reproduce a per-source
+  /// appearance that changes over the timeline.
+  static bool isMergeable(PaintLayer layer) {
+    return !layer.isCensor &&
+        layer.startTime == null &&
+        layer.endTime == null &&
+        layer.animations.isEmpty;
   }
 
-  /// Whether [layers] contains at least two non-censor paint layers that can be
+  /// Returns the mergeable paint layers contained in [layers], preserving their
+  /// original order (bottom-most first). See [isMergeable] for the criteria.
+  static List<PaintLayer> mergeableLayers(Iterable<Layer> layers) {
+    return layers.whereType<PaintLayer>().where(isMergeable).toList();
+  }
+
+  /// Whether [layers] contains at least two mergeable paint layers that can be
   /// merged into one.
   static bool canMerge(Iterable<Layer> layers) {
     return mergeableLayers(layers).length >= 2;
@@ -42,6 +53,20 @@ class PaintLayerMergeManager {
   /// given an identity transform. Per-stroke color, mode, fill and the baked
   /// stroke width / opacity / erased offsets are preserved so the appearance is
   /// unchanged.
+  ///
+  /// The merged layer inherits `groupId`, `interaction` and `meta` from the
+  /// top-most source (the last entry of [layers]), matching the z-index it is
+  /// re-inserted at.
+  ///
+  /// The geometry assumes every source uses the default center layer alignment
+  /// (`paintEditor.layerFractionalOffset == Offset(-0.5, -0.5)`), i.e. that a
+  /// layer's `offset` marks its visual center.
+  ///
+  /// Appearance is preserved for the merged strokes themselves, but stacking
+  /// order relative to *other, non-merged* layers is not: because the merged
+  /// layer occupies a single z-index (the top-most source's), any unselected
+  /// layer that previously sat between two sources ends up entirely below the
+  /// merged result.
   static PaintLayer merge(List<PaintLayer> layers) {
     assert(
       layers.length >= 2,
@@ -113,9 +138,14 @@ class PaintLayerMergeManager {
             // Bake the source scale into the stroke width so it renders the
             // same on the identity-scaled merged layer.
             strokeWidth: item.strokeWidth * layer.scale,
-            // A single-stroke source layer renders with the layer opacity, so
-            // that is the opacity the merged stroke must carry.
-            opacity: layer.opacity,
+            // Effective on-screen opacity of this stroke. A single-stroke
+            // source renders with the layer opacity only (the per-item opacity
+            // is ignored on the single-item render fast path); an already
+            // merged multi-stroke source renders each stroke with its own
+            // opacity beneath the layer opacity. Bake the product so the merged
+            // layer, which renders every stroke with its own opacity, matches.
+            opacity:
+                layer.opacity * (layer.items.length > 1 ? item.opacity : 1.0),
           ),
         );
       }
@@ -148,6 +178,10 @@ class PaintLayerMergeManager {
       );
     }).toList();
 
+    // The merged layer takes the top-most source's z-index, so it inherits
+    // that source's grouping, interaction and metadata.
+    final PaintLayer topMost = layers.last;
+
     return PaintLayer(
       items: mergedItems,
       rawSize: rect.size,
@@ -157,6 +191,11 @@ class PaintLayerMergeManager {
       rotation: 0.0,
       flipX: false,
       flipY: false,
+      groupId: topMost.groupId,
+      interaction: topMost.interaction.copyWith(),
+      meta: topMost.meta == null
+          ? null
+          : Map<String, dynamic>.of(topMost.meta!),
     );
   }
 }

--- a/lib/features/main_editor/services/paint_layer_merge_manager.dart
+++ b/lib/features/main_editor/services/paint_layer_merge_manager.dart
@@ -166,10 +166,7 @@ class PaintLayerMergeManager {
             .toList(),
         erasedOffsets: stroke.erasedOffsets
             .map(
-              (e) => ErasedOffset(
-                offset: e.offset - topLeft,
-                radius: e.radius,
-              ),
+              (e) => ErasedOffset(offset: e.offset - topLeft, radius: e.radius),
             )
             .toList(),
         strokeWidth: stroke.strokeWidth,

--- a/lib/features/main_editor/services/paint_layer_merge_manager.dart
+++ b/lib/features/main_editor/services/paint_layer_merge_manager.dart
@@ -1,0 +1,180 @@
+import 'dart:math';
+
+import 'package:flutter/widgets.dart';
+
+import '/core/models/layers/layer.dart';
+import '/features/paint_editor/models/eraser_model.dart';
+import '/features/paint_editor/models/painted_model.dart';
+
+/// Pure geometry helpers for merging several [PaintLayer]s into one.
+///
+/// The merge bakes every source layer's transform (offset, scale, rotation,
+/// flipX/flipY and layer opacity) into a shared coordinate frame so the result
+/// is a single [PaintLayer] with an identity transform (`scale = 1`,
+/// `rotation = 0`, no flip, `opacity = 1`) whose strokes render pixel-identical
+/// to the originals.
+class PaintLayerMergeManager {
+  const PaintLayerMergeManager._();
+
+  /// Returns the mergeable (non-censor) paint layers contained in [layers],
+  /// preserving their original order (bottom-most first).
+  static List<PaintLayer> mergeableLayers(Iterable<Layer> layers) {
+    return layers
+        .whereType<PaintLayer>()
+        .where((layer) => !layer.isCensor)
+        .toList();
+  }
+
+  /// Whether [layers] contains at least two non-censor paint layers that can be
+  /// merged into one.
+  static bool canMerge(Iterable<Layer> layers) {
+    return mergeableLayers(layers).length >= 2;
+  }
+
+  /// Merges [layers] (given in z-order, bottom-most first) into a single
+  /// [PaintLayer].
+  ///
+  /// Each source stroke is mapped from its layer-local space through the
+  /// layer's scale, rotation, flip and world center into a shared world frame
+  /// (relative to the editor body center). The union bounding rect of all
+  /// transformed strokes becomes the merged [PaintLayer.rawSize]; every point
+  /// is re-normalized relative to that rect's top-left and the merged layer is
+  /// given an identity transform. Per-stroke color, mode, fill and the baked
+  /// stroke width / opacity / erased offsets are preserved so the appearance is
+  /// unchanged.
+  static PaintLayer merge(List<PaintLayer> layers) {
+    assert(
+      layers.length >= 2,
+      'merge requires at least two layers, got ${layers.length}.',
+    );
+
+    final List<_TransformedStroke> strokes = [];
+
+    double minX = double.infinity;
+    double minY = double.infinity;
+    double maxX = double.negativeInfinity;
+    double maxY = double.negativeInfinity;
+
+    for (final layer in layers) {
+      final Offset center = Offset(
+        layer.rawSize.width / 2,
+        layer.rawSize.height / 2,
+      );
+      final double cosR = cos(layer.rotation);
+      final double sinR = sin(layer.rotation);
+      final double fx = layer.flipX ? -1.0 : 1.0;
+      final double fy = layer.flipY ? -1.0 : 1.0;
+
+      // Maps a layer-local point (top-left based, unscaled) into the shared
+      // world frame relative to the editor body center. Mirrors the render
+      // transform `Rx(flipY)·Ry(flipX)·Rz(rotation)` applied around the layer
+      // center with the layer scale baked into the CustomPaint.
+      Offset transform(Offset point) {
+        final Offset c = (point - center) * layer.scale;
+        final double rx = c.dx * cosR - c.dy * sinR;
+        final double ry = c.dx * sinR + c.dy * cosR;
+        return layer.offset + Offset(fx * rx, fy * ry);
+      }
+
+      for (final item in layer.items) {
+        final List<Offset?> worldOffsets = item.offsets
+            .map((o) => o == null ? null : transform(o))
+            .toList();
+
+        final List<ErasedOffset> worldErased = item.erasedOffsets
+            .map(
+              (e) => ErasedOffset(
+                offset: transform(e.offset),
+                radius: e.radius * layer.scale,
+              ),
+            )
+            .toList();
+
+        // Stroked shapes bleed half their stroke width past their points;
+        // filled shapes and censor areas do not. Padding the bounds keeps the
+        // stroke from being clipped by the merged raw size.
+        final double halfStroke = item.shouldFill
+            ? 0
+            : item.strokeWidth * layer.scale / 2;
+
+        for (final o in worldOffsets) {
+          if (o == null) continue;
+          minX = min(minX, o.dx - halfStroke);
+          minY = min(minY, o.dy - halfStroke);
+          maxX = max(maxX, o.dx + halfStroke);
+          maxY = max(maxY, o.dy + halfStroke);
+        }
+
+        strokes.add(
+          _TransformedStroke(
+            source: item,
+            offsets: worldOffsets,
+            erasedOffsets: worldErased,
+            // Bake the source scale into the stroke width so it renders the
+            // same on the identity-scaled merged layer.
+            strokeWidth: item.strokeWidth * layer.scale,
+            // A single-stroke source layer renders with the layer opacity, so
+            // that is the opacity the merged stroke must carry.
+            opacity: layer.opacity,
+          ),
+        );
+      }
+    }
+
+    // Guard against degenerate input (e.g. strokes without any offsets).
+    if (minX > maxX || minY > maxY) {
+      minX = minY = maxX = maxY = 0;
+    }
+
+    final Rect rect = Rect.fromLTRB(minX, minY, maxX, maxY);
+    final Offset topLeft = rect.topLeft;
+
+    final List<PaintedModel> mergedItems = strokes.map((stroke) {
+      return stroke.source.copyWith(
+        offsets: stroke.offsets
+            .map((o) => o == null ? null : o - topLeft)
+            .toList(),
+        erasedOffsets: stroke.erasedOffsets
+            .map(
+              (e) => ErasedOffset(
+                offset: e.offset - topLeft,
+                radius: e.radius,
+              ),
+            )
+            .toList(),
+        strokeWidth: stroke.strokeWidth,
+        opacity: stroke.opacity,
+        hit: false,
+      );
+    }).toList();
+
+    return PaintLayer(
+      items: mergedItems,
+      rawSize: rect.size,
+      opacity: 1.0,
+      offset: rect.center,
+      scale: 1.0,
+      rotation: 0.0,
+      flipX: false,
+      flipY: false,
+    );
+  }
+}
+
+/// A source stroke already mapped into the shared world frame, kept until the
+/// merged bounding rect is known so its points can be normalized in one pass.
+class _TransformedStroke {
+  _TransformedStroke({
+    required this.source,
+    required this.offsets,
+    required this.erasedOffsets,
+    required this.strokeWidth,
+    required this.opacity,
+  });
+
+  final PaintedModel source;
+  final List<Offset?> offsets;
+  final List<ErasedOffset> erasedOffsets;
+  final double strokeWidth;
+  final double opacity;
+}

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -28,6 +28,7 @@ import '/shared/widgets/slider_bottom_sheet.dart';
 import '/shared/widgets/transform/transformed_content_generator.dart';
 import '../main_editor/services/layer_copy_manager.dart';
 import 'controllers/paint_controller.dart';
+import 'models/eraser_model.dart';
 import 'models/paint_editor_response_model.dart';
 import 'models/paint_mode_helper_model.dart';
 import 'services/paint_desktop_interaction_manager.dart';
@@ -672,11 +673,17 @@ class PaintEditorState extends State<PaintEditor>
         if (!canUndo) return Navigator.pop(context);
         final scale = _layerStackTransformHelper.scale;
 
-        // Build a map for O(1) lookup instead of O(N) indexWhere
-        final originalErasedMap = <String, List<dynamic>>{};
+        // Build a map for O(1) lookup instead of O(N) indexWhere. Collect the
+        // erased offsets of every stroke so a merged (multi-stroke) layer is
+        // compared across all its items, not just the first.
+        List<ErasedOffset> allErased(PaintLayer layer) => [
+          for (final item in layer.items) ...item.erasedOffsets,
+        ];
+
+        final originalErasedMap = <String, List<ErasedOffset>>{};
         for (final layer
             in (widget.initConfigs.layers ?? []).whereType<PaintLayer>()) {
-          originalErasedMap[layer.id] = layer.item.erasedOffsets;
+          originalErasedMap[layer.id] = allErased(layer);
         }
 
         final newLayers = activeHistory.layers.whereType<PaintLayer>().where((
@@ -684,7 +691,7 @@ class PaintEditorState extends State<PaintEditor>
         ) {
           final originalErased = originalErasedMap[layer.id];
           if (originalErased == null) return true;
-          return !listEquals(originalErased, layer.item.erasedOffsets);
+          return !listEquals(originalErased, allErased(layer));
         });
 
         final transformedLayers = newLayers.map((layer) {

--- a/lib/features/paint_editor/widgets/paint_canvas.dart
+++ b/lib/features/paint_editor/widgets/paint_canvas.dart
@@ -363,24 +363,29 @@ class PaintCanvasState extends State<PaintCanvas> {
           -rotation,
         );
 
-        layer.item.erasedOffsets
-          ..add(
-            ErasedOffset(
-              offset: rotatedPosition / layerScale,
-              radius: widget.eraserRadius,
-            ),
-          )
-          ..toSet()
-          ..toList();
-        layer.item = layer.item.copy();
+        final erased = ErasedOffset(
+          offset: rotatedPosition / layerScale,
+          radius: widget.eraserRadius,
+        );
+
+        // Erase across every stroke of the layer, not just the first. A merged
+        // layer holds several strokes in this same coordinate space, all of
+        // which must be erased at the touched point.
+        for (var i = 0; i < paintLayer.items.length; i++) {
+          paintLayer.items[i].erasedOffsets.add(erased);
+          paintLayer.items[i] = paintLayer.items[i].copy();
+        }
         _hasPartialErasedAreas = true;
       } else {
-        bool hasHit = _hitTestManager.hitTest(
-          item: paintLayer.item,
-          position: position,
-          scaleFactor: stackScale * layerScale,
-          isRoundCensorArea: useRoundCensor,
-          paintEditorConfigs: widget.paintEditorConfigs,
+        // A full-stroke eraser removes the layer if it hits any of its strokes.
+        final bool hasHit = paintLayer.items.any(
+          (item) => _hitTestManager.hitTest(
+            item: item,
+            position: position,
+            scaleFactor: stackScale * layerScale,
+            isRoundCensorArea: useRoundCensor,
+            paintEditorConfigs: widget.paintEditorConfigs,
+          ),
         );
         if (hasHit) {
           removeIds.add(layer.id);

--- a/lib/features/paint_editor/widgets/paint_editor_layer_editor.dart
+++ b/lib/features/paint_editor/widgets/paint_editor_layer_editor.dart
@@ -35,8 +35,7 @@ class _PaintEditorLayerEditorState extends State<PaintEditorLayerEditor> {
   late final _style = _configs.paintEditor.style;
 
   void _setFillState(bool enableFill) {
-    _layer.item = _paintItem.copyWith(fill: enableFill);
-    setState(() {});
+    _applyToItems((item) => item.copyWith(fill: enableFill));
   }
 
   void _setOpacity(double value) {
@@ -45,12 +44,20 @@ class _PaintEditorLayerEditorState extends State<PaintEditorLayerEditor> {
   }
 
   void _setStrokeWidth(double value) {
-    _layer.item = _paintItem.copyWith(strokeWidth: value);
-    setState(() {});
+    _applyToItems((item) => item.copyWith(strokeWidth: value));
   }
 
   void _setColor(Color color) {
-    _layer.item = _paintItem.copyWith(color: color);
+    _applyToItems((item) => item.copyWith(color: color));
+  }
+
+  /// Applies [update] to every stroke of the layer.
+  ///
+  /// A freshly drawn layer holds a single stroke; a merged layer holds several,
+  /// all of which must change together so the edit affects the whole drawing
+  /// rather than only its first stroke.
+  void _applyToItems(PaintedModel Function(PaintedModel item) update) {
+    _layer.items = _layer.items.map(update).toList();
     setState(() {});
   }
 

--- a/lib/shared/services/import_export/constants/minified_keys.dart
+++ b/lib/shared/services/import_export/constants/minified_keys.dart
@@ -37,6 +37,7 @@ const Map<String, String> kMinifiedLayerKeys = {
   'emoji': 'e',
   'text': 'te',
   'item': 'i',
+  'items': 'it',
   'rawSize': 'rs',
   'opacity': 'o',
   'exportConfigs': 'ec',

--- a/lib/shared/services/import_export/utils/key_minifier.dart
+++ b/lib/shared/services/import_export/utils/key_minifier.dart
@@ -127,6 +127,17 @@ class EditorKeyMinifier {
             );
           }
 
+          if (entry.key == 'items') {
+            value = (entry.value as List)
+                .map(
+                  (el) => Map.from(el as Map).map(
+                    (itemKey, itemValue) =>
+                        MapEntry(convertPaintKey(itemKey), itemValue),
+                  ),
+                )
+                .toList();
+          }
+
           return MapEntry(newKey, value);
         }),
       );
@@ -159,6 +170,17 @@ class EditorKeyMinifier {
               (itemKey, itemValue) =>
                   MapEntry(convertPaintKey(itemKey), itemValue),
             );
+          }
+
+          if (entryKey == 'items') {
+            entryValue = (entryValue as List)
+                .map(
+                  (el) => Map.from(el as Map).map(
+                    (itemKey, itemValue) =>
+                        MapEntry(convertPaintKey(itemKey), itemValue),
+                  ),
+                )
+                .toList();
           }
 
           return MapEntry(convertLayerKey(entryKey), entryValue);

--- a/lib/shared/widgets/layer/layer_widget.dart
+++ b/lib/shared/widgets/layer/layer_widget.dart
@@ -279,7 +279,7 @@ class _LayerWidgetState extends State<LayerWidget>
 
   /// Checks if the hit is outside the canvas for certain types of layers.
   bool _isHitOutsideInCanvas() {
-    return _layer.isPaintLayer && !(_layer as PaintLayer).item.hit;
+    return _layer.isPaintLayer && !(_layer as PaintLayer).isHit;
   }
 
   /// Checks if the hit is outside the canvas for certain types of layers.
@@ -307,7 +307,7 @@ class _LayerWidgetState extends State<LayerWidget>
 
   void _onHoverLeave() {
     if (_layer.isPaintLayer) {
-      (_layer as PaintLayer).item.hit = false;
+      (_layer as PaintLayer).resetHit();
     } else if (_layer.isTextLayer) {
       (_layer as TextLayer).hit = false;
     }

--- a/lib/shared/widgets/layer/widgets/layer_widget_paint_item.dart
+++ b/lib/shared/widgets/layer/widgets/layer_widget_paint_item.dart
@@ -44,12 +44,39 @@ class LayerWidgetPaintItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final child = CustomPaint(
+    final items = layer.items;
+
+    late final Widget child;
+    if (items.length == 1) {
+      // Fast path for the common single-stroke layer: keep the exact previous
+      // behavior where the layer opacity is applied once around the stroke.
+      child = _buildItem(items.first);
+    } else {
+      // Merged layer: stack every baked-in stroke, each with its own opacity.
+      child = Stack(
+        children: [
+          for (final item in items) _buildItem(item, applyItemOpacity: true),
+        ],
+      );
+    }
+
+    if (layer.opacity >= 1.0) return child;
+
+    return Opacity(opacity: layer.opacity, child: child);
+  }
+
+  /// Builds a single stroke painter sized to the layer.
+  ///
+  /// When [applyItemOpacity] is `true` (merged multi-stroke layers) the
+  /// per-stroke opacity is applied here, because the layer-level opacity is
+  /// `1.0` for merged layers and each stroke keeps its own opacity.
+  Widget _buildItem(PaintedModel item, {bool applyItemOpacity = false}) {
+    Widget painter = CustomPaint(
       size: layer.size,
       willChange: willChange,
-      isComplex: layer.item.mode.isFreeStyleMode,
+      isComplex: item.mode.isFreeStyleMode,
       painter: DrawPaintItem(
-        item: layer.item,
+        item: item,
         scale: layer.scale,
         selected: isSelected,
         enabledHitDetection: enableHitDetection,
@@ -58,9 +85,11 @@ class LayerWidgetPaintItem extends StatelessWidget {
       ),
     );
 
-    if (layer.opacity >= 1.0) return child;
+    if (applyItemOpacity && item.opacity < 1.0) {
+      painter = Opacity(opacity: item.opacity, child: painter);
+    }
 
-    return Opacity(opacity: layer.opacity, child: child);
+    return painter;
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 13.1.0
+version: 13.2.0
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/core/models/layers/paint_layer_test.dart
+++ b/test/core/models/layers/paint_layer_test.dart
@@ -190,7 +190,10 @@ void main() {
 
     test('multi-item round-trip keeps all N items when minified', () {
       final layer = PaintLayer(
-        items: [model(color: Colors.red), model(color: Colors.green)],
+        items: [
+          model(color: Colors.red),
+          model(color: Colors.green),
+        ],
         rawSize: const Size(40, 30),
         opacity: 1,
       );

--- a/test/core/models/layers/paint_layer_test.dart
+++ b/test/core/models/layers/paint_layer_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_image_editor/shared/services/import_export/utils/key_minifier.dart';
 
 void main() {
   group('PaintLayer', () {
@@ -76,6 +77,134 @@ void main() {
       expect(paintLayer.rawSize, const Size(100, 50));
       expect(paintLayer.opacity, 0.8);
       expect(paintLayer.item, isA<PaintedModel>());
+    });
+
+    test('legacy single-item map deserializes to a one-item layer', () {
+      final layer = Layer(id: '123');
+      final Map<String, dynamic> map = {
+        'type': 'paint',
+        'item': {
+          'mode': 'arrow',
+          'offsets': [
+            {'x': 5.0, 'y': 68},
+            {'x': 70, 'y': 5.0},
+          ],
+          'erasedOffsets': [],
+          'color': 4294901760,
+          'strokeWidth': 10.0,
+          'opacity': 1.0,
+          'fill': false,
+        },
+        'rawSize': {'w': 100, 'h': 50},
+        'opacity': 0.8,
+      };
+
+      final paintLayer = PaintLayer.fromMap(layer, map);
+
+      expect(paintLayer.items.length, 1);
+      expect(paintLayer.item, same(paintLayer.items.first));
+      expect(paintLayer.item.mode, PaintMode.arrow);
+    });
+  });
+
+  group('PaintLayer multi-item (merged)', () {
+    PaintedModel model({
+      PaintMode mode = PaintMode.freeStyle,
+      Color color = Colors.blue,
+      double opacity = 1,
+    }) {
+      return PaintedModel(
+        mode: mode,
+        offsets: const [Offset(0, 0), Offset(10, 20)],
+        erasedOffsets: const [],
+        color: color,
+        strokeWidth: 3,
+        opacity: opacity,
+      );
+    }
+
+    test('item getter/setter maps to items.first (back-compat)', () {
+      final a = model(color: Colors.red);
+      final b = model(color: Colors.green);
+      final layer = PaintLayer(
+        items: [a, b],
+        rawSize: const Size(20, 20),
+        opacity: 1,
+      );
+
+      expect(layer.item, same(a));
+      expect(layer.items.length, 2);
+
+      final replacement = model(color: Colors.orange);
+      layer.item = replacement;
+      expect(layer.items.first, same(replacement));
+      expect(layer.items[1], same(b));
+    });
+
+    test('single-item toMap stays legacy (no items array)', () {
+      final layer = PaintLayer(
+        item: model(),
+        rawSize: const Size(20, 20),
+        opacity: 1,
+      );
+      final map = layer.toMap();
+      expect(map['item'], isNotNull);
+      expect(map.containsKey('items'), isFalse);
+    });
+
+    test('multi-item toMap serializes items array + legacy first item', () {
+      final layer = PaintLayer(
+        items: [
+          model(color: Colors.red),
+          model(color: Colors.green),
+          model(color: Colors.blue),
+        ],
+        rawSize: const Size(20, 20),
+        opacity: 1,
+      );
+      final map = layer.toMap();
+      expect(map['item'], isNotNull, reason: 'legacy first item retained');
+      expect((map['items'] as List).length, 3);
+    });
+
+    test('multi-item round-trip keeps all N items', () {
+      final layer = PaintLayer(
+        items: [
+          model(mode: PaintMode.freeStyle, color: Colors.red),
+          model(mode: PaintMode.line, color: Colors.green),
+          model(mode: PaintMode.rect, color: Colors.blue),
+        ],
+        rawSize: const Size(40, 30),
+        opacity: 1,
+      );
+
+      final restored = Layer.fromMap(layer.toMap()) as PaintLayer;
+
+      expect(restored.items.length, 3);
+      expect(restored.items[0].mode, PaintMode.freeStyle);
+      expect(restored.items[1].mode, PaintMode.line);
+      expect(restored.items[2].mode, PaintMode.rect);
+      expect(restored.items[0].color.toARGB32(), Colors.red.toARGB32());
+      expect(restored.items[2].color.toARGB32(), Colors.blue.toARGB32());
+    });
+
+    test('multi-item round-trip keeps all N items when minified', () {
+      final layer = PaintLayer(
+        items: [model(color: Colors.red), model(color: Colors.green)],
+        rawSize: const Size(40, 30),
+        opacity: 1,
+      );
+
+      final minifier = EditorKeyMinifier(enableMinify: true);
+      final map = layer.toMap(enableMinify: true);
+      final minified = minifier.convertListOfLayerKeys([map]).first;
+
+      // Keys are minified (`items` -> `it`).
+      expect(minified.containsKey('it'), isTrue);
+
+      final restored =
+          Layer.fromMap(minified, minifier: minifier) as PaintLayer;
+      expect(restored.items.length, 2);
     });
   });
 }

--- a/test/features/filter_editor/merge_filter_states_test.dart
+++ b/test/features/filter_editor/merge_filter_states_test.dart
@@ -72,6 +72,24 @@ void main() {
       );
       _expectMatrixClose(merged.matrices.first, full);
     });
+
+    test('carries over the metadata of every source filter', () {
+      final f1 = FilterState(
+        name: 'a',
+        matrices: [_matrixDarken],
+        meta: const {'from': 'a', 'shared': 1},
+      );
+      final f2 = FilterState(
+        name: 'b',
+        matrices: [_matrixOffset],
+        meta: const {'from': 'b', 'shared': 2},
+      );
+
+      final merged = mergeFilterStates([f1, f2]);
+
+      // All keys preserved; later filters win on conflicts.
+      expect(merged.meta, {'from': 'b', 'shared': 2});
+    });
   });
 
   group('canMergeFilterStates gating', () {

--- a/test/features/filter_editor/merge_filter_states_test.dart
+++ b/test/features/filter_editor/merge_filter_states_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_image_editor/features/filter_editor/types/filter_state.dart';
+import 'package:pro_image_editor/features/filter_editor/utils/combine_color_matrix_utils.dart';
+import 'package:pro_image_editor/features/filter_editor/utils/merge_filter_states.dart';
+
+// A darken matrix (scale RGB by 0.8).
+const _matrixDarken = <double>[
+  0.8, 0, 0, 0, 0, //
+  0, 0.8, 0, 0, 0, //
+  0, 0, 0.8, 0, 0, //
+  0, 0, 0, 1, 0, //
+];
+
+// A brightness-offset matrix (+10 on RGB).
+const _matrixOffset = <double>[
+  1, 0, 0, 0, 10, //
+  0, 1, 0, 0, 10, //
+  0, 0, 1, 0, 10, //
+  0, 0, 0, 1, 0, //
+];
+
+// A contrast-ish tune matrix.
+const _matrixTune = <double>[
+  1.2, 0, 0, 0, -25, //
+  0, 1.2, 0, 0, -25, //
+  0, 0, 1.2, 0, -25, //
+  0, 0, 0, 1, 0, //
+];
+
+void _expectMatrixClose(List<double> a, List<double> b) {
+  expect(a.length, b.length);
+  for (var i = 0; i < a.length; i++) {
+    expect(a[i], closeTo(b[i], 1e-9), reason: 'index $i');
+  }
+}
+
+void main() {
+  group('mergeFilterStates', () {
+    test('flattens to a single state whose matrix composes all sources', () {
+      final f1 = FilterState(name: 'a', matrices: [_matrixDarken]);
+      final f2 = FilterState(name: 'b', matrices: [_matrixOffset]);
+
+      final merged = mergeFilterStates([f1, f2]);
+      expect(merged.matrices.length, 1);
+
+      // Rendering the merged filter (with tune on top) is byte-identical to
+      // rendering the original stack.
+      final full = mergeColorMatrices(
+        filterList: [_matrixDarken, _matrixOffset],
+        tuneAdjustmentList: [_matrixTune],
+      );
+      final afterMerge = mergeColorMatrices(
+        filterList: merged.matrices,
+        tuneAdjustmentList: [_matrixTune],
+      );
+      _expectMatrixClose(afterMerge, full);
+    });
+
+    test('handles states that already carry multiple matrices', () {
+      final f1 = FilterState(
+        name: 'a',
+        matrices: [_matrixDarken, _matrixOffset],
+      );
+      final f2 = FilterState(name: 'b', matrices: [_matrixOffset]);
+
+      final merged = mergeFilterStates([f1, f2]);
+      expect(merged.matrices.length, 1);
+
+      final full = mergeColorMatrices(
+        filterList: [_matrixDarken, _matrixOffset, _matrixOffset],
+        tuneAdjustmentList: const [],
+      );
+      _expectMatrixClose(merged.matrices.first, full);
+    });
+  });
+
+  group('canMergeFilterStates gating', () {
+    test('true for two or more timeline-free filters', () {
+      expect(
+        canMergeFilterStates([
+          FilterState(name: 'a', matrices: [_matrixDarken]),
+          FilterState(name: 'b', matrices: [_matrixOffset]),
+        ]),
+        isTrue,
+      );
+    });
+
+    test('false for fewer than two', () {
+      expect(
+        canMergeFilterStates([
+          FilterState(name: 'a', matrices: [_matrixDarken]),
+        ]),
+        isFalse,
+      );
+      expect(canMergeFilterStates([]), isFalse);
+    });
+
+    test('false when any filter carries video-timeline metadata', () {
+      expect(
+        canMergeFilterStates([
+          FilterState(name: 'a', matrices: [_matrixDarken]),
+          FilterState(
+            name: 'b',
+            matrices: [_matrixOffset],
+            startTime: const Duration(seconds: 1),
+          ),
+        ]),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/features/main_editor/merge_filters_test.dart
+++ b/test/features/main_editor/merge_filters_test.dart
@@ -90,7 +90,11 @@ void main() {
   ) async {
     final state = await pumpEditor(tester);
 
-    state.addHistory(filters: [FilterState(name: 'a', matrices: [_matrixA])]);
+    state.addHistory(
+      filters: [
+        FilterState(name: 'a', matrices: [_matrixA]),
+      ],
+    );
     await tester.pump();
 
     expect(state.canMergeFilters, isFalse);

--- a/test/features/main_editor/merge_filters_test.dart
+++ b/test/features/main_editor/merge_filters_test.dart
@@ -1,0 +1,100 @@
+// Flutter imports:
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
+import 'package:pro_image_editor/pro_image_editor.dart';
+
+import '../../mock/mock_image.dart';
+
+const _matrixA = <double>[
+  0.8, 0, 0, 0, 0, //
+  0, 0.8, 0, 0, 0, //
+  0, 0, 0.8, 0, 0, //
+  0, 0, 0, 1, 0, //
+];
+const _matrixB = <double>[
+  1, 0, 0, 0, 10, //
+  0, 1, 0, 0, 10, //
+  0, 0, 1, 0, 10, //
+  0, 0, 0, 1, 0, //
+];
+
+void main() {
+  const configs = ProImageEditorConfigs(
+    progressIndicatorConfigs: ProgressIndicatorConfigs(
+      widgets: ProgressIndicatorWidgets(
+        circularProgressIndicator: SizedBox.shrink(),
+      ),
+    ),
+    imageGeneration: ImageGenerationConfigs(
+      enableIsolateGeneration: false,
+      enableBackgroundGeneration: false,
+    ),
+  );
+
+  Future<ProImageEditorState> pumpEditor(WidgetTester tester) async {
+    final key = GlobalKey<ProImageEditorState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ProImageEditor.memory(
+          mockMemoryImage,
+          key: key,
+          configs: configs,
+          callbacks: ProImageEditorCallbacks(
+            onImageEditingComplete: (Uint8List bytes) async {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return key.currentState!;
+  }
+
+  testWidgets('merges the active filters into one, undo restores them', (
+    tester,
+  ) async {
+    final state = await pumpEditor(tester);
+
+    state.addHistory(
+      filters: [
+        FilterState(name: 'a', matrices: [_matrixA]),
+        FilterState(name: 'b', matrices: [_matrixB]),
+      ],
+    );
+    await tester.pump();
+
+    expect(state.stateManager.activeFilters.length, 2);
+    expect(state.canMergeFilters, isTrue);
+
+    final historyLengthBefore = state.stateHistory.length;
+    final merged = state.mergeFilters();
+    await tester.pump();
+
+    expect(merged, isNotNull);
+    expect(state.stateManager.activeFilters.length, 1);
+    expect(state.stateManager.activeFilters.first.matrices.length, 1);
+    expect(state.stateHistory.length, historyLengthBefore + 1);
+
+    // A single undo restores the two original filters.
+    state.undoAction();
+    await tester.pump();
+    expect(state.stateManager.activeFilters.length, 2);
+  });
+
+  testWidgets('mergeFilters returns null with fewer than two filters', (
+    tester,
+  ) async {
+    final state = await pumpEditor(tester);
+
+    state.addHistory(filters: [FilterState(name: 'a', matrices: [_matrixA])]);
+    await tester.pump();
+
+    expect(state.canMergeFilters, isFalse);
+    expect(state.mergeFilters(), isNull);
+    expect(state.stateManager.activeFilters.length, 1);
+  });
+}

--- a/test/features/main_editor/merge_selected_layers_test.dart
+++ b/test/features/main_editor/merge_selected_layers_test.dart
@@ -1,0 +1,166 @@
+// Flutter imports:
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+
+// Project imports:
+import 'package:pro_image_editor/pro_image_editor.dart';
+
+import '../../mock/mock_image.dart';
+
+void main() {
+  const configs = ProImageEditorConfigs(
+    progressIndicatorConfigs: ProgressIndicatorConfigs(
+      widgets: ProgressIndicatorWidgets(
+        circularProgressIndicator: SizedBox.shrink(),
+      ),
+    ),
+    imageGeneration: ImageGenerationConfigs(
+      enableIsolateGeneration: false,
+      enableBackgroundGeneration: false,
+    ),
+  );
+
+  PaintLayer buildPaintLayer(Offset offset) {
+    return PaintLayer(
+      item: PaintedModel(
+        mode: PaintMode.freeStyle,
+        offsets: const [Offset(0, 0), Offset(20, 20)],
+        erasedOffsets: const [],
+        color: Colors.red,
+        strokeWidth: 4,
+        opacity: 1,
+      ),
+      rawSize: const Size(20, 20),
+      opacity: 1,
+      offset: offset,
+    );
+  }
+
+  Future<ProImageEditorState> pumpEditor(WidgetTester tester) async {
+    final key = GlobalKey<ProImageEditorState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ProImageEditor.memory(
+          mockMemoryImage,
+          key: key,
+          configs: configs,
+          callbacks: ProImageEditorCallbacks(
+            onImageEditingComplete: (Uint8List bytes) async {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return key.currentState!;
+  }
+
+  void selectAll(ProImageEditorState state, List<Layer> layers) {
+    state.layerInteractionManager.clearSelectedLayers();
+    for (final layer in layers) {
+      state.layerInteractionManager.addSelectedLayer(layer.id);
+    }
+  }
+
+  testWidgets('merges two selected paint layers into one', (tester) async {
+    final state = await pumpEditor(tester);
+
+    final layerA = buildPaintLayer(const Offset(-40, 0));
+    final layerB = buildPaintLayer(const Offset(40, 0));
+    state
+      ..addLayer(
+        layerA,
+        autoCorrectZoomOffset: false,
+        autoCorrectZoomScale: false,
+      )
+      ..addLayer(
+        layerB,
+        autoCorrectZoomOffset: false,
+        autoCorrectZoomScale: false,
+      );
+    await tester.pump();
+
+    expect(state.activeLayers.length, 2);
+
+    selectAll(state, [layerA, layerB]);
+    expect(state.canMergeSelectedLayers, isTrue);
+
+    final merged = state.mergeSelectedLayers();
+    await tester.pump();
+
+    expect(merged, isNotNull);
+    expect(state.activeLayers.length, 1);
+    expect(state.activeLayers.first, isA<PaintLayer>());
+    expect((state.activeLayers.first as PaintLayer).items.length, 2);
+    expect(
+      state.layerInteractionManager.selectedLayerIds.contains(merged!.id),
+      isTrue,
+    );
+  });
+
+  testWidgets('merge is a single undo entry restoring the originals', (
+    tester,
+  ) async {
+    final state = await pumpEditor(tester);
+
+    final layerA = buildPaintLayer(const Offset(-40, 0));
+    final layerB = buildPaintLayer(const Offset(40, 0));
+    state
+      ..addLayer(
+        layerA,
+        autoCorrectZoomOffset: false,
+        autoCorrectZoomScale: false,
+      )
+      ..addLayer(
+        layerB,
+        autoCorrectZoomOffset: false,
+        autoCorrectZoomScale: false,
+      );
+    await tester.pump();
+
+    selectAll(state, [layerA, layerB]);
+
+    final historyLengthBefore = state.stateHistory.length;
+    state.mergeSelectedLayers();
+    await tester.pump();
+
+    // Exactly one new history entry was recorded for the merge.
+    expect(state.stateHistory.length, historyLengthBefore + 1);
+    expect(state.activeLayers.length, 1);
+
+    // A single undo restores both original layers.
+    state.undoAction();
+    await tester.pump();
+
+    expect(state.activeLayers.length, 2);
+    expect(
+      state.activeLayers.map((layer) => layer.id).toSet(),
+      {layerA.id, layerB.id},
+    );
+    for (final layer in state.activeLayers) {
+      expect(layer, isA<PaintLayer>());
+      expect((layer as PaintLayer).items.length, 1);
+    }
+  });
+
+  testWidgets('mergeSelectedLayers returns null for fewer than two', (
+    tester,
+  ) async {
+    final state = await pumpEditor(tester);
+
+    final layerA = buildPaintLayer(const Offset(-40, 0));
+    state.addLayer(
+      layerA,
+      autoCorrectZoomOffset: false,
+      autoCorrectZoomScale: false,
+    );
+    await tester.pump();
+
+    selectAll(state, [layerA]);
+    expect(state.canMergeSelectedLayers, isFalse);
+    expect(state.mergeSelectedLayers(), isNull);
+    expect(state.activeLayers.length, 1);
+  });
+}

--- a/test/features/main_editor/merge_selected_layers_test.dart
+++ b/test/features/main_editor/merge_selected_layers_test.dart
@@ -135,10 +135,10 @@ void main() {
     await tester.pump();
 
     expect(state.activeLayers.length, 2);
-    expect(
-      state.activeLayers.map((layer) => layer.id).toSet(),
-      {layerA.id, layerB.id},
-    );
+    expect(state.activeLayers.map((layer) => layer.id).toSet(), {
+      layerA.id,
+      layerB.id,
+    });
     for (final layer in state.activeLayers) {
       expect(layer, isA<PaintLayer>());
       expect((layer as PaintLayer).items.length, 1);

--- a/test/features/main_editor/services/paint_layer_merge_manager_test.dart
+++ b/test/features/main_editor/services/paint_layer_merge_manager_test.dart
@@ -344,17 +344,19 @@ void main() {
     });
 
     test('excludes layers carrying animations', () {
-      final animated = _paintLayer(
-        mode: PaintMode.freeStyle,
-        offsets: const [Offset(0, 0), Offset(10, 10)],
-        rawSize: const Size(10, 10),
-      )..animations.add(
-        const LayerAnimation(
-          type: LayerAnimationType.fade,
-          phase: AnimationPhase.animateIn,
-          duration: Duration(milliseconds: 300),
-        ),
-      );
+      final animated =
+          _paintLayer(
+              mode: PaintMode.freeStyle,
+              offsets: const [Offset(0, 0), Offset(10, 10)],
+              rawSize: const Size(10, 10),
+            )
+            ..animations.add(
+              const LayerAnimation(
+                type: LayerAnimationType.fade,
+                phase: AnimationPhase.animateIn,
+                duration: Duration(milliseconds: 300),
+              ),
+            );
 
       expect(PaintLayerMergeManager.canMerge([paint(), animated]), isFalse);
       expect(PaintLayerMergeManager.isMergeable(animated), isFalse);

--- a/test/features/main_editor/services/paint_layer_merge_manager_test.dart
+++ b/test/features/main_editor/services/paint_layer_merge_manager_test.dart
@@ -224,6 +224,79 @@ void main() {
       final merged = PaintLayerMergeManager.merge([multi, single]);
       expect(merged.items.length, 3);
     });
+
+    test('preserves per-stroke opacity when re-merging merged sources', () {
+      // First merge: two strokes with distinct opacities become one layer that
+      // renders each stroke with its own opacity (layer opacity 1).
+      final multi = PaintLayerMergeManager.merge([
+        _paintLayer(
+          mode: PaintMode.freeStyle,
+          offsets: const [Offset(0, 0), Offset(10, 10)],
+          opacity: 0.25,
+          rawSize: const Size(10, 10),
+        ),
+        _paintLayer(
+          mode: PaintMode.freeStyle,
+          offsets: const [Offset(0, 0), Offset(10, 10)],
+          offset: const Offset(80, 0),
+          opacity: 0.75,
+          rawSize: const Size(10, 10),
+        ),
+      ]);
+      expect(multi.opacity, 1.0);
+
+      final single = _paintLayer(
+        mode: PaintMode.freeStyle,
+        offsets: const [Offset(0, 0), Offset(10, 10)],
+        offset: const Offset(0, 120),
+        opacity: 0.5,
+        rawSize: const Size(10, 10),
+      );
+
+      // Re-merging must keep each stroke's baked opacity, not overwrite it with
+      // the merged layer's opacity of 1.
+      final merged = PaintLayerMergeManager.merge([multi, single]);
+      expect(merged.items[0].opacity, closeTo(0.25, 1e-6));
+      expect(merged.items[1].opacity, closeTo(0.75, 1e-6));
+      expect(merged.items[2].opacity, closeTo(0.5, 1e-6));
+    });
+
+    test('inherits groupId and meta from the top-most source', () {
+      final bottom = PaintLayer(
+        item: PaintedModel(
+          mode: PaintMode.freeStyle,
+          offsets: const [Offset(0, 0), Offset(10, 10)],
+          erasedOffsets: const [],
+          color: Colors.red,
+          strokeWidth: 4,
+          opacity: 1,
+        ),
+        rawSize: const Size(10, 10),
+        opacity: 1,
+        groupId: 'group-bottom',
+        meta: const {'source': 'bottom'},
+      );
+      final top = PaintLayer(
+        item: PaintedModel(
+          mode: PaintMode.freeStyle,
+          offsets: const [Offset(0, 0), Offset(10, 10)],
+          erasedOffsets: const [],
+          color: Colors.blue,
+          strokeWidth: 4,
+          opacity: 1,
+        ),
+        rawSize: const Size(10, 10),
+        opacity: 1,
+        offset: const Offset(80, 0),
+        groupId: 'group-top',
+        meta: const {'source': 'top'},
+      );
+
+      final merged = PaintLayerMergeManager.merge([bottom, top]);
+
+      expect(merged.groupId, 'group-top');
+      expect(merged.meta, {'source': 'top'});
+    });
   });
 
   group('PaintLayerMergeManager.canMerge gating', () {
@@ -257,6 +330,34 @@ void main() {
         PaintLayerMergeManager.canMerge([paint(), Layer(id: 'non-paint')]),
         isFalse,
       );
+    });
+
+    test('excludes layers carrying video-timeline scheduling', () {
+      final scheduled = _paintLayer(
+        mode: PaintMode.freeStyle,
+        offsets: const [Offset(0, 0), Offset(10, 10)],
+        rawSize: const Size(10, 10),
+      )..startTime = const Duration(seconds: 1);
+
+      expect(PaintLayerMergeManager.canMerge([paint(), scheduled]), isFalse);
+      expect(PaintLayerMergeManager.isMergeable(scheduled), isFalse);
+    });
+
+    test('excludes layers carrying animations', () {
+      final animated = _paintLayer(
+        mode: PaintMode.freeStyle,
+        offsets: const [Offset(0, 0), Offset(10, 10)],
+        rawSize: const Size(10, 10),
+      )..animations.add(
+        const LayerAnimation(
+          type: LayerAnimationType.fade,
+          phase: AnimationPhase.animateIn,
+          duration: Duration(milliseconds: 300),
+        ),
+      );
+
+      expect(PaintLayerMergeManager.canMerge([paint(), animated]), isFalse);
+      expect(PaintLayerMergeManager.isMergeable(animated), isFalse);
     });
   });
 }

--- a/test/features/main_editor/services/paint_layer_merge_manager_test.dart
+++ b/test/features/main_editor/services/paint_layer_merge_manager_test.dart
@@ -1,0 +1,262 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_image_editor/features/main_editor/services/paint_layer_merge_manager.dart';
+import 'package:pro_image_editor/features/paint_editor/models/eraser_model.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
+
+/// Independent re-implementation of the render transform used to validate the
+/// merge geometry. Maps a layer-local point (top-left based, unscaled) into the
+/// shared world frame relative to the editor body center.
+Offset _sourceWorld(PaintLayer layer, Offset point) {
+  final center = Offset(layer.rawSize.width / 2, layer.rawSize.height / 2);
+  final v = (point - center) * layer.scale;
+  final cosR = cos(layer.rotation);
+  final sinR = sin(layer.rotation);
+  var rx = v.dx * cosR - v.dy * sinR;
+  var ry = v.dx * sinR + v.dy * cosR;
+  if (layer.flipX) rx = -rx;
+  if (layer.flipY) ry = -ry;
+  return layer.offset + Offset(rx, ry);
+}
+
+/// World position (relative to body center) of a point on the merged layer,
+/// which always has an identity transform (scale 1, rotation 0, no flip).
+Offset _mergedWorld(PaintLayer merged, Offset point) {
+  final center = Offset(merged.rawSize.width / 2, merged.rawSize.height / 2);
+  return merged.offset + (point - center);
+}
+
+void _expectOffsetClose(Offset a, Offset b, {double eps = 1e-6}) {
+  expect(a.dx, closeTo(b.dx, eps), reason: 'dx of $a vs $b');
+  expect(a.dy, closeTo(b.dy, eps), reason: 'dy of $a vs $b');
+}
+
+PaintLayer _paintLayer({
+  required PaintMode mode,
+  required List<Offset?> offsets,
+  Offset offset = Offset.zero,
+  double scale = 1,
+  double rotation = 0,
+  bool flipX = false,
+  bool flipY = false,
+  double opacity = 1,
+  double strokeWidth = 4,
+  List<ErasedOffset> erasedOffsets = const [],
+  bool fill = false,
+  required Size rawSize,
+}) {
+  return PaintLayer(
+    item: PaintedModel(
+      mode: mode,
+      offsets: offsets,
+      erasedOffsets: erasedOffsets,
+      color: Colors.red,
+      strokeWidth: strokeWidth,
+      opacity: opacity,
+      fill: fill,
+    ),
+    rawSize: rawSize,
+    opacity: opacity,
+    offset: offset,
+    scale: scale,
+    rotation: rotation,
+    flipX: flipX,
+    flipY: flipY,
+  );
+}
+
+void main() {
+  group('PaintLayerMergeManager.merge geometry', () {
+    test('bakes each source transform so world positions are preserved', () {
+      // A: identity.
+      final layerA = _paintLayer(
+        mode: PaintMode.freeStyle,
+        offsets: const [Offset(0, 0), Offset(100, 100), null, Offset(100, 0)],
+        rawSize: const Size(100, 100),
+      );
+      // B: horizontally flipped, shifted right.
+      final layerB = _paintLayer(
+        mode: PaintMode.freeStyle,
+        offsets: const [Offset(0, 0), Offset(100, 100)],
+        offset: const Offset(200, 0),
+        flipX: true,
+        rawSize: const Size(100, 100),
+      );
+      // C: rotated 90° and scaled 2x, shifted down.
+      final layerC = _paintLayer(
+        mode: PaintMode.freeStyle,
+        offsets: const [Offset(100, 50), Offset(50, 50)],
+        offset: const Offset(0, 300),
+        scale: 2,
+        rotation: pi / 2,
+        rawSize: const Size(100, 100),
+      );
+
+      final sources = [layerA, layerB, layerC];
+      final merged = PaintLayerMergeManager.merge(sources);
+
+      // Sanity: a couple of hand-computed world positions validate the formula
+      // itself (guards against a self-consistent but wrong transform).
+      _expectOffsetClose(
+        _sourceWorld(layerA, const Offset(0, 0)),
+        const Offset(-50, -50),
+      );
+      _expectOffsetClose(
+        _sourceWorld(layerB, const Offset(0, 0)),
+        const Offset(250, -50),
+      );
+      _expectOffsetClose(
+        _sourceWorld(layerC, const Offset(100, 50)),
+        const Offset(0, 400),
+      );
+
+      // Every merged point must map to the same world position as its origin.
+      var idx = 0;
+      for (final src in sources) {
+        for (final item in src.items) {
+          final mergedItem = merged.items[idx++];
+          expect(mergedItem.offsets.length, item.offsets.length);
+          for (var i = 0; i < item.offsets.length; i++) {
+            final p = item.offsets[i];
+            final q = mergedItem.offsets[i];
+            if (p == null) {
+              expect(q, isNull);
+              continue;
+            }
+            _expectOffsetClose(_mergedWorld(merged, q!), _sourceWorld(src, p));
+          }
+        }
+      }
+    });
+
+    test('produces an identity-transform layer with all strokes', () {
+      final merged = PaintLayerMergeManager.merge([
+        _paintLayer(
+          mode: PaintMode.freeStyle,
+          offsets: const [Offset(0, 0), Offset(10, 10)],
+          rawSize: const Size(10, 10),
+        ),
+        _paintLayer(
+          mode: PaintMode.line,
+          offsets: const [Offset(0, 0), Offset(10, 10)],
+          offset: const Offset(50, 0),
+          rawSize: const Size(10, 10),
+        ),
+      ]);
+
+      expect(merged.items.length, 2);
+      expect(merged.scale, 1.0);
+      expect(merged.rotation, 0.0);
+      expect(merged.flipX, isFalse);
+      expect(merged.flipY, isFalse);
+      expect(merged.opacity, 1.0);
+    });
+
+    test('bakes scale into stroke width and erased radius', () {
+      final merged = PaintLayerMergeManager.merge([
+        _paintLayer(
+          mode: PaintMode.freeStyle,
+          offsets: const [Offset(0, 0), Offset(10, 10)],
+          strokeWidth: 4,
+          scale: 3,
+          erasedOffsets: const [ErasedOffset(offset: Offset(5, 5), radius: 8)],
+          rawSize: const Size(10, 10),
+        ),
+        _paintLayer(
+          mode: PaintMode.freeStyle,
+          offsets: const [Offset(0, 0), Offset(10, 10)],
+          offset: const Offset(80, 0),
+          rawSize: const Size(10, 10),
+        ),
+      ]);
+
+      // First stroke had scale 3 → width and radius are multiplied by 3.
+      expect(merged.items.first.strokeWidth, closeTo(12, 1e-6));
+      expect(merged.items.first.erasedOffsets.first.radius, closeTo(24, 1e-6));
+    });
+
+    test('preserves per-layer opacity on the merged strokes', () {
+      final merged = PaintLayerMergeManager.merge([
+        _paintLayer(
+          mode: PaintMode.freeStyle,
+          offsets: const [Offset(0, 0), Offset(10, 10)],
+          opacity: 0.25,
+          rawSize: const Size(10, 10),
+        ),
+        _paintLayer(
+          mode: PaintMode.freeStyle,
+          offsets: const [Offset(0, 0), Offset(10, 10)],
+          offset: const Offset(80, 0),
+          opacity: 0.75,
+          rawSize: const Size(10, 10),
+        ),
+      ]);
+
+      expect(merged.items[0].opacity, closeTo(0.25, 1e-6));
+      expect(merged.items[1].opacity, closeTo(0.75, 1e-6));
+    });
+
+    test('flattens already-merged (multi-item) sources', () {
+      final multi = PaintLayerMergeManager.merge([
+        _paintLayer(
+          mode: PaintMode.freeStyle,
+          offsets: const [Offset(0, 0), Offset(10, 10)],
+          rawSize: const Size(10, 10),
+        ),
+        _paintLayer(
+          mode: PaintMode.freeStyle,
+          offsets: const [Offset(0, 0), Offset(10, 10)],
+          offset: const Offset(80, 0),
+          rawSize: const Size(10, 10),
+        ),
+      ]);
+      expect(multi.items.length, 2);
+
+      final single = _paintLayer(
+        mode: PaintMode.freeStyle,
+        offsets: const [Offset(0, 0), Offset(10, 10)],
+        offset: const Offset(0, 120),
+        rawSize: const Size(10, 10),
+      );
+
+      final merged = PaintLayerMergeManager.merge([multi, single]);
+      expect(merged.items.length, 3);
+    });
+  });
+
+  group('PaintLayerMergeManager.canMerge gating', () {
+    PaintLayer paint({PaintMode mode = PaintMode.freeStyle}) => _paintLayer(
+      mode: mode,
+      offsets: const [Offset(0, 0), Offset(10, 10)],
+      rawSize: const Size(10, 10),
+    );
+
+    test('true for two non-censor paint layers', () {
+      expect(PaintLayerMergeManager.canMerge([paint(), paint()]), isTrue);
+    });
+
+    test('false for fewer than two paint layers', () {
+      expect(PaintLayerMergeManager.canMerge([paint()]), isFalse);
+      expect(PaintLayerMergeManager.canMerge([]), isFalse);
+    });
+
+    test('false for censor layers', () {
+      expect(
+        PaintLayerMergeManager.canMerge([
+          paint(mode: PaintMode.blur),
+          paint(mode: PaintMode.pixelate),
+        ]),
+        isFalse,
+      );
+    });
+
+    test('false for mixed selections without two paint layers', () {
+      expect(
+        PaintLayerMergeManager.canMerge([paint(), Layer(id: 'non-paint')]),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds appearance-preserving **combine/flatten** operations, so a host app can reduce clutter without changing how the result looks.

Tracking issue in the consuming app: `divine-mobile#5834`.

### 1. Combine paint layers (the original ask)
Reduce several selected draw (paint) layers to a single `PaintLayer`. A true merge to one layer — distinct from grouping (`groupId`).

```dart
bool get canMergeSelectedLayers;    // true when ≥2 non-censor PaintLayers selected
PaintLayer? mergeSelectedLayers();  // merge → one layer, one undo entry, selects it
```
- `PaintLayer` now holds `List<PaintedModel> items`; `item` stays a back-compat getter/setter to `items.first`. Single-stroke layers serialize legacy `item`; merged layers add an `items` array (minified `it`); `fromMap` still reads legacy payloads.
- Pure, unit-tested `PaintLayerMergeManager.merge(...)` bakes each source layer's offset/scale/rotation/flip/opacity (+ stroke width, erase radius) into a shared frame → identity-transform layer that renders pixel-identical.
- Inserted at the top-most source z-index; originals removed; single undo entry.

### 2. Flatten filters
```dart
bool get canMergeFilters;   // true when ≥2 active filters and none use video-timeline metadata
FilterState? mergeFilters();// flatten the active filter stack into one FilterState, one undo entry
```
- Exact by construction: `ColorFilterGenerator` already composes the whole filter+tune stack into **one** `ColorFilter.matrix` (`mergeColorMatrices`), so flattening N filter states reuses that math and is appearance-identical. The filter editor re-reads prior filters as an opaque `allMatrices` base, so re-editing still works. Gated out when any filter carries video-timeline scheduling.
- Backed by pure `mergeFilterStates()` / `canMergeFilterStates()`.

## Why not text layers / tune adjustments
- **Text layers — not possible.** A `TextLayer` is one string + one style + one transform; N independently positioned/rotated/styled texts can't be baked into one without losing appearance or editability. Grouping already covers "handle together".
- **Tune adjustments — deliberately skipped.** Same color-matrix math *would* compose exactly, but the tune editor restores each slider **by semantic id** (`el.id == item.id`), so flattening to one opaque matrix would reset every slider to 0 on re-open. The re-editability regression isn't worth it. (Happy to add it opt-in if you want the trade-off.)

## Tests
`flutter test` → **507 pass**, `dart analyze` (lib, test, example) clean. New coverage:
- Paint geometry (rotated + flipped + scaled sources map to identical world positions; stroke-width/radius/opacity baking; flattening already-merged sources).
- Paint serialization round-trip (multi-item plain + minified keep N items; legacy single-item still deserializes).
- Paint history (one undo entry; undo restores exact originals) and gating (<2 / censor / mixed non-paint).
- Filter flatten exactness (merged+tune == original stack+tune), gating (<2 / video-timeline), and history/undo.
- Back-compat: existing single-item PaintLayer tests pass; `item` getter returns `items.first`.

## Housekeeping
- "Combine Paint Layers" button in the layer grouping example.
- Version bumped to **13.2.0** + CHANGELOG entries.