### PR TITLE
refactor(ui): migrate to standalone material_ui and cupertino_ui pack…

### DIFF
--- a/example/lib/core/constants/example_list_constant.dart
+++ b/example/lib/core/constants/example_list_constant.dart
@@ -1,5 +1,5 @@
 import 'package:example/features/layer/layer_group_page.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/features/ai/ai_group_page.dart';
 import '/features/crop_to_main_editor.dart';

--- a/example/lib/core/mixin/example_helper.dart
+++ b/example/lib/core/mixin/example_helper.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:vibration/vibration.dart';
 

--- a/example/lib/features/ai/ai_group_page.dart
+++ b/example/lib/features/ai/ai_group_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'ai_replace_background/ai_replace_background_page_example.dart';
 import 'ai_text_commands/ai_text_commands_page_example.dart';

--- a/example/lib/features/ai/ai_replace_background/ai_replace_background_page_example.dart
+++ b/example/lib/features/ai/ai_replace_background/ai_replace_background_page_example.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 import 'dart:math';
 
-import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 import '/core/constants/example_constants.dart';

--- a/example/lib/features/ai/ai_replace_background/widgets/ai_replace_background_toolbar_widget.dart
+++ b/example/lib/features/ai/ai_replace_background/widgets/ai_replace_background_toolbar_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A stateless widget for inputting and sending AI text commands.
 class AiReplaceBackgroundToolbarWidget extends StatelessWidget {

--- a/example/lib/features/ai/ai_text_commands/ai_text_commands_page_example.dart
+++ b/example/lib/features/ai/ai_text_commands/ai_text_commands_page_example.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 import '/core/constants/example_constants.dart';

--- a/example/lib/features/ai/ai_text_commands/providers/ai_message_base_provider.dart
+++ b/example/lib/features/ai/ai_text_commands/providers/ai_message_base_provider.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 import '../enum/ai_provider_enum.dart';

--- a/example/lib/features/ai/ai_text_commands/providers/ai_message_gemini_provider.dart
+++ b/example/lib/features/ai/ai_text_commands/providers/ai_message_gemini_provider.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 import '../enum/ai_provider_enum.dart';

--- a/example/lib/features/ai/ai_text_commands/providers/ai_message_open_ai_provider.dart
+++ b/example/lib/features/ai/ai_text_commands/providers/ai_message_open_ai_provider.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 import '../enum/ai_provider_enum.dart';

--- a/example/lib/features/ai/ai_text_commands/widgets/ai_command_input_widget.dart
+++ b/example/lib/features/ai/ai_text_commands/widgets/ai_command_input_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../enum/ai_generation_mode_enum.dart';
 

--- a/example/lib/features/ai/ai_text_commands/widgets/ai_command_toolbar_widget.dart
+++ b/example/lib/features/ai/ai_text_commands/widgets/ai_command_toolbar_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../enum/ai_generation_mode_enum.dart';
 import '../widgets/ai_command_input_widget.dart';

--- a/example/lib/features/ai/ai_text_commands/widgets/ai_example_commands_widget.dart
+++ b/example/lib/features/ai/ai_text_commands/widgets/ai_example_commands_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/shared/services/shader_manager.dart';
 
 /// A widget that displays a list of example AI text commands for image editing.

--- a/example/lib/features/ai/ai_text_commands/widgets/ai_setup_widget.dart
+++ b/example/lib/features/ai/ai_text_commands/widgets/ai_setup_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../enum/ai_provider_enum.dart';
 

--- a/example/lib/features/ai/background_remover/background_remover_example.dart
+++ b/example/lib/features/ai/background_remover/background_remover_example.dart
@@ -2,9 +2,9 @@
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:image_background_remover/image_background_remover.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 // Project imports:

--- a/example/lib/features/ai/background_remover/background_remover_stub_example.dart
+++ b/example/lib/features/ai/background_remover/background_remover_stub_example.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/mixin/example_helper.dart';

--- a/example/lib/features/crop_to_main_editor.dart
+++ b/example/lib/features/crop_to_main_editor.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/custom_guide_lines_example.dart
+++ b/example/lib/features/custom_guide_lines_example.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/custom_path_builder_example.dart
+++ b/example/lib/features/custom_path_builder_example.dart
@@ -1,7 +1,7 @@
 // Flutter imports:
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/custom_widgets_example.dart
+++ b/example/lib/features/custom_widgets_example.dart
@@ -1,11 +1,10 @@
 // Dart imports:
 import 'dart:math';
 
-// Flutter imports:
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:google_fonts/google_fonts.dart';
+// Flutter imports:
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 // Project imports:

--- a/example/lib/features/default_example.dart
+++ b/example/lib/features/default_example.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 import '/core/constants/example_constants.dart';

--- a/example/lib/features/design_examples/design_example.dart
+++ b/example/lib/features/design_examples/design_example.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 import '/core/constants/example_constants.dart';

--- a/example/lib/features/design_examples/frosted_glass_example.dart
+++ b/example/lib/features/design_examples/frosted_glass_example.dart
@@ -2,8 +2,8 @@
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/designs/frosted_glass/frosted_glass.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 

--- a/example/lib/features/design_examples/grounded_example.dart
+++ b/example/lib/features/design_examples/grounded_example.dart
@@ -2,10 +2,9 @@
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:google_fonts/google_fonts.dart';
-
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/designs/grounded/grounded_design.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 

--- a/example/lib/features/design_examples/highly_configurable_example.dart
+++ b/example/lib/features/design_examples/highly_configurable_example.dart
@@ -1,9 +1,8 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
 // Package imports:
 import 'package:google_fonts/google_fonts.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 // Project imports:

--- a/example/lib/features/design_examples/whatsapp_example.dart
+++ b/example/lib/features/design_examples/whatsapp_example.dart
@@ -4,9 +4,9 @@ import 'dart:math';
 // Flutter imports:
 import 'package:example/shared/widgets/demo_build_stickers.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 // Package imports:
 import 'package:google_fonts/google_fonts.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/designs/whatsapp/whatsapp.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 

--- a/example/lib/features/emoji_translate_example.dart
+++ b/example/lib/features/emoji_translate_example.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 import '/core/constants/example_constants.dart';

--- a/example/lib/features/firebase_supabase_example.dart
+++ b/example/lib/features/firebase_supabase_example.dart
@@ -1,7 +1,7 @@
 // Package imports:
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 

--- a/example/lib/features/frame_example.dart
+++ b/example/lib/features/frame_example.dart
@@ -3,11 +3,11 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_image_editor/shared/utils/transparent_image_generator_utils.dart';
 

--- a/example/lib/features/generation_configs_example.dart
+++ b/example/lib/features/generation_configs_example.dart
@@ -1,8 +1,8 @@
 // Flutter imports:
 import 'dart:ui' as ui;
 
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/google_font_example.dart
+++ b/example/lib/features/google_font_example.dart
@@ -3,10 +3,9 @@ import 'dart:io';
 
 // Flutter imports:
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:google_fonts/google_fonts.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 // Project imports:

--- a/example/lib/features/image_format_convert_example.dart
+++ b/example/lib/features/image_format_convert_example.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 // Flutter imports:
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/import_export_example.dart
+++ b/example/lib/features/import_export_example.dart
@@ -1,5 +1,5 @@
 import 'package:example/core/constants/example_constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 import '/core/constants/history_demo/import_history_6_3_0_minified.dart';

--- a/example/lib/features/layer/layer_export_example.dart
+++ b/example/lib/features/layer/layer_export_example.dart
@@ -1,7 +1,7 @@
 // Flutter imports:
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/layer/layer_group_page.dart
+++ b/example/lib/features/layer/layer_group_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/features/layer/layer_export_example.dart';
 import '/features/layer/layer_grouping_example.dart';

--- a/example/lib/features/layer/layer_grouping_example.dart
+++ b/example/lib/features/layer/layer_grouping_example.dart
@@ -1,5 +1,5 @@
 import 'package:example/core/constants/example_constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_image_editor/shared/widgets/layer/interaction_helper/layer_interaction_button.dart';
 

--- a/example/lib/features/layer/layer_rasterizer_example.dart
+++ b/example/lib/features/layer/layer_rasterizer_example.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/layer/layer_select_design_example.dart
+++ b/example/lib/features/layer/layer_select_design_example.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/designs/layer_selection/float_select/float_select.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 

--- a/example/lib/features/layer/selectable_layer_example.dart
+++ b/example/lib/features/layer/selectable_layer_example.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/movable_background_image.dart
+++ b/example/lib/features/movable_background_image.dart
@@ -1,6 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+
 import '/core/mixin/example_helper.dart';
 import '/shared/widgets/pixel_transparent_painter.dart';
 

--- a/example/lib/features/pick_image_example.dart
+++ b/example/lib/features/pick_image_example.dart
@@ -3,10 +3,9 @@ import 'dart:io';
 
 // Flutter imports:
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:image_picker/image_picker.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 // Project imports:

--- a/example/lib/features/preview/preview_img.dart
+++ b/example/lib/features/preview/preview_img.dart
@@ -6,9 +6,9 @@ import 'dart:ui' as ui;
 import 'package:bot_toast/bot_toast.dart';
 import 'package:file_saver/file_saver.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:gal/gal.dart';
 import 'package:intl/intl.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:mime/mime.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 

--- a/example/lib/features/preview/preview_video.dart
+++ b/example/lib/features/preview/preview_video.dart
@@ -1,8 +1,8 @@
 import 'dart:math';
 import 'dart:ui' as ui;
 
-import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/reorder_layer_example.dart
+++ b/example/lib/features/reorder_layer_example.dart
@@ -1,7 +1,7 @@
 // Flutter imports:
 import 'package:example/core/constants/example_constants.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/round_cropper_example.dart
+++ b/example/lib/features/round_cropper_example.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
 import 'package:example/core/constants/example_constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/signature_drawing_example.dart
+++ b/example/lib/features/signature_drawing_example.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/standalone_example.dart
+++ b/example/lib/features/standalone_example.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
 import 'package:example/core/constants/example_constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/stickers_example.dart
+++ b/example/lib/features/stickers_example.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/video_examples/mixins/video_editor_mixin.dart
+++ b/example/lib/features/video_examples/mixins/video_editor_mixin.dart
@@ -6,7 +6,7 @@ import 'package:example/features/preview/preview_video.dart';
 import 'package:example/shared/widgets/video_progress_alert.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:pro_image_editor/core/platform/io/io_helper.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/features/video_examples/pages/chewie_player_example.dart
+++ b/example/lib/features/video_examples/pages/chewie_player_example.dart
@@ -1,5 +1,5 @@
 import 'package:chewie/chewie.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:video_player/video_player.dart';

--- a/example/lib/features/video_examples/pages/flick_video_player_example.dart
+++ b/example/lib/features/video_examples/pages/flick_video_player_example.dart
@@ -1,5 +1,5 @@
 import 'package:flick_video_player/flick_video_player.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:video_player/video_player.dart';

--- a/example/lib/features/video_examples/pages/video_media_kit_example.dart
+++ b/example/lib/features/video_examples/pages/video_media_kit_example.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 import 'package:path_provider/path_provider.dart';

--- a/example/lib/features/video_examples/pages/video_player_example.dart
+++ b/example/lib/features/video_examples/pages/video_player_example.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:example/core/constants/example_constants.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:video_player/video_player.dart';
 

--- a/example/lib/features/video_examples/video_example.dart
+++ b/example/lib/features/video_examples/video_example.dart
@@ -1,6 +1,6 @@
 import 'package:example/shared/widgets/paragraph_info_widget.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/platform/io/io_helper.dart';
 
 import '/core/mixin/example_helper.dart';

--- a/example/lib/features/video_examples/widgets/video_initializing_widget.dart
+++ b/example/lib/features/video_examples/widgets/video_initializing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A widget that displays a initializing screen when the video editor startup.
 class VideoInitializingWidget extends StatelessWidget {

--- a/example/lib/features/zoom_example.dart
+++ b/example/lib/features/zoom_example.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Package imports:
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,10 +1,9 @@
 import 'package:bot_toast/bot_toast.dart';
 import 'package:example/shared/widgets/not_found_example.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:media_kit/media_kit.dart';
-
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';

--- a/example/lib/shared/widgets/demo_build_stickers.dart
+++ b/example/lib/shared/widgets/demo_build_stickers.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 /// A widget that demonstrates the building of sticker categories and displays

--- a/example/lib/shared/widgets/material_icon_button.dart
+++ b/example/lib/shared/widgets/material_icon_button.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A stateless widget that displays a material-styled icon button with a custom
 /// circular background, half of which is a secondary color. Below the icon,

--- a/example/lib/shared/widgets/not_found_example.dart
+++ b/example/lib/shared/widgets/not_found_example.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A widget that displays a centered "Example not found" message.
 ///

--- a/example/lib/shared/widgets/prepare_image_widget.dart
+++ b/example/lib/shared/widgets/prepare_image_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A widget that displays a loading screen with a progress indicator and a
 /// message.

--- a/example/lib/shared/widgets/video_progress_alert.dart
+++ b/example/lib/shared/widgets/video_progress_alert.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -15,6 +15,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
   onnxruntime
 )
 

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -42,7 +42,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ProVideoEditorPlugin.register(with: registry.registrar(forPlugin: "ProVideoEditorPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
-  FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
+  VideoPlayerPlugin.register(with: registry.registrar(forPlugin: "VideoPlayerPlugin"))
   VolumeControllerPlugin.register(with: registry.registrar(forPlugin: "VolumeControllerPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -45,6 +45,8 @@ dependencies:
   media_kit_video: ^1.3.0 # For video rendering.
   media_kit_libs_video: ^1.0.6 # Native video dependencies.
 
+  material_ui: any
+  cupertino_ui: any
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -18,6 +18,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
   onnxruntime
 )
 

--- a/lib/core/mixins/editor_callbacks_mixin.dart
+++ b/lib/core/mixins/editor_callbacks_mixin.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../enums/editor_mode.dart';
 import '../models/editor_callbacks/pro_image_editor_callbacks.dart';

--- a/lib/core/mixins/editor_configs_mixin.dart
+++ b/lib/core/mixins/editor_configs_mixin.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '../models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/core/mixins/standalone_editor.dart
+++ b/lib/core/mixins/standalone_editor.dart
@@ -1,8 +1,8 @@
 // Dart imports:
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/models/complete_parameters.dart';

--- a/lib/core/models/editor_configs/crop_rotate_editor_configs.dart
+++ b/lib/core/models/editor_configs/crop_rotate_editor_configs.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/features/crop_rotate_editor/enums/crop_mode.enum.dart';
 import '/features/crop_rotate_editor/enums/crop_tool_enum.dart';

--- a/lib/core/models/editor_configs/pro_image_editor_configs.dart
+++ b/lib/core/models/editor_configs/pro_image_editor_configs.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/constants/editor_various_constants.dart';
 // Project imports:

--- a/lib/core/models/editor_configs/text_editor_configs.dart
+++ b/lib/core/models/editor_configs/text_editor_configs.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '../custom_widgets/text_editor_widgets.dart';

--- a/lib/core/models/editor_image.dart
+++ b/lib/core/models/editor_image.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/platform/io/io_helper.dart';
 import '/shared/utils/converters.dart';

--- a/lib/core/models/icons/audio_editor_icons.dart
+++ b/lib/core/models/icons/audio_editor_icons.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Defines icon configurations for the audio editor.
 class AudioEditorIcons {

--- a/lib/core/models/icons/blur_editor_icons.dart
+++ b/lib/core/models/icons/blur_editor_icons.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Customizable icons for the Blur Editor component.
 class BlurEditorIcons {

--- a/lib/core/models/icons/clips_editor_icons.dart
+++ b/lib/core/models/icons/clips_editor_icons.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Defines icon configurations for the Video Clips editor.
 class ClipsEditorIcons {

--- a/lib/core/models/icons/crop_rotate_editor_icons.dart
+++ b/lib/core/models/icons/crop_rotate_editor_icons.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Customizable icons for the Crop/Rotate Editor component.
 class CropRotateEditorIcons {

--- a/lib/core/models/icons/emoji_editor_icons.dart
+++ b/lib/core/models/icons/emoji_editor_icons.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Customizable icons for the Emoji Editor component.
 class EmojiEditorIcons {

--- a/lib/core/models/icons/filter_editor_icons.dart
+++ b/lib/core/models/icons/filter_editor_icons.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Customizable icons for the Filter Editor component.
 class FilterEditorIcons {

--- a/lib/core/models/icons/layer_interaction_icons.dart
+++ b/lib/core/models/icons/layer_interaction_icons.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Represents the interaction icons for layers in the theme.
 ///

--- a/lib/core/models/icons/main_editor_icons.dart
+++ b/lib/core/models/icons/main_editor_icons.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Customizable icons for Main-Editor component.
 class MainEditorIcons {

--- a/lib/core/models/icons/paint_editor_icons.dart
+++ b/lib/core/models/icons/paint_editor_icons.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Customizable icons for the Paint Editor component.
 class PaintEditorIcons {

--- a/lib/core/models/icons/sticker_editor_icons.dart
+++ b/lib/core/models/icons/sticker_editor_icons.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/ui/pro_image_editor_icons.dart';

--- a/lib/core/models/icons/text_editor_icons.dart
+++ b/lib/core/models/icons/text_editor_icons.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Customizable icons for the Text Editor component.
 class TextEditorIcons {

--- a/lib/core/models/icons/tune_editor_icons.dart
+++ b/lib/core/models/icons/tune_editor_icons.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A configuration class for defining icons used in the Tune Editor.
 ///

--- a/lib/core/models/icons/video_editor_icons.dart
+++ b/lib/core/models/icons/video_editor_icons.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Defines icon configurations for the video editor.
 class VideoEditorIcons {

--- a/lib/core/models/init_configs/editor_init_configs.dart
+++ b/lib/core/models/init_configs/editor_init_configs.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/features/filter_editor/types/filter_matrix.dart';
 import '/features/tune_editor/models/tune_adjustment_matrix.dart';

--- a/lib/core/models/layers/layer.dart
+++ b/lib/core/models/layers/layer.dart
@@ -4,8 +4,8 @@ import 'dart:ui' as ui;
 
 // Flutter imports:
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/constants/int_constants.dart';
 import '/core/models/editor_configs/image_generation_configs/image_generation_configs.dart';

--- a/lib/core/models/styles/layer_interaction_style.dart
+++ b/lib/core/models/styles/layer_interaction_style.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Represents the interaction settings for layers in the style.
 ///

--- a/lib/core/models/styles/text_editor_style.dart
+++ b/lib/core/models/styles/text_editor_style.dart
@@ -1,7 +1,7 @@
 // Flutter imports:
 import 'dart:ui' as ui;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../constants/editor_style_constants.dart';
 

--- a/lib/core/models/styles/video_editor_style.dart
+++ b/lib/core/models/styles/video_editor_style.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Defines style configurations for the video editor.
 class VideoEditorStyle {

--- a/lib/designs/frosted_glass/widgets/appbar/frosted_glass_appbar.dart
+++ b/lib/designs/frosted_glass/widgets/appbar/frosted_glass_appbar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/pro_image_editor.dart';
 import '../../frosted_glass.dart';

--- a/lib/designs/frosted_glass/widgets/appbar/frosted_glass_audio_appbar.dart
+++ b/lib/designs/frosted_glass/widgets/appbar/frosted_glass_audio_appbar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/features/audio_editor/audio_editor_page.dart';

--- a/lib/designs/frosted_glass/widgets/appbar/frosted_glass_blur_appbar.dart
+++ b/lib/designs/frosted_glass/widgets/appbar/frosted_glass_blur_appbar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/features/blur_editor/blur_editor.dart';

--- a/lib/designs/frosted_glass/widgets/appbar/frosted_glass_clip_edit_appbar.dart
+++ b/lib/designs/frosted_glass/widgets/appbar/frosted_glass_clip_edit_appbar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/features/clips_editor/pages/clips_editor_edit_page.dart';

--- a/lib/designs/frosted_glass/widgets/appbar/frosted_glass_clips_appbar.dart
+++ b/lib/designs/frosted_glass/widgets/appbar/frosted_glass_clips_appbar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/features/clips_editor/pages/clips_editor_page.dart';

--- a/lib/designs/frosted_glass/widgets/appbar/frosted_glass_filter_appbar.dart
+++ b/lib/designs/frosted_glass/widgets/appbar/frosted_glass_filter_appbar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '../../../../pro_image_editor.dart';

--- a/lib/designs/frosted_glass/widgets/appbar/frosted_glass_paint_appbar.dart
+++ b/lib/designs/frosted_glass/widgets/appbar/frosted_glass_paint_appbar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '../../../../pro_image_editor.dart';

--- a/lib/designs/frosted_glass/widgets/appbar/frosted_glass_text_appbar.dart
+++ b/lib/designs/frosted_glass/widgets/appbar/frosted_glass_text_appbar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/features/text_editor/text_editor.dart';

--- a/lib/designs/frosted_glass/widgets/appbar/frosted_glass_tune_appbar.dart
+++ b/lib/designs/frosted_glass/widgets/appbar/frosted_glass_tune_appbar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/features/tune_editor/tune_editor.dart';

--- a/lib/designs/frosted_glass/widgets/bottombar/frosted_glass_paint_bottombar.dart
+++ b/lib/designs/frosted_glass/widgets/bottombar/frosted_glass_paint_bottombar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/ui/pro_image_editor_icons.dart';
 import '/designs/frosted_glass/frosted_glass.dart';

--- a/lib/designs/frosted_glass/widgets/bottombar/frosted_glass_text_bottombar.dart
+++ b/lib/designs/frosted_glass/widgets/bottombar/frosted_glass_text_bottombar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/features/text_editor/widgets/text_editor_bottom_bar.dart';

--- a/lib/designs/frosted_glass/widgets/bottombar/frosted_glass_tune_bottombar.dart
+++ b/lib/designs/frosted_glass/widgets/bottombar/frosted_glass_tune_bottombar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/constants/editor_style_constants.dart';
 import '/features/tune_editor/tune_editor.dart';

--- a/lib/designs/frosted_glass/widgets/frosted_glass_close_dialog.dart
+++ b/lib/designs/frosted_glass/widgets/frosted_glass_close_dialog.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/pro_image_editor.dart';

--- a/lib/designs/frosted_glass/widgets/frosted_glass_crop_rotate_toolbar.dart
+++ b/lib/designs/frosted_glass/widgets/frosted_glass_crop_rotate_toolbar.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/pro_image_editor.dart';
 import '../frosted_glass.dart';

--- a/lib/designs/frosted_glass/widgets/frosted_glass_effect.dart
+++ b/lib/designs/frosted_glass/widgets/frosted_glass_effect.dart
@@ -2,7 +2,7 @@
 import 'dart:ui';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A stateless widget that applies a frosted glass effect to its child widget.
 ///

--- a/lib/designs/frosted_glass/widgets/frosted_glass_loading_dialog.dart
+++ b/lib/designs/frosted_glass/widgets/frosted_glass_loading_dialog.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/pro_image_editor.dart';
 import 'frosted_glass_effect.dart';

--- a/lib/designs/frosted_glass/widgets/frosted_glass_sticker_editor.dart
+++ b/lib/designs/frosted_glass/widgets/frosted_glass_sticker_editor.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/designs/frosted_glass/widgets/frosted_glass_text_size_slider.dart
+++ b/lib/designs/frosted_glass/widgets/frosted_glass_text_size_slider.dart
@@ -2,7 +2,7 @@
 import 'dart:math';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/pro_image_editor.dart';
 

--- a/lib/designs/grounded/widgets/bottombar/grounded_audio_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_audio_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';

--- a/lib/designs/grounded/widgets/bottombar/grounded_blur_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_blur_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';
@@ -61,9 +61,7 @@ class _GroundedBlurBarState extends State<GroundedBlurBar>
       child: FadeInUp(
         duration: kGroundedFadeInDuration,
         child: Slider(
-          onChanged: (value) {
-            widget.editor.setBlurFactor(value);
-          },
+          onChanged: widget.editor.setBlurFactor,
           value: widget.editor.blurFactor,
           max: blurEditorConfigs.maxBlur,
           activeColor: Colors.blue.shade200,

--- a/lib/designs/grounded/widgets/bottombar/grounded_bottom_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_bottom_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 
 /// A widget that represents the bottom action bar in the image editor.

--- a/lib/designs/grounded/widgets/bottombar/grounded_clip_edit_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_clip_edit_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';

--- a/lib/designs/grounded/widgets/bottombar/grounded_clips_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_clips_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';

--- a/lib/designs/grounded/widgets/bottombar/grounded_crop_rotate_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_crop_rotate_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';
@@ -169,9 +169,7 @@ class _GroundedCropRotateBarState extends State<GroundedCropRotateBar>
           cropRotateEditorConfigs.icons.rotate,
           color: _foreGroundColor,
         ),
-        onPressed: () {
-          widget.editor.rotate();
-        },
+        onPressed: widget.editor.rotate,
       ),
       FlatIconTextButton(
         label: Text(
@@ -179,9 +177,7 @@ class _GroundedCropRotateBarState extends State<GroundedCropRotateBar>
           style: TextStyle(fontSize: 10.0, color: _foreGroundColorAccent),
         ),
         icon: Icon(cropRotateEditorConfigs.icons.flip, color: _foreGroundColor),
-        onPressed: () {
-          widget.editor.flip();
-        },
+        onPressed: widget.editor.flip,
       ),
     ];
   }

--- a/lib/designs/grounded/widgets/bottombar/grounded_filter_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_filter_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';
@@ -133,9 +133,7 @@ class _GroundedFilterBarState extends State<GroundedFilterBar>
               configs: configs,
               transformConfigs: widget.editor.initialTransformConfigs,
               selectedFilter: widget.editor.selectedFilter.filters,
-              onSelectFilter: (filter) {
-                widget.editor.setFilter(filter);
-              },
+              onSelectFilter: widget.editor.setFilter,
             ),
           ),
         ],

--- a/lib/designs/grounded/widgets/bottombar/grounded_main_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_main_bar.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';

--- a/lib/designs/grounded/widgets/bottombar/grounded_paint_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_paint_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';
@@ -190,9 +190,7 @@ class _GroundedPaintBarState extends State<GroundedPaintBar>
           paintEditorConfigs.icons.lineWeight,
           color: _foreGroundColor,
         ),
-        onPressed: () {
-          widget.editor.openLinWidthBottomSheet();
-        },
+        onPressed: widget.editor.openLinWidthBottomSheet,
       ),
       FlatIconTextButton(
         label: Text(
@@ -203,9 +201,7 @@ class _GroundedPaintBarState extends State<GroundedPaintBar>
           paintEditorConfigs.icons.changeOpacity,
           color: _foreGroundColor,
         ),
-        onPressed: () {
-          widget.editor.openOpacityBottomSheet();
-        },
+        onPressed: widget.editor.openOpacityBottomSheet,
       ),
       AnimatedSwitcher(
         duration: const Duration(milliseconds: 220),
@@ -236,9 +232,7 @@ class _GroundedPaintBarState extends State<GroundedPaintBar>
                         : paintEditorConfigs.icons.noFill,
                     color: _foreGroundColor,
                   ),
-                  onPressed: () {
-                    widget.editor.toggleFill();
-                  },
+                  onPressed: widget.editor.toggleFill,
                 ),
               )
             : const SizedBox.shrink(),

--- a/lib/designs/grounded/widgets/bottombar/grounded_text_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_text_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';
@@ -168,9 +168,7 @@ class _GroundedTextBarState extends State<GroundedTextBar>
           TextAlign.right => textEditorConfigs.icons.alignRight,
           TextAlign.center || _ => textEditorConfigs.icons.alignCenter,
         }, color: _foreGroundColor),
-        onPressed: () {
-          widget.editor.toggleTextAlign();
-        },
+        onPressed: widget.editor.toggleTextAlign,
       ),
       FlatIconTextButton(
         label: Text(
@@ -181,9 +179,7 @@ class _GroundedTextBarState extends State<GroundedTextBar>
           textEditorConfigs.icons.backgroundMode,
           color: _foreGroundColor,
         ),
-        onPressed: () {
-          widget.editor.toggleBackgroundMode();
-        },
+        onPressed: widget.editor.toggleBackgroundMode,
       ),
     ];
   }

--- a/lib/designs/grounded/widgets/bottombar/grounded_tune_bar.dart
+++ b/lib/designs/grounded/widgets/bottombar/grounded_tune_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';

--- a/lib/designs/grounded/widgets/grounded_bottom_wrapper.dart
+++ b/lib/designs/grounded/widgets/grounded_bottom_wrapper.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A wrapper widget that provides a themed layout for bottom UI components.
 ///

--- a/lib/designs/grounded/widgets/grounded_emoji_editor.dart
+++ b/lib/designs/grounded/widgets/grounded_emoji_editor.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';

--- a/lib/designs/grounded/widgets/grounded_loading_dialog.dart
+++ b/lib/designs/grounded/widgets/grounded_loading_dialog.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/pro_image_editor.dart';
 import '../../frosted_glass/widgets/frosted_glass_effect.dart';

--- a/lib/designs/grounded/widgets/grounded_sticker_editor.dart
+++ b/lib/designs/grounded/widgets/grounded_sticker_editor.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/pro_image_editor.dart';
 import '../../frosted_glass/frosted_glass.dart';

--- a/lib/designs/grounded/widgets/grounded_text_size_slider.dart
+++ b/lib/designs/grounded/widgets/grounded_text_size_slider.dart
@@ -2,7 +2,7 @@
 import 'dart:math';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/pro_image_editor.dart';
 import '/shared/widgets/animated/fade_in_left.dart';

--- a/lib/designs/layer_selection/float_select/painter/float_select_border_painter.dart
+++ b/lib/designs/layer_selection/float_select/painter/float_select_border_painter.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Paints a custom rectangular border for FloatSelect
 class FloatSelectBorderPainter extends CustomPainter {

--- a/lib/designs/layer_selection/float_select/utils/float_select_transparent_hit_test.dart
+++ b/lib/designs/layer_selection/float_select/utils/float_select_transparent_hit_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A widget that ignores all pointer events
 class HitTestTransparent extends SingleChildRenderObjectWidget {

--- a/lib/designs/layer_selection/float_select/widgets/float_select_resize_handler.dart
+++ b/lib/designs/layer_selection/float_select/widgets/float_select_resize_handler.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/custom_widgets/layer_interaction_widgets.dart';
 import '../utils/float_select_transparent_hit_test.dart';

--- a/lib/designs/layer_selection/float_select/widgets/float_select_toolbar.dart
+++ b/lib/designs/layer_selection/float_select/widgets/float_select_toolbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/custom_widgets/layer_interaction_widgets.dart';
 import '/core/models/layers/layer.dart';

--- a/lib/designs/layer_selection/float_select/widgets/float_select_toolbar_button.dart
+++ b/lib/designs/layer_selection/float_select/widgets/float_select_toolbar_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A styled text button used in the FloatSelect toolbar
 class FloatSelectToolbarButton extends StatelessWidget {

--- a/lib/designs/layer_selection/float_select/widgets/float_selection_overlay.dart
+++ b/lib/designs/layer_selection/float_select/widgets/float_selection_overlay.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/custom_widgets/layer_interaction_widgets.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/designs/whatsapp/styles/whatsapp_appbar_button_style.dart
+++ b/lib/designs/whatsapp/styles/whatsapp_appbar_button_style.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Represents the button style for WhatsApp-themed buttons.
 ///

--- a/lib/designs/whatsapp/whatsapp_color_picker.dart
+++ b/lib/designs/whatsapp/whatsapp_color_picker.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A stateful widget that provides a color picker inspired by WhatsApp.
 ///

--- a/lib/designs/whatsapp/whatsapp_crop_rotate_toolbar.dart
+++ b/lib/designs/whatsapp/whatsapp_crop_rotate_toolbar.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/pro_image_editor.dart';

--- a/lib/designs/whatsapp/whatsapp_done_btn.dart
+++ b/lib/designs/whatsapp/whatsapp_done_btn.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/designs/whatsapp/whatsapp_paint_colorpicker.dart
+++ b/lib/designs/whatsapp/whatsapp_paint_colorpicker.dart
@@ -2,7 +2,7 @@
 import 'dart:math';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/enums/design_mode.dart';
 import '/features/paint_editor/paint_editor.dart';

--- a/lib/designs/whatsapp/whatsapp_sticker_editor.dart
+++ b/lib/designs/whatsapp/whatsapp_sticker_editor.dart
@@ -1,8 +1,8 @@
 import 'dart:ui';
 
 // Flutter imports:
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';

--- a/lib/designs/whatsapp/whatsapp_text_colorpicker.dart
+++ b/lib/designs/whatsapp/whatsapp_text_colorpicker.dart
@@ -2,7 +2,7 @@
 import 'dart:math';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/pro_image_editor.dart';
 

--- a/lib/designs/whatsapp/whatsapp_text_size_slider.dart
+++ b/lib/designs/whatsapp/whatsapp_text_size_slider.dart
@@ -2,7 +2,7 @@
 import 'dart:math';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/pro_image_editor.dart';
 

--- a/lib/designs/whatsapp/widgets/appbar/whatsapp_appbar.dart
+++ b/lib/designs/whatsapp/widgets/appbar/whatsapp_appbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/shared/widgets/gesture/gesture_interceptor_widget.dart';

--- a/lib/designs/whatsapp/widgets/appbar/whatsapp_paint_appbar.dart
+++ b/lib/designs/whatsapp/widgets/appbar/whatsapp_paint_appbar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/pro_image_editor.dart';

--- a/lib/designs/whatsapp/widgets/appbar/whatsapp_text_appbar.dart
+++ b/lib/designs/whatsapp/widgets/appbar/whatsapp_text_appbar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/pro_image_editor.dart';

--- a/lib/designs/whatsapp/widgets/bottombar/whatsapp_paint_bottombar.dart
+++ b/lib/designs/whatsapp/widgets/bottombar/whatsapp_paint_bottombar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/ui/pro_image_editor_icons.dart';
 import '/designs/whatsapp/whatsapp_color_picker.dart';

--- a/lib/designs/whatsapp/widgets/bottombar/whatsapp_text_bottombar.dart
+++ b/lib/designs/whatsapp/widgets/bottombar/whatsapp_text_bottombar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/features/text_editor/widgets/text_editor_bottom_bar.dart';
 import '/pro_image_editor.dart';

--- a/lib/designs/whatsapp/widgets/filter/whatsapp_filter_button.dart
+++ b/lib/designs/whatsapp/widgets/filter/whatsapp_filter_button.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/features/filter_editor/utils/filter_generator/filter_model.dart';

--- a/lib/designs/whatsapp/widgets/filter/whatsapp_filters.dart
+++ b/lib/designs/whatsapp/widgets/filter/whatsapp_filters.dart
@@ -2,7 +2,7 @@
 import 'dart:math';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/pro_image_editor.dart';
 import '../../whatsapp.dart';

--- a/lib/designs/whatsapp/widgets/filter/whatsapp_open_filter_button.dart
+++ b/lib/designs/whatsapp/widgets/filter/whatsapp_open_filter_button.dart
@@ -2,7 +2,7 @@
 import 'dart:math';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/features/audio_editor/audio_editor_page.dart
+++ b/lib/features/audio_editor/audio_editor_page.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';
@@ -42,7 +42,7 @@ class AudioEditorPage extends StatefulWidget with SimpleConfigsAccess {
   final AudioTrack? initialSelectedTrack;
 
   @override
-  createState() => AudioEditorPageState();
+  AudioEditorPageState createState() => AudioEditorPageState();
 }
 
 /// State responsible for rendering and managing the audio editor page.

--- a/lib/features/audio_editor/widgets/audio_editor_app_bar.dart
+++ b/lib/features/audio_editor/widgets/audio_editor_app_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 

--- a/lib/features/audio_editor/widgets/audio_main_bottom_bar.dart
+++ b/lib/features/audio_editor/widgets/audio_main_bottom_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_callbacks/audio_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/features/audio_editor/widgets/audio_track_list_tile.dart
+++ b/lib/features/audio_editor/widgets/audio_track_list_tile.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/shared/widgets/auto_image.dart';

--- a/lib/features/blur_editor/blur_editor.dart
+++ b/lib/features/blur_editor/blur_editor.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 
 // Flutter imports:
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/mixins/converted_configs.dart';
@@ -156,7 +156,7 @@ class BlurEditor extends StatefulWidget
   final ProVideoController? videoController;
 
   @override
-  createState() => BlurEditorState();
+  BlurEditorState createState() => BlurEditorState();
 }
 
 /// The state class for the `BlurEditor` widget.

--- a/lib/features/blur_editor/widgets/blur_editor_appbar.dart
+++ b/lib/features/blur_editor/widgets/blur_editor_appbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import '/core/models/editor_configs/blur_editor_configs.dart';
 import '/core/models/i18n/i18n_blur_editor.dart';
 

--- a/lib/features/blur_editor/widgets/blur_editor_bottombar.dart
+++ b/lib/features/blur_editor/widgets/blur_editor_bottombar.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import '/core/models/editor_configs/blur_editor_configs.dart';
 
 import '../blur_editor.dart';

--- a/lib/features/clips_editor/pages/clips_editor_edit_page.dart
+++ b/lib/features/clips_editor/pages/clips_editor_edit_page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';

--- a/lib/features/clips_editor/pages/clips_editor_page.dart
+++ b/lib/features/clips_editor/pages/clips_editor_page.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';
@@ -45,7 +45,7 @@ class ClipsEditorPage extends StatefulWidget with SimpleConfigsAccess {
   final List<VideoClip>? initialClips;
 
   @override
-  createState() => ClipsEditorPageState();
+  ClipsEditorPageState createState() => ClipsEditorPageState();
 }
 
 /// State responsible for rendering and managing the clips editor page.

--- a/lib/features/clips_editor/widgets/clips_editor_app_bar.dart
+++ b/lib/features/clips_editor/widgets/clips_editor_app_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 

--- a/lib/features/clips_editor/widgets/clips_editor_edit_app_bar.dart
+++ b/lib/features/clips_editor/widgets/clips_editor_edit_app_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 

--- a/lib/features/clips_editor/widgets/clips_editor_list_tile.dart
+++ b/lib/features/clips_editor/widgets/clips_editor_list_tile.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/features/crop_rotate_editor/crop_rotate_editor.dart
+++ b/lib/features/crop_rotate_editor/crop_rotate_editor.dart
@@ -3,8 +3,8 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart' hide Image;
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart' hide Image;
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/mixins/converted_configs.dart';

--- a/lib/features/crop_rotate_editor/mixins/crop_area_history.dart
+++ b/lib/features/crop_rotate_editor/mixins/crop_area_history.dart
@@ -3,7 +3,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/mixins/standalone_editor.dart';

--- a/lib/features/crop_rotate_editor/services/crop_desktop_interaction_manager.dart
+++ b/lib/features/crop_rotate_editor/services/crop_desktop_interaction_manager.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A manager class responsible for handling desktop interactions in the
 /// crop-rotate editor.

--- a/lib/features/crop_rotate_editor/widgets/crop_aspect_ratio_button.dart
+++ b/lib/features/crop_rotate_editor/widgets/crop_aspect_ratio_button.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A custom widget representing a button with a specific aspect ratio.
 class AspectRatioButton extends StatelessWidget {

--- a/lib/features/crop_rotate_editor/widgets/crop_aspect_ratio_options.dart
+++ b/lib/features/crop_rotate_editor/widgets/crop_aspect_ratio_options.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/features/crop_rotate_editor/widgets/crop_corner_painter.dart
+++ b/lib/features/crop_rotate_editor/widgets/crop_corner_painter.dart
@@ -2,7 +2,7 @@
 import 'dart:math';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/models/styles/crop_rotate_editor_style.dart';

--- a/lib/features/crop_rotate_editor/widgets/crop_editor_appbar.dart
+++ b/lib/features/crop_rotate_editor/widgets/crop_editor_appbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../core/models/editor_configs/crop_rotate_editor_configs.dart';
 import '../../../core/models/i18n/i18n_crop_rotate_editor.dart';

--- a/lib/features/crop_rotate_editor/widgets/crop_editor_bottombar.dart
+++ b/lib/features/crop_rotate_editor/widgets/crop_editor_bottombar.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/shared/widgets/editor_scrollbar.dart';

--- a/lib/features/crop_rotate_editor/widgets/crop_layer_painter.dart
+++ b/lib/features/crop_rotate_editor/widgets/crop_layer_painter.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A custom painter for drawing the crop layer background and overlay.
 ///

--- a/lib/features/crop_rotate_editor/widgets/tilt/tilt_item_row.dart
+++ b/lib/features/crop_rotate_editor/widgets/tilt/tilt_item_row.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/shared/widgets/flat_icon_text_button.dart';
 import '../../enums/tilt_mode_enum.dart';

--- a/lib/features/crop_rotate_editor/widgets/tilt/tilt_ruler.dart
+++ b/lib/features/crop_rotate_editor/widgets/tilt/tilt_ruler.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/crop_rotate_editor_configs.dart';
 

--- a/lib/features/crop_rotate_editor/widgets/tilt/tilt_ruler_chooser.dart
+++ b/lib/features/crop_rotate_editor/widgets/tilt/tilt_ruler_chooser.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/shared/extensions/double_extension.dart';
 import '../../enums/tilt_mode_enum.dart';

--- a/lib/features/emoji_editor/emoji_editor.dart
+++ b/lib/features/emoji_editor/emoji_editor.dart
@@ -2,7 +2,7 @@
 import 'dart:math';
 
 import 'package:flutter/foundation.dart' show defaultTargetPlatform;
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';
@@ -38,7 +38,7 @@ class EmojiEditor extends StatefulWidget with SimpleConfigsAccess {
   final ScrollController? scrollController;
 
   @override
-  createState() => EmojiEditorState();
+  EmojiEditorState createState() => EmojiEditorState();
 }
 
 /// The state class for the `EmojiEditor` widget.

--- a/lib/features/emoji_editor/services/emoji_state_manager.dart
+++ b/lib/features/emoji_editor/services/emoji_state_manager.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/features/emoji_editor/widgets/emoji_cell_extended.dart
+++ b/lib/features/emoji_editor/widgets/emoji_cell_extended.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/features/emoji_editor/widgets/emoji_editor_bottom_bar.dart
+++ b/lib/features/emoji_editor/widgets/emoji_editor_bottom_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 import '../services/emoji_state_manager.dart';

--- a/lib/features/emoji_editor/widgets/emoji_editor_category_view.dart
+++ b/lib/features/emoji_editor/widgets/emoji_editor_category_view.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 import '../widgets/emoji_editor_bottom_bar.dart';

--- a/lib/features/emoji_editor/widgets/emoji_editor_full_screen_search.dart
+++ b/lib/features/emoji_editor/widgets/emoji_editor_full_screen_search.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/features/emoji_editor/widgets/emoji_editor_header_search.dart
+++ b/lib/features/emoji_editor/widgets/emoji_editor_header_search.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/constants/editor_style_constants.dart';
 import '/core/models/i18n/i18n_emoji_editor.dart';

--- a/lib/features/emoji_editor/widgets/emoji_picker_view.dart
+++ b/lib/features/emoji_editor/widgets/emoji_picker_view.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/i18n/i18n_emoji_editor.dart';
 import '/core/models/styles/emoji_editor_style.dart';

--- a/lib/features/filter_editor/filter_editor.dart
+++ b/lib/features/filter_editor/filter_editor.dart
@@ -2,8 +2,8 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/constants/image_constants.dart';
 import '/core/mixins/converted_callbacks.dart';
@@ -159,7 +159,7 @@ class FilterEditor extends StatefulWidget
   final ProVideoController? videoController;
 
   @override
-  createState() => FilterEditorState();
+  FilterEditorState createState() => FilterEditorState();
 }
 
 /// The state class for the `FilterEditor` widget.

--- a/lib/features/filter_editor/widgets/filter_editor_appbar.dart
+++ b/lib/features/filter_editor/widgets/filter_editor_appbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/filter_editor_configs.dart';
 import '/core/models/i18n/i18n_filter_editor.dart';

--- a/lib/features/filter_editor/widgets/filter_editor_item_list.dart
+++ b/lib/features/filter_editor/widgets/filter_editor_item_list.dart
@@ -2,7 +2,7 @@
 import 'dart:math';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/editor_image.dart';

--- a/lib/features/filter_editor/widgets/filtered_widget.dart
+++ b/lib/features/filter_editor/widgets/filtered_widget.dart
@@ -3,7 +3,7 @@ import 'dart:ui';
 
 // Flutter imports:
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/constants/editor_various_constants.dart';
 import '/core/constants/image_constants.dart';

--- a/lib/features/main_editor/services/desktop_interaction_manager.dart
+++ b/lib/features/main_editor/services/desktop_interaction_manager.dart
@@ -3,14 +3,13 @@ import 'dart:math';
 
 // Flutter imports:
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/layers/layer.dart';
 import '/core/services/keyboard_service.dart';
-
 import '/shared/widgets/extended/interactive_viewer/extended_interactive_viewer.dart';
 
 /// A manager class responsible for handling desktop interactions in the image

--- a/lib/features/main_editor/services/layer_interaction_manager.dart
+++ b/lib/features/main_editor/services/layer_interaction_manager.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'dart:math';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/models/editor_callbacks/main_editor/helper_lines/helper_lines_callbacks.dart';

--- a/lib/features/main_editor/services/main_editor_layers_service.dart
+++ b/lib/features/main_editor/services/main_editor_layers_service.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/features/main_editor/services/main_editor_state_history_service.dart
+++ b/lib/features/main_editor/services/main_editor_state_history_service.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_callbacks/main_editor/main_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/features/main_editor/services/sizes_manager.dart
+++ b/lib/features/main_editor/services/sizes_manager.dart
@@ -2,7 +2,7 @@
 import 'dart:math';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/history/state_history.dart';

--- a/lib/features/main_editor/widgets/main_editor_appbar.dart
+++ b/lib/features/main_editor/widgets/main_editor_appbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/shared/widgets/platform/platform_circular_progress_indicator.dart';

--- a/lib/features/main_editor/widgets/main_editor_background_image.dart
+++ b/lib/features/main_editor/widgets/main_editor_background_image.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/editor_image.dart';

--- a/lib/features/main_editor/widgets/main_editor_background_video.dart
+++ b/lib/features/main_editor/widgets/main_editor_background_video.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/features/filter_editor/types/filter_state.dart';

--- a/lib/features/main_editor/widgets/main_editor_bottombar.dart
+++ b/lib/features/main_editor/widgets/main_editor_bottombar.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/shared/widgets/editor_scrollbar.dart';

--- a/lib/features/main_editor/widgets/main_editor_font_preloader.dart
+++ b/lib/features/main_editor/widgets/main_editor_font_preloader.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/emoji_editor_configs.dart';
 

--- a/lib/features/main_editor/widgets/main_editor_helper_lines.dart
+++ b/lib/features/main_editor/widgets/main_editor_helper_lines.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '../../../shared/widgets/extended/interactive_viewer/extended_interactive_viewer.dart';

--- a/lib/features/main_editor/widgets/main_editor_interactive_content.dart
+++ b/lib/features/main_editor/widgets/main_editor_interactive_content.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/features/main_editor/widgets/main_editor_layers.dart
+++ b/lib/features/main_editor/widgets/main_editor_layers.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/features/main_editor/widgets/main_editor_remove_layer_area.dart
+++ b/lib/features/main_editor/widgets/main_editor_remove_layer_area.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/layer_interaction_configs.dart';
 import '/core/models/editor_configs/main_editor_configs.dart';

--- a/lib/features/paint_editor/controllers/paint_controller.dart
+++ b/lib/features/paint_editor/controllers/paint_controller.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../enums/paint_editor_enum.dart';
 // Project imports:

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -3,8 +3,8 @@ import 'dart:math';
 
 // Flutter imports:
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/constants/image_constants.dart';
 import '/core/mixins/converted_callbacks.dart';

--- a/lib/features/paint_editor/services/paint_desktop_interaction_manager.dart
+++ b/lib/features/paint_editor/services/paint_desktop_interaction_manager.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A manager class responsible for handling desktop interactions in the
 /// crop-rotate editor.

--- a/lib/features/paint_editor/widgets/draw_paint_item.dart
+++ b/lib/features/paint_editor/widgets/draw_paint_item.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/paint_editor/paint_editor_configs.dart';
 import '../services/paint_item_hit_test_manager.dart';

--- a/lib/features/paint_editor/widgets/paint_canvas.dart
+++ b/lib/features/paint_editor/widgets/paint_canvas.dart
@@ -4,7 +4,7 @@ import 'dart:math';
 
 // Flutter imports:
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/paint_editor/paint_editor_configs.dart';
 import '/core/models/layers/layer.dart';

--- a/lib/features/paint_editor/widgets/paint_editor_appbar.dart
+++ b/lib/features/paint_editor/widgets/paint_editor_appbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/shared/widgets/platform/platform_popup_menu.dart';

--- a/lib/features/paint_editor/widgets/paint_editor_bottombar.dart
+++ b/lib/features/paint_editor/widgets/paint_editor_bottombar.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/features/paint_editor/enums/paint_editor_enum.dart';

--- a/lib/features/paint_editor/widgets/paint_editor_color_picker.dart
+++ b/lib/features/paint_editor/widgets/paint_editor_color_picker.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/shared/widgets/color_picker/bar_color_picker.dart';

--- a/lib/features/paint_editor/widgets/paint_editor_layer_editor.dart
+++ b/lib/features/paint_editor/widgets/paint_editor_layer_editor.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/pro_image_editor.dart';
 import '/shared/widgets/layer/widgets/layer_widget_paint_item.dart';

--- a/lib/features/sticker_editor/sticker_editor.dart
+++ b/lib/features/sticker_editor/sticker_editor.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';
@@ -27,7 +27,7 @@ class StickerEditor extends StatefulWidget with SimpleConfigsAccess {
   final ScrollController scrollController;
 
   @override
-  createState() => StickerEditorState();
+  StickerEditorState createState() => StickerEditorState();
 }
 
 /// The state class for the `StickerEditor` widget.

--- a/lib/features/text_editor/text_editor.dart
+++ b/lib/features/text_editor/text_editor.dart
@@ -2,7 +2,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/mixins/converted_configs.dart';
@@ -58,7 +58,7 @@ class TextEditor extends StatefulWidget with SimpleConfigsAccess {
   final double scaleFactor;
 
   @override
-  createState() => TextEditorState();
+  TextEditorState createState() => TextEditorState();
 }
 
 /// The state class for the `TextEditor` widget.

--- a/lib/features/text_editor/utils/rounded_background_painter.dart
+++ b/lib/features/text_editor/utils/rounded_background_painter.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/line_metrics_model.dart';
 

--- a/lib/features/text_editor/widgets/rounded_background_text/rounded_background_text.dart
+++ b/lib/features/text_editor/widgets/rounded_background_text/rounded_background_text.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../utils/rounded_background_painter.dart';
 

--- a/lib/features/text_editor/widgets/rounded_background_text/rounded_background_text_field.dart
+++ b/lib/features/text_editor/widgets/rounded_background_text/rounded_background_text_field.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import 'rounded_background_text.dart';

--- a/lib/features/text_editor/widgets/text_editor_appbar.dart
+++ b/lib/features/text_editor/widgets/text_editor_appbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/enums/design_mode.dart';
 import '/core/models/editor_configs/text_editor_configs.dart';

--- a/lib/features/text_editor/widgets/text_editor_bottom_bar.dart
+++ b/lib/features/text_editor/widgets/text_editor_bottom_bar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 

--- a/lib/features/text_editor/widgets/text_editor_color_picker.dart
+++ b/lib/features/text_editor/widgets/text_editor_color_picker.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/shared/widgets/color_picker/bar_color_picker.dart';

--- a/lib/features/text_editor/widgets/text_editor_input.dart
+++ b/lib/features/text_editor/widgets/text_editor_input.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_callbacks/text_editor_callbacks.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/features/tune_editor/models/tune_adjustment_item.dart
+++ b/lib/features/tune_editor/models/tune_adjustment_item.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import './tune_adjustment_matrix.dart';
 
 /// A class representing an adjustable tune item in the editor.

--- a/lib/features/tune_editor/tune_editor.dart
+++ b/lib/features/tune_editor/tune_editor.dart
@@ -2,8 +2,8 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_callbacks.dart';
 import '/core/mixins/converted_configs.dart';
@@ -153,7 +153,7 @@ class TuneEditor extends StatefulWidget
   final ProVideoController? videoController;
 
   @override
-  createState() => TuneEditorState();
+  TuneEditorState createState() => TuneEditorState();
 }
 
 /// The state class for the `TuneEditor` widget.

--- a/lib/features/tune_editor/widgets/tune_editor_appbar.dart
+++ b/lib/features/tune_editor/widgets/tune_editor_appbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/tune_editor_configs.dart';
 import '/core/models/i18n/i18n_tune_editor.dart';

--- a/lib/features/tune_editor/widgets/tune_editor_bottombar.dart
+++ b/lib/features/tune_editor/widgets/tune_editor_bottombar.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/tune_editor_configs.dart';
 import '/shared/widgets/editor_scrollbar.dart';

--- a/lib/plugins/defer_pointer/defer_pointer.dart
+++ b/lib/plugins/defer_pointer/defer_pointer.dart
@@ -3,13 +3,14 @@
 
 import 'dart:collection';
 
-// Flutter imports:
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+// Flutter imports:
+import 'package:material_ui/material_ui.dart';
+
 import '/shared/utils/unique_id_generator.dart';
 
-part 'deferred_pointer_handler_link.dart';
 part 'deferred_pointer_handler.dart';
+part 'deferred_pointer_handler_link.dart';
 
 /// Create a StatelessWidget to wrap our RenderObjectWidget so we can bind to
 /// inherited widget.

--- a/lib/plugins/emoji_picker_flutter/locales/default_emoji_set_locale.dart
+++ b/lib/plugins/emoji_picker_flutter/locales/default_emoji_set_locale.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/bottom_action_bar/bottom_action_bar.dart
+++ b/lib/plugins/emoji_picker_flutter/src/bottom_action_bar/bottom_action_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/bottom_action_bar/bottom_action_bar_config.dart
+++ b/lib/plugins/emoji_picker_flutter/src/bottom_action_bar/bottom_action_bar_config.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/bottom_action_bar/default_bottom_action_bar.dart
+++ b/lib/plugins/emoji_picker_flutter/src/bottom_action_bar/default_bottom_action_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/category_view/category_icon.dart
+++ b/lib/plugins/emoji_picker_flutter/src/category_view/category_icon.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Class that defines the icon representing a [Category]
 class CategoryIcon {

--- a/lib/plugins/emoji_picker_flutter/src/category_view/category_icons.dart
+++ b/lib/plugins/emoji_picker_flutter/src/category_view/category_icons.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Class used to define all the [CategoryIcon] shown for each [Category]
 ///

--- a/lib/plugins/emoji_picker_flutter/src/category_view/category_view.dart
+++ b/lib/plugins/emoji_picker_flutter/src/category_view/category_view.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/category_view/category_view_config.dart
+++ b/lib/plugins/emoji_picker_flutter/src/category_view/category_view_config.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/category_view/default_category_tab_bar.dart
+++ b/lib/plugins/emoji_picker_flutter/src/category_view/default_category_tab_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/category_view/default_category_view.dart
+++ b/lib/plugins/emoji_picker_flutter/src/category_view/default_category_view.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/config.dart
+++ b/lib/plugins/emoji_picker_flutter/src/config.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 import '/plugins/emoji_picker_flutter/locales/default_emoji_set_locale.dart';

--- a/lib/plugins/emoji_picker_flutter/src/emoji.dart
+++ b/lib/plugins/emoji_picker_flutter/src/emoji.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Delimiter for keywords
 const _keywordDelimiter = ' | ';

--- a/lib/plugins/emoji_picker_flutter/src/emoji_picker.dart
+++ b/lib/plugins/emoji_picker_flutter/src/emoji_picker.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: constant_identifier_names
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/platform/io/io_helper.dart';
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';

--- a/lib/plugins/emoji_picker_flutter/src/emoji_picker_utils.dart
+++ b/lib/plugins/emoji_picker_flutter/src/emoji_picker_utils.dart
@@ -2,7 +2,7 @@
 
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 import '/plugins/emoji_picker_flutter/src/emoji_picker_internal_utils.dart';

--- a/lib/plugins/emoji_picker_flutter/src/emoji_text_style.dart
+++ b/lib/plugins/emoji_picker_flutter/src/emoji_text_style.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Emoji text style providing commonly available fallback fonts
 // ignore: constant_identifier_names

--- a/lib/plugins/emoji_picker_flutter/src/emoji_view/default_emoji_picker_view.dart
+++ b/lib/plugins/emoji_picker_flutter/src/emoji_view/default_emoji_picker_view.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/emoji_view/emoji_container.dart
+++ b/lib/plugins/emoji_picker_flutter/src/emoji_view/emoji_container.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/src/emoji_picker.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/emoji_view/emoji_picker_view.dart
+++ b/lib/plugins/emoji_picker_flutter/src/emoji_view/emoji_picker_view.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/src/config.dart';
 import '/plugins/emoji_picker_flutter/src/emoji_view_state.dart';

--- a/lib/plugins/emoji_picker_flutter/src/emoji_view/emoji_view_config.dart
+++ b/lib/plugins/emoji_picker_flutter/src/emoji_view/emoji_view_config.dart
@@ -2,7 +2,7 @@
 
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/emoji_view_state.dart
+++ b/lib/plugins/emoji_picker_flutter/src/emoji_view_state.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/search_view/default_search_view.dart
+++ b/lib/plugins/emoji_picker_flutter/src/search_view/default_search_view.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 
@@ -55,9 +55,7 @@ class DefaultSearchViewState extends SearchViewState {
               Row(
                 children: [
                   IconButton(
-                    onPressed: () {
-                      widget.showEmojiView();
-                    },
+                    onPressed: widget.showEmojiView,
                     color: widget.config.searchViewConfig.buttonIconColor,
                     icon: const Icon(Icons.arrow_back),
                   ),

--- a/lib/plugins/emoji_picker_flutter/src/search_view/search_view.dart
+++ b/lib/plugins/emoji_picker_flutter/src/search_view/search_view.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/search_view/search_view_config.dart
+++ b/lib/plugins/emoji_picker_flutter/src/search_view/search_view_config.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/skin_tones/skin_tone_config.dart
+++ b/lib/plugins/emoji_picker_flutter/src/skin_tones/skin_tone_config.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Skin tone config Config
 class SkinToneConfig {

--- a/lib/plugins/emoji_picker_flutter/src/skin_tones/skin_tone_overlay.dart
+++ b/lib/plugins/emoji_picker_flutter/src/skin_tones/skin_tone_overlay.dart
@@ -1,6 +1,6 @@
 import 'dart:collection';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/skin_tones/triangle_decoration.dart
+++ b/lib/plugins/emoji_picker_flutter/src/skin_tones/triangle_decoration.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Decoration that can be used to render a triangle in the bottom-right
 /// corner of a container

--- a/lib/plugins/emoji_picker_flutter/src/widgets/backspace_button.dart
+++ b/lib/plugins/emoji_picker_flutter/src/widgets/backspace_button.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/widgets/emoji_cell.dart
+++ b/lib/plugins/emoji_picker_flutter/src/widgets/emoji_cell.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/plugins/emoji_picker_flutter/src/widgets/search_button.dart
+++ b/lib/plugins/emoji_picker_flutter/src/widgets/search_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/lib/shared/extensions/box_constraints_extension.dart
+++ b/lib/shared/extensions/box_constraints_extension.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/constants/int_constants.dart';
 import 'num_extension.dart';

--- a/lib/shared/extensions/color_extension.dart
+++ b/lib/shared/extensions/color_extension.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Extension on the [Color] class to provide a method for converting a color
 /// to its hexadecimal representation.

--- a/lib/shared/services/content_recorder/controllers/content_recorder_controller.dart
+++ b/lib/shared/services/content_recorder/controllers/content_recorder_controller.dart
@@ -3,8 +3,8 @@ import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/multi_threading/thread_capture_model.dart';

--- a/lib/shared/services/content_recorder/services/image_render_service.dart
+++ b/lib/shared/services/content_recorder/services/image_render_service.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 import 'dart:ui' as ui;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/image_generation_configs/image_generation_configs.dart';
 import '/shared/utils/decode_image.dart';

--- a/lib/shared/services/content_recorder/utils/generate_high_quality_image.dart
+++ b/lib/shared/services/content_recorder/utils/generate_high_quality_image.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/shared/services/content_recorder/controllers/content_recorder_controller.dart';

--- a/lib/shared/services/content_recorder/widgets/content_recorder.dart
+++ b/lib/shared/services/content_recorder/widgets/content_recorder.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/shared/widgets/extended/repaint/extended_repaint_boundary.dart';

--- a/lib/shared/services/layer_rasterizer/layer_rasterizer_host.dart
+++ b/lib/shared/services/layer_rasterizer/layer_rasterizer_host.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/shared/utils/default_editor_theme.dart';

--- a/lib/shared/styles/platform_text_styles.dart
+++ b/lib/shared/styles/platform_text_styles.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/enums/design_mode.dart';

--- a/lib/shared/utils/default_editor_theme.dart
+++ b/lib/shared/utils/default_editor_theme.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// The theme the editor falls back to when `ProImageEditorConfigs.theme` is
 /// `null`.

--- a/lib/shared/widgets/adaptive_dialog.dart
+++ b/lib/shared/widgets/adaptive_dialog.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/enums/design_mode.dart';

--- a/lib/shared/widgets/animated/fade_in_base.dart
+++ b/lib/shared/widgets/animated/fade_in_base.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// An abstract base widget that applies a fade-in and slide-in animation
 /// to its child.

--- a/lib/shared/widgets/animated/fade_in_left.dart
+++ b/lib/shared/widgets/animated/fade_in_left.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'fade_in_base.dart';
 

--- a/lib/shared/widgets/animated/fade_in_up.dart
+++ b/lib/shared/widgets/animated/fade_in_up.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'fade_in_base.dart';
 

--- a/lib/shared/widgets/bottom_sheets_header_row.dart
+++ b/lib/shared/widgets/bottom_sheets_header_row.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A custom widget for the header row of a bottom sheet.
 class BottomSheetHeaderRow extends StatefulWidget {

--- a/lib/shared/widgets/censor/pixelate_area_item.dart
+++ b/lib/shared/widgets/censor/pixelate_area_item.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/features/main_editor/providers/image_infos_provider.dart';
 import '/shared/services/shader_manager.dart';

--- a/lib/shared/widgets/color_picker/bar_color_picker.dart
+++ b/lib/shared/widgets/color_picker/bar_color_picker.dart
@@ -3,7 +3,7 @@ import 'dart:math';
 
 // Flutter imports:
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/shared/extensions/color_extension.dart';
@@ -91,7 +91,7 @@ class BarColorPicker extends StatefulWidget {
   final Duration animationDuration;
 
   @override
-  createState() => _BarColorPickerState();
+  _BarColorPickerState createState() => _BarColorPickerState();
 }
 
 class _BarColorPickerState extends State<BarColorPicker>

--- a/lib/shared/widgets/editor_scrollbar.dart
+++ b/lib/shared/widgets/editor_scrollbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../utils/platform_info.dart';
 

--- a/lib/shared/widgets/flat_icon_text_button.dart
+++ b/lib/shared/widgets/flat_icon_text_button.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A custom TextButton widget with an icon placed above the label.
 class FlatIconTextButton extends TextButton {

--- a/lib/shared/widgets/layer/interaction_helper/layer_interaction_button.dart
+++ b/lib/shared/widgets/layer/interaction_helper/layer_interaction_button.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A stateful widget that represents a customizable button for interacting
 /// with layers.

--- a/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
+++ b/lib/shared/widgets/layer/interaction_helper/layer_interaction_helper_widget.dart
@@ -2,7 +2,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/mixins/converted_configs.dart';
 import '/core/mixins/editor_configs_mixin.dart';

--- a/lib/shared/widgets/layer/layer_drag_selection_area_widget.dart
+++ b/lib/shared/widgets/layer/layer_drag_selection_area_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/features/main_editor/services/layer_drag_selection_service.dart';
 

--- a/lib/shared/widgets/layer/layer_stack.dart
+++ b/lib/shared/widgets/layer/layer_stack.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/layers/layer.dart';

--- a/lib/shared/widgets/layer/layer_widget.dart
+++ b/lib/shared/widgets/layer/layer_widget.dart
@@ -5,7 +5,7 @@ import 'dart:math';
 // Flutter imports:
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/constants/editor_various_constants.dart';
 import '/core/mixins/converted_configs.dart';
@@ -83,7 +83,7 @@ class LayerWidget extends StatefulWidget with SimpleConfigsAccess {
   final ValueNotifier<Duration>? playTimeNotifier;
 
   @override
-  createState() => _LayerWidgetState();
+  _LayerWidgetState createState() => _LayerWidgetState();
 }
 
 class _LayerWidgetState extends State<LayerWidget>

--- a/lib/shared/widgets/layer/services/layer_widget_context_menu.dart
+++ b/lib/shared/widgets/layer/services/layer_widget_context_menu.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/i18n/i18n_layer_interaction.dart';
 import '/core/models/icons/layer_interaction_icons.dart';

--- a/lib/shared/widgets/layer/widgets/layer_widget_censor_item.dart
+++ b/lib/shared/widgets/layer/widgets/layer_widget_censor_item.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/paint_editor/censor_configs.dart';
 import '/core/models/layers/paint_layer.dart';

--- a/lib/shared/widgets/layer/widgets/layer_widget_custom_item.dart
+++ b/lib/shared/widgets/layer/widgets/layer_widget_custom_item.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/sticker_editor_configs.dart';
 import '/core/models/layers/widget_layer.dart';

--- a/lib/shared/widgets/layer/widgets/layer_widget_emoji_item.dart
+++ b/lib/shared/widgets/layer/widgets/layer_widget_emoji_item.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/enums/design_mode.dart';
 import '/core/models/editor_configs/emoji_editor_configs.dart';

--- a/lib/shared/widgets/layer/widgets/layer_widget_paint_item.dart
+++ b/lib/shared/widgets/layer/widgets/layer_widget_paint_item.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/paint_editor/paint_editor_configs.dart';
 import '/core/models/layers/paint_layer.dart';

--- a/lib/shared/widgets/layer/widgets/layer_widget_text_item.dart
+++ b/lib/shared/widgets/layer/widgets/layer_widget_text_item.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/text_editor_configs.dart';
 import '/core/models/layers/text_layer.dart';

--- a/lib/shared/widgets/overlays/loading_dialog/loading_dialog.dart
+++ b/lib/shared/widgets/overlays/loading_dialog/loading_dialog.dart
@@ -1,7 +1,7 @@
 // Flutter imports:
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/shared/widgets/overlays/loading_dialog/models/loading_dialog_overlay_details.dart
+++ b/lib/shared/widgets/overlays/loading_dialog/models/loading_dialog_overlay_details.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../animations/loading_dialog_base_animation.dart';
 

--- a/lib/shared/widgets/platform/platform_circular_progress_indicator.dart
+++ b/lib/shared/widgets/platform/platform_circular_progress_indicator.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 
 /// A circular progress indicator that adapts to the platform.

--- a/lib/shared/widgets/platform/platform_popup_menu.dart
+++ b/lib/shared/widgets/platform/platform_popup_menu.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/enums/design_mode.dart';

--- a/lib/shared/widgets/reactive_widgets/reactive_custom_appbar.dart
+++ b/lib/shared/widgets/reactive_widgets/reactive_custom_appbar.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// A custom app bar widget that reacts to stream updates.
 ///

--- a/lib/shared/widgets/screen_resize_detector.dart
+++ b/lib/shared/widgets/screen_resize_detector.dart
@@ -2,7 +2,7 @@
 import 'dart:ui';
 
 // Flutter imports:
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '../utils/debounce.dart';

--- a/lib/shared/widgets/slider_bottom_sheet.dart
+++ b/lib/shared/widgets/slider_bottom_sheet.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/enums/design_mode.dart';
 import '/shared/styles/platform_text_styles.dart';

--- a/lib/shared/widgets/transform/transformed_content_generator.dart
+++ b/lib/shared/widgets/transform/transformed_content_generator.dart
@@ -1,6 +1,6 @@
 // Flutter imports:
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Project imports:
 import '/core/models/editor_configs/pro_image_editor_configs.dart';

--- a/lib/shared/widgets/video/export_prebuild/video_editor_prebuild_remove_area.dart
+++ b/lib/shared/widgets/video/export_prebuild/video_editor_prebuild_remove_area.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import '/features/main_editor/main_editor.dart';
 
 /// A widget representing the remove area in the video editor.

--- a/lib/shared/widgets/video/toolbar/video_editor_info_banner.dart
+++ b/lib/shared/widgets/video/toolbar/video_editor_info_banner.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import '/core/models/video/trim_duration_span_model.dart';
 import '/shared/controllers/video_controller.dart';
 import '/shared/extensions/duration_extension.dart';

--- a/lib/shared/widgets/video/toolbar/video_editor_mute_button.dart
+++ b/lib/shared/widgets/video/toolbar/video_editor_mute_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/shared/widgets/video/video_editor_configurable.dart';
 import '../../gesture/gesture_interceptor_widget.dart';

--- a/lib/shared/widgets/video/toolbar/video_editor_play_button.dart
+++ b/lib/shared/widgets/video/toolbar/video_editor_play_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/shared/widgets/video/video_editor_configurable.dart';
 import '../../gesture/gesture_interceptor_widget.dart';

--- a/lib/shared/widgets/video/trimmer/video_editor_play_time_indicator.dart
+++ b/lib/shared/widgets/video/trimmer/video_editor_play_time_indicator.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../video_editor_configurable.dart';
 

--- a/lib/shared/widgets/video/trimmer/video_editor_trim_bar.dart
+++ b/lib/shared/widgets/video/trimmer/video_editor_trim_bar.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/video/trim_duration_span_model.dart';

--- a/lib/shared/widgets/video/trimmer/video_editor_trim_handle.dart
+++ b/lib/shared/widgets/video/trimmer/video_editor_trim_handle.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../video_editor_configurable.dart';
 

--- a/lib/shared/widgets/video/trimmer/video_editor_trim_skeleton.dart
+++ b/lib/shared/widgets/video/trimmer/video_editor_trim_skeleton.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../video_editor_configurable.dart';
 

--- a/lib/shared/widgets/video/trimmer/video_editor_trim_thumbnail_bar.dart
+++ b/lib/shared/widgets/video/trimmer/video_editor_trim_thumbnail_bar.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:material_ui/material_ui.dart';
+
 import '/shared/widgets/video/video_editor_configurable.dart';
 import 'video_editor_trim_skeleton.dart';
 

--- a/lib/shared/widgets/video/video_editor_configurable.dart
+++ b/lib/shared/widgets/video/video_editor_configurable.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_callbacks/video_editor_callbacks.dart';
 import '/core/models/editor_configs/video/video_editor_configs.dart';

--- a/lib/shared/widgets/video/video_editor_controls_widget.dart
+++ b/lib/shared/widgets/video/video_editor_controls_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_configs/video/video_editor_configs.dart';
 import '/core/models/video/trim_duration_span_model.dart';

--- a/lib/shared/widgets/video/video_editor_state_widget.dart
+++ b/lib/shared/widgets/video/video_editor_state_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'video_editor_configurable.dart';
 
 /// Displays the current play state in the video editor.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,8 @@ dependencies:
   vector_math: ^2.2.0
   web: ^1.1.1
 
+  material_ui: any
+  cupertino_ui: any
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/core/models/layers/layer_capture_test.dart
+++ b/test/core/models/layers/layer_capture_test.dart
@@ -1,7 +1,7 @@
 import 'dart:ui' as ui;
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 import '../../../mock/mock_image.dart';

--- a/test/core/models/layers/layer_test.dart
+++ b/test/core/models/layers/layer_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/editor_configs/pro_image_editor_configs.dart';
 import 'package:pro_image_editor/core/models/layers/layer.dart';
 import 'package:pro_image_editor/core/models/layers/layer_interaction.dart';

--- a/test/core/models/layers/paint_layer_test.dart
+++ b/test/core/models/layers/paint_layer_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_image_editor/shared/services/import_export/utils/key_minifier.dart';
 

--- a/test/core/models/layers/text_layer_test.dart
+++ b/test/core/models/layers/text_layer_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/layers/enums/layer_background_mode.dart';
 import 'package:pro_image_editor/core/models/layers/text_layer.dart';
 import 'package:pro_image_editor/shared/extensions/color_extension.dart';

--- a/test/core/models/layers/widget_layer_test.dart
+++ b/test/core/models/layers/widget_layer_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/layers/widget_layer.dart';
 
 void main() {

--- a/test/features/blur_editor_test.dart
+++ b/test/features/blur_editor_test.dart
@@ -1,8 +1,7 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 

--- a/test/features/crop_rotate_editor/crop_rotate_editor_test.dart
+++ b/test/features/crop_rotate_editor/crop_rotate_editor_test.dart
@@ -2,10 +2,9 @@
 
 // Flutter imports:
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 import 'package:pro_image_editor/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
 import 'package:pro_image_editor/core/models/editor_configs/pro_image_editor_configs.dart';
@@ -13,6 +12,7 @@ import 'package:pro_image_editor/core/models/init_configs/crop_rotate_editor_ini
 import 'package:pro_image_editor/features/crop_rotate_editor/crop_rotate_editor.dart';
 import 'package:pro_image_editor/features/crop_rotate_editor/utils/crop_aspect_ratios.dart';
 import 'package:pro_image_editor/features/crop_rotate_editor/widgets/outside_gestures/crop_rotate_gesture_detector.dart';
+
 import '../../mock/mock_image.dart';
 
 void main() {

--- a/test/features/crop_rotate_editor/widgets/crop_aspect_ratio_options_test.dart
+++ b/test/features/crop_rotate_editor/widgets/crop_aspect_ratio_options_test.dart
@@ -1,8 +1,7 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:mockito/mockito.dart';
 import 'package:pro_image_editor/features/crop_rotate_editor/widgets/crop_aspect_ratio_button.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/test/features/crop_rotate_editor/widgets/crop_corner_painter_test.dart
+++ b/test/features/crop_rotate_editor/widgets/crop_corner_painter_test.dart
@@ -1,11 +1,10 @@
 // Dart imports:
 import 'dart:ui' as ui;
 
-// Flutter imports:
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+// Flutter imports:
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/styles/crop_rotate_editor_style.dart';
 import 'package:pro_image_editor/features/crop_rotate_editor/widgets/crop_corner_painter.dart';
 import 'package:pro_image_editor/shared/extensions/matrix_extension.dart';
@@ -162,7 +161,7 @@ void main() {
         // Reconstruct the tilted image quad with the same transform the
         // painter uses, then sample its centroid (clearly inside the image,
         // outside the crop) and a point far outside the quad.
-        final center = Offset(imageSize.width / 2, imageSize.height / 2);
+        const center = Offset(imageSize.width / 2, imageSize.height / 2);
         final tiltMatrix = Matrix4.identity().tilt(
           rotate: 0,
           vertical: 0,
@@ -175,9 +174,9 @@ void main() {
 
         final corners = [
           toScreen(const Offset(0, 0)),
-          toScreen(Offset(imageSize.width, 0)),
-          toScreen(Offset(imageSize.width, imageSize.height)),
-          toScreen(Offset(0, imageSize.height)),
+          toScreen(const Offset(imageSize.width, 0)),
+          toScreen(const Offset(imageSize.width, imageSize.height)),
+          toScreen(const Offset(0, imageSize.height)),
         ];
         final centroid =
             corners.reduce((a, b) => a + b) / corners.length.toDouble();

--- a/test/features/crop_rotate_editor/widgets/tilt/tilt_item_row_test.dart
+++ b/test/features/crop_rotate_editor/widgets/tilt/tilt_item_row_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/editor_configs/crop_rotate_editor_configs.dart';
 import 'package:pro_image_editor/core/models/i18n/i18n_crop_rotate_editor.dart';
 import 'package:pro_image_editor/features/crop_rotate_editor/providers/tilt_provider.dart';

--- a/test/features/crop_rotate_editor/widgets/tilt/tilt_ruler_chooser_test.dart
+++ b/test/features/crop_rotate_editor/widgets/tilt/tilt_ruler_chooser_test.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: invalid_use_of_protected_member
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/editor_configs/pro_image_editor_configs.dart';
 import 'package:pro_image_editor/core/models/init_configs/crop_rotate_editor_init_configs.dart';
 import 'package:pro_image_editor/features/crop_rotate_editor/crop_rotate_editor.dart';

--- a/test/features/crop_rotate_editor/widgets/tilt/tilt_ruler_test.dart
+++ b/test/features/crop_rotate_editor/widgets/tilt/tilt_ruler_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/editor_configs/crop_rotate_editor_configs.dart';
 import 'package:pro_image_editor/features/crop_rotate_editor/widgets/tilt/tilt_ruler.dart';
 

--- a/test/features/emoji_editor_test.dart
+++ b/test/features/emoji_editor_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/features/emoji_editor/emoji_editor.dart';
 import 'package:pro_image_editor/plugins/emoji_picker_flutter/emoji_picker_flutter.dart';
 

--- a/test/features/filter_editor_test.dart
+++ b/test/features/filter_editor_test.dart
@@ -1,8 +1,7 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 import 'package:pro_image_editor/core/models/init_configs/filter_editor_init_configs.dart';
 import 'package:pro_image_editor/features/filter_editor/filter_editor.dart';

--- a/test/features/main_editor/merge_filters_test.dart
+++ b/test/features/main_editor/merge_filters_test.dart
@@ -1,10 +1,8 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:material_ui/material_ui.dart';
 // Project imports:
 import 'package:pro_image_editor/pro_image_editor.dart';
 

--- a/test/features/main_editor/merge_selected_layers_test.dart
+++ b/test/features/main_editor/merge_selected_layers_test.dart
@@ -1,10 +1,8 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:material_ui/material_ui.dart';
 // Project imports:
 import 'package:pro_image_editor/pro_image_editor.dart';
 

--- a/test/features/main_editor/multitouch_third_finger_test.dart
+++ b/test/features/main_editor/multitouch_third_finger_test.dart
@@ -1,12 +1,10 @@
 // Flutter imports:
 import 'dart:math';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:material_ui/material_ui.dart';
 // Project imports:
 import 'package:pro_image_editor/pro_image_editor.dart';
 

--- a/test/features/main_editor/services/paint_layer_merge_manager_test.dart
+++ b/test/features/main_editor/services/paint_layer_merge_manager_test.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/features/main_editor/services/paint_layer_merge_manager.dart';
 import 'package:pro_image_editor/features/paint_editor/models/eraser_model.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/test/features/main_editor/sizes_manager_test.dart
+++ b/test/features/main_editor/sizes_manager_test.dart
@@ -1,9 +1,7 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:material_ui/material_ui.dart';
 // Project imports:
 import 'package:pro_image_editor/features/main_editor/services/sizes_manager.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/test/features/main_editor_test.dart
+++ b/test/features/main_editor_test.dart
@@ -1,11 +1,9 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:network_image_mock/network_image_mock.dart';
-
 // Project imports:
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_image_editor/shared/widgets/layer/layer_widget.dart';

--- a/test/features/paint_editor/paint_editor_test.dart
+++ b/test/features/paint_editor/paint_editor_test.dart
@@ -1,9 +1,8 @@
 // Flutter imports:
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 import 'package:pro_image_editor/features/paint_editor/widgets/paint_canvas.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/test/features/paint_editor/painting_canvas_test.dart
+++ b/test/features/paint_editor/painting_canvas_test.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/features/paint_editor/controllers/paint_controller.dart';
 import 'package:pro_image_editor/features/paint_editor/widgets/paint_canvas.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/test/features/paint_editor/utils/draw/draw_canvas_test.dart
+++ b/test/features/paint_editor/utils/draw/draw_canvas_test.dart
@@ -1,8 +1,8 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/features/paint_editor/enums/paint_editor_enum.dart';
 import 'package:pro_image_editor/features/paint_editor/models/painted_model.dart';
 import 'package:pro_image_editor/features/paint_editor/widgets/draw_paint_item.dart';

--- a/test/features/paint_editor/utils/paint_controller_test.dart
+++ b/test/features/paint_editor/utils/paint_controller_test.dart
@@ -1,7 +1,7 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/features/paint_editor/controllers/paint_controller.dart';
 import 'package:pro_image_editor/features/paint_editor/enums/paint_editor_enum.dart';
 

--- a/test/features/paint_editor/widgets/paint_editor_layer_editor_test.dart
+++ b/test/features/paint_editor/widgets/paint_editor_layer_editor_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/features/paint_editor/widgets/paint_editor_layer_editor.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_image_editor/shared/widgets/layer/widgets/layer_widget_paint_item.dart';

--- a/test/features/sticker_editor_test.dart
+++ b/test/features/sticker_editor_test.dart
@@ -1,9 +1,7 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:material_ui/material_ui.dart';
 // Project imports:
 import 'package:pro_image_editor/pro_image_editor.dart';
 

--- a/test/features/text_editor/rounded_background_text_field_hitbox_test.dart
+++ b/test/features/text_editor/rounded_background_text_field_hitbox_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/editor_configs/text_editor_configs.dart';
 import 'package:pro_image_editor/features/text_editor/widgets/rounded_background_text/rounded_background_text.dart';
 import 'package:pro_image_editor/features/text_editor/widgets/rounded_background_text/rounded_background_text_field.dart';

--- a/test/features/text_editor_test.dart
+++ b/test/features/text_editor_test.dart
@@ -1,8 +1,7 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/features/text_editor/text_editor.dart';
 import 'package:pro_image_editor/shared/widgets/slider_bottom_sheet.dart';
 

--- a/test/features/tune_editor_test.dart
+++ b/test/features/tune_editor_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:mockito/mockito.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';

--- a/test/mock/layers/paint_layer_mock.dart
+++ b/test/mock/layers/paint_layer_mock.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/layers/layer_interaction.dart';
 import 'package:pro_image_editor/core/models/layers/paint_layer.dart';
 import 'package:pro_image_editor/features/paint_editor/paint_editor.dart';

--- a/test/mock/layers/text_layer_mock.dart
+++ b/test/mock/layers/text_layer_mock.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/layers/layer_interaction.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 

--- a/test/mock/layers/widget_layer_mock.dart
+++ b/test/mock/layers/widget_layer_mock.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/layers/layer_interaction.dart';
 import 'package:pro_image_editor/core/models/layers/widget_layer.dart';
 

--- a/test/models/editor_image_test.dart
+++ b/test/models/editor_image_test.dart
@@ -1,11 +1,10 @@
 // Dart imports:
 import 'dart:typed_data';
 
-// Flutter imports:
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+// Flutter imports:
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/editor_image.dart';
 import 'package:pro_image_editor/core/platform/io/io_helper.dart';
 

--- a/test/shared/factories/editor_mapper_test.dart
+++ b/test/shared/factories/editor_mapper_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_image_editor/shared/factories/editor_mapper.dart';
 

--- a/test/shared/services/import_export/import_export_test.dart
+++ b/test/shared/services/import_export/import_export_test.dart
@@ -1,8 +1,9 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+
 import '../../../mock/layers/emoji_layer_mock.dart';
 import '../../../mock/layers/paint_layer_mock.dart';
 import '../../../mock/layers/text_layer_mock.dart';

--- a/test/shared/services/import_export/import_state_history_test.dart
+++ b/test/shared/services/import_export/import_state_history_test.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/platform/io/io_helper.dart' show File;
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_image_editor/shared/services/import_export/utils/key_minifier.dart';

--- a/test/shared/services/layer_rasterizer/layer_rasterizer_host_test.dart
+++ b/test/shared/services/layer_rasterizer/layer_rasterizer_host_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_image_editor/shared/utils/default_editor_theme.dart';
 import 'package:pro_image_editor/shared/widgets/layer/layer_widget.dart';

--- a/test/shared/services/layer_rasterizer/layer_rasterizer_test.dart
+++ b/test/shared/services/layer_rasterizer/layer_rasterizer_test.dart
@@ -1,7 +1,7 @@
 import 'dart:ui' as ui;
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_image_editor/shared/widgets/layer/layer_widget.dart';
 

--- a/test/shared/services/layer_transform_generator_test.dart
+++ b/test/shared/services/layer_transform_generator_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_image_editor/shared/services/layer_transform_generator.dart';
 

--- a/test/shared/styles/platform_text_styles_test.dart
+++ b/test/shared/styles/platform_text_styles_test.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/enums/design_mode.dart';
 import 'package:pro_image_editor/shared/styles/platform_text_styles.dart';
 

--- a/test/shared/widgets/auto_image_test.dart
+++ b/test/shared/widgets/auto_image_test.dart
@@ -1,8 +1,7 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:network_image_mock/network_image_mock.dart';

--- a/test/shared/widgets/color_picker/bar_color_picker_test.dart
+++ b/test/shared/widgets/color_picker/bar_color_picker_test.dart
@@ -1,10 +1,8 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:mockito/annotations.dart';
-
 // Project imports:
 import 'package:pro_image_editor/core/models/editor_configs/pro_image_editor_configs.dart';
 import 'package:pro_image_editor/shared/widgets/color_picker/bar_color_picker.dart';

--- a/test/shared/widgets/layer_widget_test.dart
+++ b/test/shared/widgets/layer_widget_test.dart
@@ -1,9 +1,7 @@
 // Flutter imports:
-import 'package:flutter/material.dart';
-
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:material_ui/material_ui.dart';
 // Project imports:
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_image_editor/shared/widgets/layer/layer_widget.dart';


### PR DESCRIPTION
## Summary

Migrates this package from Flutter’s built-in Material and Cupertino libraries to the standalone [`[material_ui](https://pub.dev/packages/material_ui)`](https://pub.dev/packages/material_ui) and [`[cupertino_ui](https://pub.dev/packages/cupertino_ui)`](https://pub.dev/packages/cupertino_ui) packages introduced in Flutter 3.47.

## Changes

- Added the standalone UI packages to dependencies.
- Replaced imports from:
  - `package:flutter/material.dart`
  - `package:flutter/cupertino.dart`
- Applied Flutter’s `migrate_design_widgets` automated migration.

## Testing

- [x] `flutter analyze`
- [ ] `flutter test`