### PR TITLE
feat(paint-editor): allow zoom while drawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 13.4.0
+- **FEAT**(paint-editor): Navigate while a drawing tool is active via `PaintEditorConfigs.enableZoomWhileDrawing` (opt-in). Pinch, trackpad and mouse wheel zoom; secondary/middle mouse buttons pan.
+
 ## 13.3.1
 - **FIX**(crop-rotate): Crop handles no longer jump onto the finger when a drag starts; the gesture slop and the distance to the grabbed handle are compensated.
 - **FIX**(crop-rotate): Corner drags with a fixed aspect ratio now follow the finger diagonally instead of tracking horizontal movement only, and stay inside the image.

--- a/lib/core/models/editor_configs/paint_editor/paint_editor_configs.dart
+++ b/lib/core/models/editor_configs/paint_editor/paint_editor_configs.dart
@@ -64,7 +64,7 @@ class PaintEditorConfigs extends ZoomConfigs
     this.isInitiallyFilled = false,
     this.showLayers = true,
     this.enableShareZoomMatrix = true,
-    this.enableZoomWhileDrawing = true,
+    this.enableZoomWhileDrawing = false,
     this.polygonConnectionThreshold = 20,
     this.minStrokeWidth = 1.0,
     this.maxStrokeWidth = 40.0,
@@ -183,9 +183,9 @@ class PaintEditorConfigs extends ZoomConfigs
   /// that stroke is discarded so path coordinates stay in one transform
   /// space. Has no effect when [enableZoom] is `false`.
   ///
-  /// Defaults to `true`. Set to `false` to restore the previous behavior
-  /// where the viewport is frozen until [PaintMode.moveAndZoom] is selected
-  /// and every mouse button draws.
+  /// Defaults to `false` (viewport stays frozen until
+  /// [PaintMode.moveAndZoom] is selected). Set to `true` to navigate while
+  /// drawing.
   final bool enableZoomWhileDrawing;
 
   /// Indicates the initial paint mode.

--- a/lib/core/models/editor_configs/paint_editor/paint_editor_configs.dart
+++ b/lib/core/models/editor_configs/paint_editor/paint_editor_configs.dart
@@ -64,6 +64,7 @@ class PaintEditorConfigs extends ZoomConfigs
     this.isInitiallyFilled = false,
     this.showLayers = true,
     this.enableShareZoomMatrix = true,
+    this.enableZoomWhileDrawing = true,
     this.polygonConnectionThreshold = 20,
     this.minStrokeWidth = 1.0,
     this.maxStrokeWidth = 40.0,
@@ -173,6 +174,19 @@ class PaintEditorConfigs extends ZoomConfigs
 
   /// Shares the zoom matrix between the main and paint editor.
   final bool enableShareZoomMatrix;
+
+  /// Whether pinch, trackpad, pointer-scroll and secondary/middle mouse
+  /// buttons may navigate while a drawing tool is active.
+  ///
+  /// Primary click-drag still draws. Secondary and middle mouse buttons pan
+  /// instead of drawing. If the view moves while a stroke is in progress,
+  /// that stroke is discarded so path coordinates stay in one transform
+  /// space. Has no effect when [enableZoom] is `false`.
+  ///
+  /// Defaults to `true`. Set to `false` to restore the previous behavior
+  /// where the viewport is frozen until [PaintMode.moveAndZoom] is selected
+  /// and every mouse button draws.
+  final bool enableZoomWhileDrawing;
 
   /// Indicates the initial paint mode.
   final PaintMode initialPaintMode;
@@ -313,6 +327,7 @@ class PaintEditorConfigs extends ZoomConfigs
     bool? isInitiallyFilled,
     bool? showLayers,
     bool? enableShareZoomMatrix,
+    bool? enableZoomWhileDrawing,
     PaintMode? initialPaintMode,
     EraserMode? eraserMode,
     double? eraserSize,
@@ -363,6 +378,8 @@ class PaintEditorConfigs extends ZoomConfigs
       showLayers: showLayers ?? this.showLayers,
       enableShareZoomMatrix:
           enableShareZoomMatrix ?? this.enableShareZoomMatrix,
+      enableZoomWhileDrawing:
+          enableZoomWhileDrawing ?? this.enableZoomWhileDrawing,
       initialPaintMode: initialPaintMode ?? this.initialPaintMode,
       eraserMode: eraserMode ?? this.eraserMode,
       eraserSize: eraserSize ?? this.eraserSize,

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -626,11 +626,30 @@ class PaintEditorState extends State<PaintEditor>
     paintCtrl.setMode(mode);
     paintEditorCallbacks?.handlePaintModeChanged(mode);
     rebuildController.add(null);
-    interactiveViewer.currentState?.setEnableInteraction(
-      mode == PaintMode.moveAndZoom,
-    );
+    _syncViewerInteraction();
     _paintCanvas.currentState?.setState(() {});
     setState(() {});
+  }
+
+  bool get _viewerPanEnabled =>
+      _enableZoom && paintMode == PaintMode.moveAndZoom;
+
+  bool get _viewerScaleEnabled {
+    if (!_enableZoom) return false;
+    if (paintMode == PaintMode.moveAndZoom) return true;
+    return paintEditorConfigs.enableZoomWhileDrawing;
+  }
+
+  void _syncViewerInteraction() {
+    interactiveViewer.currentState?.setPanAndScaleEnabled(
+      pan: _viewerPanEnabled,
+      scale: _viewerScaleEnabled,
+    );
+  }
+
+  void _onPaintViewerMatrixChanged(Matrix4 value) {
+    _paintCanvas.currentState?.cancelActiveDrawing();
+    callbacks.paintEditorCallbacks?.onEditorZoomMatrix4Change?.call(value);
   }
 
   /// Undoes the last action performed in the paint editor.
@@ -1009,7 +1028,9 @@ class PaintEditorState extends State<PaintEditor>
               ? initConfigs.initialZoomMatrix
               : null,
           zoomConfigs: paintEditorConfigs,
-          enableInteraction: paintMode == PaintMode.moveAndZoom,
+          enableInteraction: _viewerPanEnabled || _viewerScaleEnabled,
+          panEnabled: _viewerPanEnabled,
+          scaleEnabled: _viewerScaleEnabled,
           onInteractionStart: (details) {
             callbacks.paintEditorCallbacks?.onEditorZoomScaleStart?.call(
               details,
@@ -1022,8 +1043,7 @@ class PaintEditorState extends State<PaintEditor>
             callbacks.paintEditorCallbacks?.onEditorZoomScaleEnd?.call(details);
             setState(() {});
           },
-          onMatrix4Change:
-              callbacks.paintEditorCallbacks?.onEditorZoomMatrix4Change,
+          onMatrix4Change: _onPaintViewerMatrixChanged,
           child: Stack(
             alignment: Alignment.center,
             fit: StackFit.expand,
@@ -1278,6 +1298,13 @@ class PaintEditorState extends State<PaintEditor>
       ..add(FlagProperty('canRedo', value: canRedo, ifTrue: 'can redo'))
       ..add(
         FlagProperty('_enableZoom', value: _enableZoom, ifTrue: 'zoom enabled'),
+      )
+      ..add(
+        FlagProperty(
+          'enableZoomWhileDrawing',
+          value: paintEditorConfigs.enableZoomWhileDrawing,
+          ifTrue: 'zoom while drawing',
+        ),
       )
       ..add(
         FlagProperty(

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -675,7 +675,6 @@ class PaintEditorState extends State<PaintEditor>
       // A second finger joined a stroke, so the viewer takes the gesture over
       // from here. Report the start it never got.
       if (!_isNavigationGesture(details.pointerCount)) return;
-      _viewerGestureNavigates = true;
       _onPaintViewerInteractionStart(
         ScaleStartDetails(
           focalPoint: details.focalPoint,

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -652,6 +652,48 @@ class PaintEditorState extends State<PaintEditor>
     callbacks.paintEditorCallbacks?.onEditorZoomMatrix4Change?.call(value);
   }
 
+  /// Whether the gesture the viewer is currently reporting can move the view.
+  bool _viewerGestureNavigates = false;
+
+  /// While a drawing tool is active the viewer keeps its gesture detector
+  /// alive so pinch may still zoom, but it reports every one-finger drag too -
+  /// and those drags are strokes, not navigation. Only gestures the viewer can
+  /// act on count: any gesture while panning is enabled, or a real multi-finger
+  /// pinch.
+  bool _isNavigationGesture(int pointerCount) =>
+      _viewerPanEnabled || pointerCount > 1;
+
+  void _onPaintViewerInteractionStart(ScaleStartDetails details) {
+    _viewerGestureNavigates = _isNavigationGesture(details.pointerCount);
+    if (!_viewerGestureNavigates) return;
+    callbacks.paintEditorCallbacks?.onEditorZoomScaleStart?.call(details);
+    setState(() {});
+  }
+
+  void _onPaintViewerInteractionUpdate(ScaleUpdateDetails details) {
+    if (!_viewerGestureNavigates) {
+      // A second finger joined a stroke, so the viewer takes the gesture over
+      // from here. Report the start it never got.
+      if (!_isNavigationGesture(details.pointerCount)) return;
+      _viewerGestureNavigates = true;
+      _onPaintViewerInteractionStart(
+        ScaleStartDetails(
+          focalPoint: details.focalPoint,
+          localFocalPoint: details.localFocalPoint,
+          pointerCount: details.pointerCount,
+        ),
+      );
+    }
+    callbacks.paintEditorCallbacks?.onEditorZoomScaleUpdate?.call(details);
+  }
+
+  void _onPaintViewerInteractionEnd(ScaleEndDetails details) {
+    if (!_viewerGestureNavigates) return;
+    _viewerGestureNavigates = false;
+    callbacks.paintEditorCallbacks?.onEditorZoomScaleEnd?.call(details);
+    setState(() {});
+  }
+
   /// Undoes the last action performed in the paint editor.
   void undoAction() {
     if (canUndo) {
@@ -1031,18 +1073,9 @@ class PaintEditorState extends State<PaintEditor>
           enableInteraction: _viewerPanEnabled || _viewerScaleEnabled,
           panEnabled: _viewerPanEnabled,
           scaleEnabled: _viewerScaleEnabled,
-          onInteractionStart: (details) {
-            callbacks.paintEditorCallbacks?.onEditorZoomScaleStart?.call(
-              details,
-            );
-            setState(() {});
-          },
-          onInteractionUpdate:
-              callbacks.paintEditorCallbacks?.onEditorZoomScaleUpdate,
-          onInteractionEnd: (details) {
-            callbacks.paintEditorCallbacks?.onEditorZoomScaleEnd?.call(details);
-            setState(() {});
-          },
+          onInteractionStart: _onPaintViewerInteractionStart,
+          onInteractionUpdate: _onPaintViewerInteractionUpdate,
+          onInteractionEnd: _onPaintViewerInteractionEnd,
           onMatrix4Change: _onPaintViewerMatrixChanged,
           child: Stack(
             alignment: Alignment.center,

--- a/lib/features/paint_editor/widgets/paint_canvas.dart
+++ b/lib/features/paint_editor/widgets/paint_canvas.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'dart:math';
 
 // Flutter imports:
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import '/core/models/editor_configs/paint_editor/paint_editor_configs.dart';
@@ -137,6 +138,8 @@ class PaintCanvasState extends State<PaintCanvas> {
   /// for the interaction to be considered a tap rather than a drag gesture.
   static const double _tapDistanceThreshold = 10.0;
 
+  final Set<int> _navigationPointers = <int>{};
+
   bool get _isPartialEraser => widget.eraserMode == EraserMode.partial;
   bool get _isFreeStyleMode =>
       _paintCtrl.mode == PaintMode.freeStyle ||
@@ -156,6 +159,38 @@ class PaintCanvasState extends State<PaintCanvas> {
     super.dispose();
   }
 
+  /// Discards the in-progress stroke so a viewport change cannot mix
+  /// coordinate spaces in a single path.
+  ///
+  /// Remaining pointers are ignored until they are released, matching the
+  /// multi-touch pinch behavior.
+  void cancelActiveDrawing() {
+    _discardActiveStroke();
+    if (_activePointerCount > 0) {
+      _isMultiTouch = true;
+    }
+  }
+
+  void _discardActiveStroke() {
+    if (_paintCtrl.busy || _paintCtrl.start != null) {
+      _paintCtrl
+        ..setInProgress(false)
+        ..reset();
+      _activePaintStreamCtrl.add(null);
+    }
+  }
+
+  bool get _auxiliaryMousePansView =>
+      widget.paintEditorConfigs.enableZoom &&
+      widget.paintEditorConfigs.enableZoomWhileDrawing;
+
+  bool _isAuxiliaryMousePan(PointerEvent event) {
+    if (!_auxiliaryMousePansView) return false;
+    if (event.kind != PointerDeviceKind.mouse) return false;
+    return (event.buttons & kSecondaryMouseButton) != 0 ||
+        (event.buttons & kMiddleMouseButton) != 0;
+  }
+
   /// Handles the pointer down event for immediate response to touch/stylus
   /// input.
   ///
@@ -163,17 +198,25 @@ class PaintCanvasState extends State<PaintCanvas> {
   /// to eliminate gesture disambiguation delays, significantly reducing drawing
   /// latency on devices like iPad with Apple Pencil.
   void _onPointerDown(PointerDownEvent event) {
+    if (_isAuxiliaryMousePan(event)) {
+      _navigationPointers.add(event.pointer);
+      _discardActiveStroke();
+      if (_activePointerCount > 0) {
+        _isMultiTouch = true;
+      }
+      return;
+    }
+    if (_navigationPointers.isNotEmpty) {
+      _activePointerCount++;
+      _isMultiTouch = true;
+      _discardActiveStroke();
+      return;
+    }
     _activePointerCount++;
     if (_activePointerCount > 1) {
       // Multi-touch detected - disable drawing to allow pinch-to-zoom
       _isMultiTouch = true;
-      // Cancel any ongoing drawing
-      if (_paintCtrl.busy) {
-        _paintCtrl
-          ..setInProgress(false)
-          ..reset();
-        _activePaintStreamCtrl.add(null);
-      }
+      _discardActiveStroke();
       return;
     }
 
@@ -207,6 +250,10 @@ class PaintCanvasState extends State<PaintCanvas> {
   /// This provides immediate response to pointer movement without the
   /// gesture disambiguation delay that occurs with [GestureDetector].
   void _onPointerMove(PointerMoveEvent event) {
+    if (_navigationPointers.contains(event.pointer) ||
+        _isAuxiliaryMousePan(event)) {
+      return;
+    }
     // Skip if multi-touch gesture is active (pinch-to-zoom)
     if (_isMultiTouch || _activePointerCount > 1) return;
 
@@ -241,6 +288,7 @@ class PaintCanvasState extends State<PaintCanvas> {
 
   /// Handles the pointer up event to finalize drawing.
   void _onPointerUp(PointerUpEvent event) {
+    if (_navigationPointers.remove(event.pointer)) return;
     _activePointerCount = max(0, _activePointerCount - 1);
 
     // If this was part of a multi-touch gesture, reset and return
@@ -298,6 +346,7 @@ class PaintCanvasState extends State<PaintCanvas> {
 
   /// Handles the pointer cancel event to clean up state.
   void _onPointerCancel(PointerCancelEvent event) {
+    if (_navigationPointers.remove(event.pointer)) return;
     _activePointerCount = max(0, _activePointerCount - 1);
     _pointerDownPosition = null;
 
@@ -306,12 +355,7 @@ class PaintCanvasState extends State<PaintCanvas> {
     }
 
     // Reset any ongoing drawing
-    if (_paintCtrl.busy) {
-      _paintCtrl
-        ..setInProgress(false)
-        ..reset();
-      _activePaintStreamCtrl.add(null);
-    }
+    _discardActiveStroke();
   }
 
   Offset _rotatePoint(Offset point, Offset center, double angle) {

--- a/lib/features/paint_editor/widgets/paint_canvas.dart
+++ b/lib/features/paint_editor/widgets/paint_canvas.dart
@@ -250,8 +250,13 @@ class PaintCanvasState extends State<PaintCanvas> {
   /// This provides immediate response to pointer movement without the
   /// gesture disambiguation delay that occurs with [GestureDetector].
   void _onPointerMove(PointerMoveEvent event) {
-    if (_navigationPointers.contains(event.pointer) ||
-        _isAuxiliaryMousePan(event)) {
+    if (_navigationPointers.contains(event.pointer)) return;
+    if (_isAuxiliaryMousePan(event)) {
+      // A mouse button pressed mid-stroke arrives as a move event, not a new
+      // pointer. Drop the stroke instead of pausing it, which would otherwise
+      // resume with a straight jump once the button is released again.
+      _isMultiTouch = true;
+      _discardActiveStroke();
       return;
     }
     // Skip if multi-touch gesture is active (pinch-to-zoom)

--- a/lib/shared/widgets/extended/interactive_viewer/extended_interactive_viewer.dart
+++ b/lib/shared/widgets/extended/interactive_viewer/extended_interactive_viewer.dart
@@ -14,6 +14,8 @@ class ExtendedInteractiveViewer extends StatefulWidget {
     super.key,
     required this.child,
     this.enableInteraction = true,
+    this.panEnabled,
+    this.scaleEnabled,
     required this.zoomConfigs,
     required this.onInteractionStart,
     required this.onInteractionUpdate,
@@ -44,8 +46,19 @@ class ExtendedInteractiveViewer extends StatefulWidget {
   /// Indicates whether user interactions such as panning and zooming are
   /// enabled.
   ///
-  /// Default value is `true`.
+  /// Used as the default for [panEnabled] and [scaleEnabled] when those
+  /// values are omitted. Default value is `true`.
   final bool enableInteraction;
+
+  /// Whether one-finger / click-drag panning is enabled.
+  ///
+  /// Defaults to [enableInteraction] when `null`.
+  final bool? panEnabled;
+
+  /// Whether pinch, trackpad and pointer-scroll navigation is enabled.
+  ///
+  /// Defaults to [enableInteraction] when `null`.
+  final bool? scaleEnabled;
 
   /// Determines whether an external gesture detector should be enabled.
   ///
@@ -133,10 +146,22 @@ class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer>
   final _rawViewerKey = GlobalKey<ExtendedRawInteractiveViewerState>();
   late ExtendedTransformationController _transformCtrl;
   late final AnimationController _animationCtrl;
-  late bool _enableInteraction;
+  late bool _panEnabled;
+  late bool _scaleEnabled;
 
-  /// A getter that indicates whether interaction is enabled for the viewer.
-  bool get isInteractionEnabled => _enableInteraction;
+  /// Whether pan or scale interaction is currently enabled.
+  bool get isInteractionEnabled => _panEnabled || _scaleEnabled;
+
+  /// Whether one-finger / click-drag panning is currently enabled.
+  bool get isPanEnabled => _panEnabled;
+
+  /// Whether pinch, trackpad and pointer-scroll navigation is enabled.
+  bool get isScaleEnabled => _scaleEnabled;
+
+  bool get _widgetPanEnabled => widget.panEnabled ?? widget.enableInteraction;
+
+  bool get _widgetScaleEnabled =>
+      widget.scaleEnabled ?? widget.enableInteraction;
 
   @override
   void initState() {
@@ -149,7 +174,21 @@ class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer>
       vsync: this,
       duration: widget.zoomConfigs.doubleTapZoomDuration,
     );
-    _enableInteraction = widget.enableInteraction;
+    _panEnabled = _widgetPanEnabled;
+    _scaleEnabled = _widgetScaleEnabled;
+  }
+
+  @override
+  void didUpdateWidget(covariant ExtendedInteractiveViewer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final interactionChanged =
+        widget.enableInteraction != oldWidget.enableInteraction;
+    if (interactionChanged || widget.panEnabled != oldWidget.panEnabled) {
+      _panEnabled = _widgetPanEnabled;
+    }
+    if (interactionChanged || widget.scaleEnabled != oldWidget.scaleEnabled) {
+      _scaleEnabled = _widgetScaleEnabled;
+    }
   }
 
   @override
@@ -165,13 +204,20 @@ class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer>
   /// Sets the transform matrix.
   set transformMatrix4(Matrix4 value) => _transformCtrl.value = value;
 
-  /// Sets the interaction state to the given value and updates the UI
-  /// accordingly.
+  /// Sets pan and scale together and updates the UI accordingly.
   void setEnableInteraction(bool value) {
-    if (_enableInteraction != value) {
-      _enableInteraction = value;
-      setState(() {});
-    }
+    setPanAndScaleEnabled(pan: value, scale: value);
+  }
+
+  /// Enables pan and scale independently and updates the UI accordingly.
+  ///
+  /// Use this when one-finger dragging should draw (or otherwise be claimed)
+  /// while pinch, trackpad and pointer-scroll may still navigate the view.
+  void setPanAndScaleEnabled({required bool pan, required bool scale}) {
+    if (_panEnabled == pan && _scaleEnabled == scale) return;
+    _panEnabled = pan;
+    _scaleEnabled = scale;
+    setState(() {});
   }
 
   /// Reset the transformations
@@ -242,7 +288,7 @@ class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer>
     Duration? duration,
     Curve? curve,
   }) async {
-    if (!_enableInteraction) return;
+    if (!_scaleEnabled) return;
     if (scaleFactor > 1) {
       await animateZoomToPoint(offset: Offset.zero, scale: 1);
     } else {
@@ -310,8 +356,8 @@ class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer>
       key: _rawViewerKey,
       boundaryMargin: widget.zoomConfigs.boundaryMargin,
       transformationController: _transformCtrl,
-      panEnabled: _enableInteraction,
-      scaleEnabled: _enableInteraction,
+      panEnabled: _panEnabled,
+      scaleEnabled: _scaleEnabled,
       minScale: widget.zoomConfigs.editorMinScale,
       maxScale: widget.zoomConfigs.editorMaxScale,
       onInteractionStart: widget.onInteractionStart,

--- a/lib/shared/widgets/extended/interactive_viewer/extended_raw_interactive_viewer.dart
+++ b/lib/shared/widgets/extended/interactive_viewer/extended_raw_interactive_viewer.dart
@@ -614,6 +614,8 @@ class ExtendedRawInteractiveViewerState
   double _currentRotation = 0.0; // Rotation of _transformationController.value.
   _GestureType? _gestureType;
   final bool _rotateEnabled = false;
+  final Set<int> _auxiliaryPanPointers = <int>{};
+  Offset? _auxiliaryPanFocalScene;
 
   // The _boundaryRect is calculated by adding the boundaryMargin to the size of
   // the child.
@@ -815,6 +817,41 @@ class ExtendedRawInteractiveViewerState
       _GestureType.scale => widget.scaleEnabled,
       _GestureType.pan || null => widget.panEnabled,
     };
+  }
+
+  bool _isAuxiliaryMousePanButton(int buttons) {
+    return (buttons & kSecondaryMouseButton) != 0 ||
+        (buttons & kMiddleMouseButton) != 0;
+  }
+
+  void _onAuxiliaryPanPointerDown(PointerDownEvent event) {
+    if (event.kind != PointerDeviceKind.mouse ||
+        !_isAuxiliaryMousePanButton(event.buttons)) {
+      return;
+    }
+    _auxiliaryPanPointers.add(event.pointer);
+    if (widget.panEnabled) return;
+    _auxiliaryPanFocalScene = _transformer.toScene(event.localPosition);
+  }
+
+  void _onAuxiliaryPanPointerMove(PointerMoveEvent event) {
+    if (!_auxiliaryPanPointers.contains(event.pointer) || widget.panEnabled) {
+      return;
+    }
+    final Offset focalPointScene = _transformer.toScene(event.localPosition);
+    _auxiliaryPanFocalScene ??= focalPointScene;
+    _transformer.value = _matrixTranslate(
+      _transformer.value,
+      focalPointScene - _auxiliaryPanFocalScene!,
+    );
+    _auxiliaryPanFocalScene = _transformer.toScene(event.localPosition);
+  }
+
+  void _onAuxiliaryPanPointerUp(PointerEvent event) {
+    if (!_auxiliaryPanPointers.remove(event.pointer)) return;
+    if (_auxiliaryPanPointers.isEmpty) {
+      _auxiliaryPanFocalScene = null;
+    }
   }
 
   // Decide which type of gesture this is by comparing the amount of scale
@@ -1072,7 +1109,7 @@ class ExtendedRawInteractiveViewerState
           transform: event.transform,
         );
 
-        if (!_gestureIsSupported(_GestureType.pan)) {
+        if (!_gestureIsSupported(_GestureType.pan) && !widget.scaleEnabled) {
           widget.onInteractionUpdate?.call(
             ScaleUpdateDetails(
               focalPoint: global - event.scrollDelta,
@@ -1352,6 +1389,10 @@ class ExtendedRawInteractiveViewerState
 
     return Listener(
       key: _parentKey,
+      onPointerDown: _onAuxiliaryPanPointerDown,
+      onPointerMove: _onAuxiliaryPanPointerMove,
+      onPointerUp: _onAuxiliaryPanPointerUp,
+      onPointerCancel: _onAuxiliaryPanPointerUp,
       onPointerSignal: _receivedPointerSignal,
       onPointerPanZoomStart: _handlePointerPanZoomStart,
       onPointerPanZoomUpdate: _handlePointerPanZoomUpdate,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 13.3.1
+version: 13.4.0
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/features/paint_editor/paint_editor_test.dart
+++ b/test/features/paint_editor/paint_editor_test.dart
@@ -535,6 +535,33 @@ void main() {
       expect(viewer.isScaleEnabled, isTrue);
     });
 
+    testWidgets('keeps the viewer frozen by default in a drawing tool', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: PaintEditor.memory(
+              mockMemoryImage,
+              key: key,
+              initConfigs: PaintEditorInitConfigs(
+                theme: ThemeData(),
+                configs: const ProImageEditorConfigs(
+                  paintEditor: PaintEditorConfigs(enableZoom: true),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final viewer = key.currentState!.interactiveViewer.currentState!;
+      expect(key.currentState!.paintMode, PaintMode.freeStyle);
+      expect(viewer.isPanEnabled, isFalse);
+      expect(viewer.isScaleEnabled, isFalse);
+    });
+
     testWidgets('freezes the viewer when enableZoomWhileDrawing is false', (
       tester,
     ) async {

--- a/test/features/paint_editor/paint_editor_test.dart
+++ b/test/features/paint_editor/paint_editor_test.dart
@@ -572,67 +572,54 @@ void main() {
       expect(viewer.isScaleEnabled, isFalse);
     });
 
-    testWidgets(
-      'right mouse button pans without drawing',
-      (tester) async {
-        await expectMouseButtonPansWithoutDrawing(
-          tester,
-          kSecondaryMouseButton,
-        );
-      },
-    );
+    testWidgets('right mouse button pans without drawing', (tester) async {
+      await expectMouseButtonPansWithoutDrawing(tester, kSecondaryMouseButton);
+    });
 
-    testWidgets(
-      'middle mouse button pans without drawing',
-      (tester) async {
-        await expectMouseButtonPansWithoutDrawing(
-          tester,
-          kMiddleMouseButton,
-        );
-      },
-    );
+    testWidgets('middle mouse button pans without drawing', (tester) async {
+      await expectMouseButtonPansWithoutDrawing(tester, kMiddleMouseButton);
+    });
 
-    testWidgets(
-      'right mouse button pans when click-drag pan is disabled',
-      (tester) async {
-        final viewerKey = GlobalKey<ExtendedInteractiveViewerState>();
-        const childKey = Key('aux-pan-child');
-        await tester.pumpWidget(
-          MaterialApp(
-            home: SizedBox(
-              width: 400,
-              height: 400,
-              child: ExtendedInteractiveViewer(
-                key: viewerKey,
-                panEnabled: false,
-                scaleEnabled: true,
-                zoomConfigs: const PaintEditorConfigs(
-                  enableZoom: true,
-                  boundaryMargin: EdgeInsets.all(double.infinity),
-                ),
-                onInteractionStart: (_) {},
-                onInteractionUpdate: (_) {},
-                onInteractionEnd: (_) {},
-                child: const ColoredBox(key: childKey, color: Colors.red),
+    testWidgets('right mouse button pans when click-drag pan is disabled', (
+      tester,
+    ) async {
+      final viewerKey = GlobalKey<ExtendedInteractiveViewerState>();
+      const childKey = Key('aux-pan-child');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SizedBox(
+            width: 400,
+            height: 400,
+            child: ExtendedInteractiveViewer(
+              key: viewerKey,
+              panEnabled: false,
+              scaleEnabled: true,
+              zoomConfigs: const PaintEditorConfigs(
+                enableZoom: true,
+                boundaryMargin: EdgeInsets.all(double.infinity),
               ),
+              onInteractionStart: (_) {},
+              onInteractionUpdate: (_) {},
+              onInteractionEnd: (_) {},
+              child: const ColoredBox(key: childKey, color: Colors.red),
             ),
           ),
-        );
-        await tester.pump();
+        ),
+      );
+      await tester.pump();
 
-        final viewer = viewerKey.currentState!;
-        final Offset center = tester.getCenter(find.byKey(childKey));
-        final TestGesture gesture = await tester.startGesture(
-          center,
-          kind: PointerDeviceKind.mouse,
-          buttons: kSecondaryMouseButton,
-        );
-        await gesture.moveBy(const Offset(50, 0));
-        await tester.pump();
-        await gesture.up();
+      final viewer = viewerKey.currentState!;
+      final Offset center = tester.getCenter(find.byKey(childKey));
+      final TestGesture gesture = await tester.startGesture(
+        center,
+        kind: PointerDeviceKind.mouse,
+        buttons: kSecondaryMouseButton,
+      );
+      await gesture.moveBy(const Offset(50, 0));
+      await tester.pump();
+      await gesture.up();
 
-        expect(viewer.transformMatrix4.getTranslation().x, isNot(0));
-      },
-    );
+      expect(viewer.transformMatrix4.getTranslation().x, isNot(0));
+    });
   });
 }

--- a/test/features/paint_editor/paint_editor_test.dart
+++ b/test/features/paint_editor/paint_editor_test.dart
@@ -1,4 +1,5 @@
 // Flutter imports:
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 // Package imports:
@@ -6,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 import 'package:pro_image_editor/features/paint_editor/widgets/paint_canvas.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_image_editor/shared/widgets/extended/interactive_viewer/extended_interactive_viewer.dart';
 import 'package:pro_image_editor/shared/widgets/layer/layer_widget.dart';
 import 'package:pro_image_editor/shared/widgets/slider_bottom_sheet.dart';
 
@@ -444,5 +446,166 @@ void main() {
       expect(editor.historyPointer, 0);
       expect(editor.canUndo, isFalse);
     });
+  });
+
+  group('PaintEditor zoom while drawing', () {
+    Future<void> pumpZoomEditor(
+      WidgetTester tester, {
+      bool enableZoomWhileDrawing = true,
+      EdgeInsets boundaryMargin = EdgeInsets.zero,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: PaintEditor.memory(
+              mockMemoryImage,
+              key: key,
+              initConfigs: PaintEditorInitConfigs(
+                theme: ThemeData(),
+                configs: ProImageEditorConfigs(
+                  paintEditor: PaintEditorConfigs(
+                    enableZoom: true,
+                    enableZoomWhileDrawing: enableZoomWhileDrawing,
+                    boundaryMargin: boundaryMargin,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+    }
+
+    Future<void> expectMouseButtonPansWithoutDrawing(
+      WidgetTester tester,
+      int buttons,
+    ) async {
+      await pumpZoomEditor(
+        tester,
+        boundaryMargin: const EdgeInsets.all(double.infinity),
+      );
+
+      final editor = key.currentState!;
+      expect(editor.paintMode, PaintMode.freeStyle);
+
+      final Offset center = tester.getCenter(
+        find.byKey(editor.interactiveViewer),
+      );
+      final TestGesture gesture = await tester.startGesture(
+        center,
+        kind: PointerDeviceKind.mouse,
+        buttons: buttons,
+      );
+      await gesture.moveBy(const Offset(80, 40));
+      expect(
+        editor.interactiveViewer.currentState!.transformMatrix4
+            .getTranslation()
+            .x,
+        isNot(0),
+      );
+      await gesture.up();
+      await tester.pump();
+      expect(
+        editor.interactiveViewer.currentState!.transformMatrix4
+            .getTranslation()
+            .x,
+        isNot(0),
+      );
+      expect(editor.canUndo, isFalse);
+    }
+
+    testWidgets('keeps scale on and pan off in a drawing tool', (tester) async {
+      await pumpZoomEditor(tester);
+
+      final viewer = key.currentState!.interactiveViewer.currentState!;
+      expect(key.currentState!.paintMode, PaintMode.freeStyle);
+      expect(viewer.isPanEnabled, isFalse);
+      expect(viewer.isScaleEnabled, isTrue);
+    });
+
+    testWidgets('enables pan and scale in moveAndZoom', (tester) async {
+      await pumpZoomEditor(tester);
+
+      key.currentState!.setMode(PaintMode.moveAndZoom);
+      await tester.pump();
+
+      final viewer = key.currentState!.interactiveViewer.currentState!;
+      expect(viewer.isPanEnabled, isTrue);
+      expect(viewer.isScaleEnabled, isTrue);
+    });
+
+    testWidgets('freezes the viewer when enableZoomWhileDrawing is false', (
+      tester,
+    ) async {
+      await pumpZoomEditor(tester, enableZoomWhileDrawing: false);
+
+      final viewer = key.currentState!.interactiveViewer.currentState!;
+      expect(viewer.isPanEnabled, isFalse);
+      expect(viewer.isScaleEnabled, isFalse);
+    });
+
+    testWidgets(
+      'right mouse button pans without drawing',
+      (tester) async {
+        await expectMouseButtonPansWithoutDrawing(
+          tester,
+          kSecondaryMouseButton,
+        );
+      },
+    );
+
+    testWidgets(
+      'middle mouse button pans without drawing',
+      (tester) async {
+        await expectMouseButtonPansWithoutDrawing(
+          tester,
+          kMiddleMouseButton,
+        );
+      },
+    );
+
+    testWidgets(
+      'right mouse button pans when click-drag pan is disabled',
+      (tester) async {
+        final viewerKey = GlobalKey<ExtendedInteractiveViewerState>();
+        const childKey = Key('aux-pan-child');
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SizedBox(
+              width: 400,
+              height: 400,
+              child: ExtendedInteractiveViewer(
+                key: viewerKey,
+                panEnabled: false,
+                scaleEnabled: true,
+                zoomConfigs: const PaintEditorConfigs(
+                  enableZoom: true,
+                  boundaryMargin: EdgeInsets.all(double.infinity),
+                ),
+                onInteractionStart: (_) {},
+                onInteractionUpdate: (_) {},
+                onInteractionEnd: (_) {},
+                child: const ColoredBox(key: childKey, color: Colors.red),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final viewer = viewerKey.currentState!;
+        final Offset center = tester.getCenter(find.byKey(childKey));
+        final TestGesture gesture = await tester.startGesture(
+          center,
+          kind: PointerDeviceKind.mouse,
+          buttons: kSecondaryMouseButton,
+        );
+        await gesture.moveBy(const Offset(50, 0));
+        await tester.pump();
+        await gesture.up();
+
+        expect(viewer.transformMatrix4.getTranslation().x, isNot(0));
+      },
+    );
   });
 }

--- a/test/features/paint_editor/paint_editor_test.dart
+++ b/test/features/paint_editor/paint_editor_test.dart
@@ -453,6 +453,7 @@ void main() {
       WidgetTester tester, {
       bool enableZoomWhileDrawing = true,
       EdgeInsets boundaryMargin = EdgeInsets.zero,
+      PaintEditorCallbacks? paintEditorCallbacks,
     }) async {
       await tester.pumpWidget(
         MaterialApp(
@@ -468,6 +469,9 @@ void main() {
                     enableZoomWhileDrawing: enableZoomWhileDrawing,
                     boundaryMargin: boundaryMargin,
                   ),
+                ),
+                callbacks: ProImageEditorCallbacks(
+                  paintEditorCallbacks: paintEditorCallbacks,
                 ),
               ),
             ),
@@ -578,6 +582,76 @@ void main() {
 
     testWidgets('middle mouse button pans without drawing', (tester) async {
       await expectMouseButtonPansWithoutDrawing(tester, kMiddleMouseButton);
+    });
+
+    testWidgets('a stroke is not reported as a zoom interaction', (
+      tester,
+    ) async {
+      var starts = 0;
+      var updates = 0;
+      var ends = 0;
+      await pumpZoomEditor(
+        tester,
+        paintEditorCallbacks: PaintEditorCallbacks(
+          onEditorZoomScaleStart: (_) => starts++,
+          onEditorZoomScaleUpdate: (_) => updates++,
+          onEditorZoomScaleEnd: (_) => ends++,
+        ),
+      );
+
+      final editor = key.currentState!;
+      expect(editor.paintMode, PaintMode.freeStyle);
+
+      final Offset center = tester.getCenter(find.byType(PaintCanvas));
+      final TestGesture gesture = await tester.startGesture(center);
+      for (var i = 0; i < 5; i++) {
+        await gesture.moveBy(const Offset(12, 12));
+        await tester.pump();
+      }
+      await gesture.up();
+      await tester.pump();
+
+      // The viewer keeps its gesture detector alive so a pinch can still zoom,
+      // but a one-finger drag is a stroke - not navigation.
+      expect(starts, 0);
+      expect(updates, 0);
+      expect(ends, 0);
+      expect(editor.canUndo, isTrue);
+    });
+
+    testWidgets('a pinch is reported as a zoom interaction', (tester) async {
+      var starts = 0;
+      var updates = 0;
+      var ends = 0;
+      await pumpZoomEditor(
+        tester,
+        boundaryMargin: const EdgeInsets.all(double.infinity),
+        paintEditorCallbacks: PaintEditorCallbacks(
+          onEditorZoomScaleStart: (_) => starts++,
+          onEditorZoomScaleUpdate: (_) => updates++,
+          onEditorZoomScaleEnd: (_) => ends++,
+        ),
+      );
+
+      final Offset center = tester.getCenter(find.byType(PaintCanvas));
+      final TestGesture first = await tester.startGesture(
+        center - const Offset(20, 0),
+      );
+      final TestGesture second = await tester.startGesture(
+        center + const Offset(20, 0),
+      );
+      for (var i = 0; i < 5; i++) {
+        await first.moveBy(const Offset(-10, 0));
+        await second.moveBy(const Offset(10, 0));
+        await tester.pump();
+      }
+      await first.up();
+      await second.up();
+      await tester.pump();
+
+      expect(starts, 1);
+      expect(updates, greaterThan(0));
+      expect(ends, 1);
     });
 
     testWidgets('right mouse button pans when click-drag pan is disabled', (

--- a/test/features/paint_editor/painting_canvas_test.dart
+++ b/test/features/paint_editor/painting_canvas_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 // Package imports:
@@ -122,5 +123,182 @@ void main() {
       // Assuming the paintMode didn't change
       expect(ctrl.mode, PaintMode.freeStyle);
     });
+
+    testWidgets('cancelActiveDrawing discards an in-progress stroke', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey<PaintCanvasState> canvasKey = GlobalKey();
+      var created = 0;
+      PaintController ctrl = PaintController(
+        color: Colors.red,
+        mode: PaintMode.freeStyle,
+        fill: false,
+        strokeWidth: 1,
+        strokeMultiplier: 1,
+        opacity: 1,
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: PaintCanvas(
+              layers: const [],
+              key: canvasKey,
+              drawAreaSize: const Size(1000, 1000),
+              editorBodySize: const Size(1000, 1000),
+              layerStackScaleFactor: 1,
+              paintCtrl: ctrl,
+              eraserMode: EraserMode.partial,
+              eraserRadius: 8.0,
+              paintEditorConfigs: const PaintEditorConfigs(),
+              onRefresh: () {},
+              onCreated: (PaintedModel item) {
+                created++;
+              },
+              onRemoveLayer: (List<String> value) {},
+              onRemovePartialStart: () {},
+              onRemovePartialEnd: (bool hasRemovedAreas) {},
+              onTap: (TapDownDetails details) {},
+            ),
+          ),
+        ),
+      );
+
+      Offset center = tester.getCenter(find.byKey(canvasKey));
+      final TestGesture gesture = await tester.startGesture(center);
+      await gesture.moveTo(center + const Offset(40, 40));
+      expect(ctrl.start, isNotNull);
+      expect(ctrl.offsets, isNotEmpty);
+
+      canvasKey.currentState!.cancelActiveDrawing();
+      expect(ctrl.start, isNull);
+      expect(ctrl.offsets, isEmpty);
+      expect(ctrl.busy, isFalse);
+
+      await gesture.moveTo(center + const Offset(80, 80));
+      await gesture.up();
+      expect(ctrl.start, isNull);
+      expect(created, 0);
+    });
+
+    testWidgets('right and middle mouse buttons do not start a stroke', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey<PaintCanvasState> canvasKey = GlobalKey();
+      var created = 0;
+      PaintController ctrl = PaintController(
+        color: Colors.red,
+        mode: PaintMode.freeStyle,
+        fill: false,
+        strokeWidth: 1,
+        strokeMultiplier: 1,
+        opacity: 1,
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: PaintCanvas(
+              layers: const [],
+              key: canvasKey,
+              drawAreaSize: const Size(1000, 1000),
+              editorBodySize: const Size(1000, 1000),
+              layerStackScaleFactor: 1,
+              paintCtrl: ctrl,
+              eraserMode: EraserMode.partial,
+              eraserRadius: 8.0,
+              paintEditorConfigs: const PaintEditorConfigs(enableZoom: true),
+              onRefresh: () {},
+              onCreated: (PaintedModel item) {
+                created++;
+              },
+              onRemoveLayer: (List<String> value) {},
+              onRemovePartialStart: () {},
+              onRemovePartialEnd: (bool hasRemovedAreas) {},
+              onTap: (TapDownDetails details) {},
+            ),
+          ),
+        ),
+      );
+
+      Offset center = tester.getCenter(find.byKey(canvasKey));
+      for (final int buttons in <int>[
+        kSecondaryMouseButton,
+        kMiddleMouseButton,
+      ]) {
+        final TestGesture gesture = await tester.startGesture(
+          center,
+          kind: PointerDeviceKind.mouse,
+          buttons: buttons,
+        );
+        await gesture.moveTo(center + const Offset(40, 40));
+        expect(ctrl.start, isNull);
+        expect(ctrl.offsets, isEmpty);
+        await gesture.up();
+        expect(created, 0);
+      }
+    });
+
+    testWidgets(
+      'right and middle mouse buttons still draw when the view cannot pan',
+      (WidgetTester tester) async {
+        for (final PaintEditorConfigs configs in <PaintEditorConfigs>[
+          const PaintEditorConfigs(),
+          const PaintEditorConfigs(
+            enableZoom: true,
+            enableZoomWhileDrawing: false,
+          ),
+        ]) {
+          final GlobalKey<PaintCanvasState> canvasKey = GlobalKey();
+          PaintController ctrl = PaintController(
+            color: Colors.red,
+            mode: PaintMode.freeStyle,
+            fill: false,
+            strokeWidth: 1,
+            strokeMultiplier: 1,
+            opacity: 1,
+          );
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: PaintCanvas(
+                  layers: const [],
+                  key: canvasKey,
+                  drawAreaSize: const Size(1000, 1000),
+                  editorBodySize: const Size(1000, 1000),
+                  layerStackScaleFactor: 1,
+                  paintCtrl: ctrl,
+                  eraserMode: EraserMode.partial,
+                  eraserRadius: 8.0,
+                  paintEditorConfigs: configs,
+                  onRefresh: () {},
+                  onCreated: (PaintedModel item) {},
+                  onRemoveLayer: (List<String> value) {},
+                  onRemovePartialStart: () {},
+                  onRemovePartialEnd: (bool hasRemovedAreas) {},
+                  onTap: (TapDownDetails details) {},
+                ),
+              ),
+            ),
+          );
+
+          Offset center = tester.getCenter(find.byKey(canvasKey));
+          for (final int buttons in <int>[
+            kSecondaryMouseButton,
+            kMiddleMouseButton,
+          ]) {
+            ctrl
+              ..setInProgress(false)
+              ..reset();
+            final TestGesture gesture = await tester.startGesture(
+              center,
+              kind: PointerDeviceKind.mouse,
+              buttons: buttons,
+            );
+            await gesture.moveTo(center + const Offset(40, 40));
+            expect(ctrl.start, isNotNull);
+            await gesture.up();
+          }
+        }
+      },
+    );
   });
 }

--- a/test/features/paint_editor/painting_canvas_test.dart
+++ b/test/features/paint_editor/painting_canvas_test.dart
@@ -205,7 +205,10 @@ void main() {
               paintCtrl: ctrl,
               eraserMode: EraserMode.partial,
               eraserRadius: 8.0,
-              paintEditorConfigs: const PaintEditorConfigs(enableZoom: true),
+              paintEditorConfigs: const PaintEditorConfigs(
+                enableZoom: true,
+                enableZoomWhileDrawing: true,
+              ),
               onRefresh: () {},
               onCreated: (PaintedModel item) {
                 created++;

--- a/test/features/paint_editor/painting_canvas_test.dart
+++ b/test/features/paint_editor/painting_canvas_test.dart
@@ -240,6 +240,85 @@ void main() {
       }
     });
 
+    testWidgets('an auxiliary button pressed mid-stroke discards the stroke', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey<PaintCanvasState> canvasKey = GlobalKey();
+      var created = 0;
+      PaintController ctrl = PaintController(
+        color: Colors.red,
+        mode: PaintMode.freeStyle,
+        fill: false,
+        strokeWidth: 1,
+        strokeMultiplier: 1,
+        opacity: 1,
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: PaintCanvas(
+              layers: const [],
+              key: canvasKey,
+              drawAreaSize: const Size(1000, 1000),
+              editorBodySize: const Size(1000, 1000),
+              layerStackScaleFactor: 1,
+              paintCtrl: ctrl,
+              eraserMode: EraserMode.partial,
+              eraserRadius: 8.0,
+              paintEditorConfigs: const PaintEditorConfigs(
+                enableZoom: true,
+                enableZoomWhileDrawing: true,
+              ),
+              onRefresh: () {},
+              onCreated: (PaintedModel item) {
+                created++;
+              },
+              onRemoveLayer: (List<String> value) {},
+              onRemovePartialStart: () {},
+              onRemovePartialEnd: (bool hasRemovedAreas) {},
+              onTap: (TapDownDetails details) {},
+            ),
+          ),
+        ),
+      );
+
+      final Offset center = tester.getCenter(find.byKey(canvasKey));
+      final TestPointer pointer = TestPointer(
+        1,
+        PointerDeviceKind.mouse,
+        null,
+        kPrimaryMouseButton,
+      );
+      await tester.sendEventToBinding(pointer.down(center));
+      await tester.sendEventToBinding(
+        pointer.move(center + const Offset(30, 30)),
+      );
+      expect(ctrl.offsets, isNotEmpty);
+
+      // Pressing a second mouse button mid-drag arrives as a move event with
+      // the extra button set, not as a new pointer.
+      await tester.sendEventToBinding(
+        pointer.move(
+          center + const Offset(60, 60),
+          buttons: kPrimaryMouseButton | kSecondaryMouseButton,
+        ),
+      );
+      expect(ctrl.start, isNull);
+      expect(ctrl.offsets, isEmpty);
+
+      // Releasing the auxiliary button must not resume the discarded stroke
+      // with a jump.
+      await tester.sendEventToBinding(
+        pointer.move(
+          center + const Offset(90, 90),
+          buttons: kPrimaryMouseButton,
+        ),
+      );
+      expect(ctrl.offsets, isEmpty);
+      await tester.sendEventToBinding(pointer.up());
+      expect(created, 0);
+    });
+
     testWidgets(
       'right and middle mouse buttons still draw when the view cannot pan',
       (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Hello,

This PR is to allow navigating the paint editor while a drawing tool is active. This has been AI-assisted, but I tested myself.

Pinch, trackpad, and mouse-wheel still move the view; primary click-drag still draws. Secondary and middle mouse buttons pan, matching the main editor. An in-progress stroke is discarded if the view moves so path coordinates stay in one transform space.

Disable with `PaintEditorConfigs.enableZoomWhileDrawing: false` (also restores every mouse button drawing).

By default, the library behaves like it was before this PR. Flag needs to be set to true to benefit from this.

### Implementation:

- Drawing already used a Listener on the canvas (that was upstream, for stylus latency). We only skip secondary/middle there when zoom-while-drawing is on.
- Right/middle pan is a Listener on the viewer (onPointerDown / Move / Up), because GestureDetector pan is tied to left-drag (panEnabled).
- Pinch, trackpad, wheel still go through the viewer’s existing GestureDetector / pointer-signal path, with scale enabled independently of pan.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore