### PR TITLE
feat(helper-lines): allow softer helper lines without edge snap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 13.4.0
 - **FEAT**(paint-editor): Navigate while a drawing tool is active via `PaintEditorConfigs.enableZoomWhileDrawing` (opt-in). Pinch, trackpad and mouse wheel zoom; secondary/middle mouse buttons pan.
+- **FEAT**(helper-lines): Add `HelperLineConfigs.enableEdgeSnapping` to let text and paint layers snap from their center only instead of from every edge.
 
 ## 13.3.1
 - **FIX**(crop-rotate): Crop handles no longer jump onto the finger when a drag starts; the gesture slop and the distance to the grabbed handle are compensated.

--- a/lib/core/models/editor_configs/helper_lines_configs.dart
+++ b/lib/core/models/editor_configs/helper_lines_configs.dart
@@ -16,6 +16,7 @@ class HelperLineConfigs {
     this.showRotateLine = true,
     this.showLayerAlignLine = true,
     this.isDisabledAtZoom = false,
+    this.enableEdgeSnapping = true,
     this.releaseThreshold = 10.0,
     this.customGuides = const [],
     this.style = const HelperLineStyle(),
@@ -41,6 +42,11 @@ class HelperLineConfigs {
   /// If set to `false`, helper lines will remain visible regardless of the
   /// zoom level.
   final bool isDisabledAtZoom;
+
+  /// When `true`, text and paint layers also snap on their visible edges
+  /// (left/center/right and top/center/bottom). When `false`, every layer
+  /// snaps from its center only.
+  final bool enableEdgeSnapping;
 
   /// Style configuration for helper lines.
   final HelperLineStyle style;
@@ -69,6 +75,7 @@ class HelperLineConfigs {
     bool? showRotateLine,
     bool? showLayerAlignLine,
     bool? isDisabledAtZoom,
+    bool? enableEdgeSnapping,
     double? releaseThreshold,
     List<HelperGuideLine>? customGuides,
     HelperLineStyle? style,
@@ -79,6 +86,7 @@ class HelperLineConfigs {
       showRotateLine: showRotateLine ?? this.showRotateLine,
       showLayerAlignLine: showLayerAlignLine ?? this.showLayerAlignLine,
       isDisabledAtZoom: isDisabledAtZoom ?? this.isDisabledAtZoom,
+      enableEdgeSnapping: enableEdgeSnapping ?? this.enableEdgeSnapping,
       releaseThreshold: releaseThreshold ?? this.releaseThreshold,
       customGuides: customGuides ?? this.customGuides,
       style: style ?? this.style,

--- a/lib/features/main_editor/services/layer_interaction_manager.dart
+++ b/lib/features/main_editor/services/layer_interaction_manager.dart
@@ -517,7 +517,8 @@ class LayerInteractionManager {
   /// right and top/center/bottom); all other layer types expose only their
   /// configured center anchor.
   bool _supportsEdgeSnapping(Layer layer) =>
-      layer is TextLayer || layer is PaintLayer;
+      helperLineConfigs.enableEdgeSnapping &&
+      (layer is TextLayer || layer is PaintLayer);
 
   /// Returns the candidate horizontal snap anchors for [layer] in
   /// center-relative editor coordinates.


### PR DESCRIPTION
## Description

Hello, after struggling with helper lines, I submit a PR to soften the pull. This PR is AI-assisted but manually tested.

After #852, text and paint layers snap on every edge (left/center/right and top/center/bottom). That is great for a few boxes, but a page of labels turns into a magnet field — you fight the same guide three times, then every neighbor.

This adds `HelperLineConfigs.enableEdgeSnapping` (default `true`, so nothing changes unless you opt out). Set it to `false` and every layer snaps from its center only. The guides still show; they just do not lock onto every edge.

**Related Issue:** Closes #

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore