### PR TITLE
fix(tune-editor): replace stacked globals on re-apply and host materi…

### DIFF
--- a/lib/core/models/styles/tune_editor_style.dart
+++ b/lib/core/models/styles/tune_editor_style.dart
@@ -1,5 +1,6 @@
 // Flutter imports:
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 
 import '../../constants/editor_style_constants.dart';
 
@@ -19,6 +20,7 @@ class TuneEditorStyle {
     this.bottomBarBackground = kImageEditorBottomBarBackground,
     this.bottomBarActiveItemColor = kImageEditorPrimaryColor,
     this.bottomBarInactiveItemColor = kImageEditorBottomBarColor,
+    this.bottomBarActiveItemDecoration,
     this.background = kImageEditorBackground,
     this.uiOverlayStyle = kImageEditorUiOverlayStyle,
   });
@@ -41,6 +43,12 @@ class TuneEditorStyle {
   /// Color of inactive items in the bottom navigation bar.
   final Color bottomBarInactiveItemColor;
 
+  /// Optional decoration drawn behind the selected tune item.
+  ///
+  /// Use this to add a box, background, or border so the active adjustment
+  /// stays recognizable when active/inactive colors are close.
+  final BoxDecoration? bottomBarActiveItemDecoration;
+
   /// UI overlay style, defining the appearance of system status bars.
   final SystemUiOverlayStyle uiOverlayStyle;
 
@@ -62,6 +70,7 @@ class TuneEditorStyle {
     Color? bottomBarBackground,
     Color? bottomBarActiveItemColor,
     Color? bottomBarInactiveItemColor,
+    BoxDecoration? bottomBarActiveItemDecoration,
     SystemUiOverlayStyle? uiOverlayStyle,
   }) {
     return TuneEditorStyle(
@@ -73,6 +82,8 @@ class TuneEditorStyle {
           bottomBarActiveItemColor ?? this.bottomBarActiveItemColor,
       bottomBarInactiveItemColor:
           bottomBarInactiveItemColor ?? this.bottomBarInactiveItemColor,
+      bottomBarActiveItemDecoration:
+          bottomBarActiveItemDecoration ?? this.bottomBarActiveItemDecoration,
       uiOverlayStyle: uiOverlayStyle ?? this.uiOverlayStyle,
     );
   }

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -30,6 +30,7 @@ import '/shared/utils/file_constructor_utils.dart';
 import '/shared/utils/transparent_image_generator_utils.dart';
 import '/shared/widgets/adaptive_dialog.dart';
 import '/shared/widgets/extended/interactive_viewer/extended_interactive_viewer.dart';
+import '/shared/widgets/material_ui_localizations_scope.dart';
 import '/shared/widgets/screen_resize_detector.dart';
 import '../audio_editor/audio_editor_page.dart';
 import '../audio_editor/models/audio_editor_response.dart';
@@ -2189,11 +2190,11 @@ class ProImageEditorState extends State<ProImageEditor>
 
     if (tuneAdjustments == null) return;
 
+    // TuneEditor returns the merged set: current global slider values plus
+    // any timed/custom entries it did not edit. Replacing (not appending)
+    // avoids stacking the same untimed ids across sessions.
     addHistory(
-      tuneAdjustments: [
-        ...stateManager.activeTuneAdjustments.map((item) => item.copy()),
-        ...tuneAdjustments,
-      ],
+      tuneAdjustments: tuneAdjustments.map((item) => item.copy()).toList(),
       heroScreenshotRequired: true,
     );
 
@@ -3168,7 +3169,8 @@ class ProImageEditorState extends State<ProImageEditor>
   Widget build(BuildContext context) {
     _theme = configs.theme ?? defaultEditorTheme();
 
-    return RecordInvisibleWidget(
+    return MaterialUiLocalizationsScope(
+      child: RecordInvisibleWidget(
       controller: _controllers.screenshot,
       child: ExtendedPopScope(
         canPop:
@@ -3309,6 +3311,7 @@ class ProImageEditorState extends State<ProImageEditor>
             ),
           ),
         ),
+      ),
       ),
     );
   }

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -3171,147 +3171,149 @@ class ProImageEditorState extends State<ProImageEditor>
 
     return MaterialUiLocalizationsScope(
       child: RecordInvisibleWidget(
-      controller: _controllers.screenshot,
-      child: ExtendedPopScope(
-        canPop:
-            (isPopScopeDisabled ||
-                !stateManager.canUndo ||
-                _isProcessingFinalImage) &&
-            (!mainEditorConfigs.enableSubEditorPage || !isSubEditorOpen),
-        onPopInvokedWithResult: (didPop, result) {
-          if (mainEditorConfigs.enableSubEditorPage && isSubEditorOpen) {
-            if (_navigatorKey.currentState?.canPop() == true) {
-              _navigatorKey.currentState?.pop();
-              return;
+        controller: _controllers.screenshot,
+        child: ExtendedPopScope(
+          canPop:
+              (isPopScopeDisabled ||
+                  !stateManager.canUndo ||
+                  _isProcessingFinalImage) &&
+              (!mainEditorConfigs.enableSubEditorPage || !isSubEditorOpen),
+          onPopInvokedWithResult: (didPop, result) {
+            if (mainEditorConfigs.enableSubEditorPage && isSubEditorOpen) {
+              if (_navigatorKey.currentState?.canPop() == true) {
+                _navigatorKey.currentState?.pop();
+                return;
+              }
             }
-          }
-          if (!didPop &&
-              !isPopScopeDisabled &&
-              stateManager.canUndo &&
-              !_isProcessingFinalImage) {
-            closeWarning();
-          }
-          mainEditorCallbacks?.onPopInvoked?.call(didPop, result);
-        },
-        child: ImageInfosProvider(
-          infos: _imageInfos,
-          imageFitToWidth:
-              _imageInfos?.renderedSize.width == sizesManager.bodySize.width,
-          child: ScreenResizeDetector(
-            ignoreSafeArea: false,
-            onResizeUpdate: (event) {
-              sizesManager
-                ..recalculateLayerPosition(
-                  history: stateManager.stateHistory,
-                  resizeEvent: ResizeEvent(
-                    oldContentSize: Size(
-                      event.oldContentSize.width,
-                      event.oldContentSize.height -
-                          sizesManager.allToolbarHeight,
+            if (!didPop &&
+                !isPopScopeDisabled &&
+                stateManager.canUndo &&
+                !_isProcessingFinalImage) {
+              closeWarning();
+            }
+            mainEditorCallbacks?.onPopInvoked?.call(didPop, result);
+          },
+          child: ImageInfosProvider(
+            infos: _imageInfos,
+            imageFitToWidth:
+                _imageInfos?.renderedSize.width == sizesManager.bodySize.width,
+            child: ScreenResizeDetector(
+              ignoreSafeArea: false,
+              onResizeUpdate: (event) {
+                sizesManager
+                  ..recalculateLayerPosition(
+                    history: stateManager.stateHistory,
+                    resizeEvent: ResizeEvent(
+                      oldContentSize: Size(
+                        event.oldContentSize.width,
+                        event.oldContentSize.height -
+                            sizesManager.allToolbarHeight,
+                      ),
+                      newContentSize: Size(
+                        event.newContentSize.width,
+                        event.newContentSize.height -
+                            sizesManager.allToolbarHeight,
+                      ),
                     ),
-                    newContentSize: Size(
-                      event.newContentSize.width,
-                      event.newContentSize.height -
-                          sizesManager.allToolbarHeight,
-                    ),
-                  ),
-                )
-                ..lastScreenSize = event.newContentSize;
-            },
-            onResizeEnd: (event) async {
-              await decodeImage();
-            },
-            child: AnnotatedRegion<SystemUiOverlayStyle>(
-              value: mainEditorConfigs.style.uiOverlayStyle,
-              child: Theme(
-                data: _theme,
-                child: SafeArea(
-                  top: mainEditorConfigs.safeArea.top,
-                  bottom: mainEditorConfigs.safeArea.bottom,
-                  left: mainEditorConfigs.safeArea.left,
-                  right: mainEditorConfigs.safeArea.right,
-                  child: LayoutBuilder(
-                    builder: (context, constraints) {
-                      sizesManager.editorSize = constraints.biggest;
-                      var scaffold = Scaffold(
-                        backgroundColor: mainEditorConfigs.style.background,
-                        resizeToAvoidBottomInset: false,
-                        appBar: _buildAppBar(),
-                        body: _buildBody(),
-                        bottomNavigationBar: ValueListenableBuilder(
-                          valueListenable: _audioBottomBarNotifier,
-                          builder: (_, showAudioBar, _) {
-                            return AnimatedSwitcher(
-                              duration: const Duration(milliseconds: 220),
-                              switchInCurve: Curves.ease,
-                              switchOutCurve: Curves.ease,
-                              transitionBuilder: (child, animation) {
-                                return SizeTransition(
-                                  sizeFactor: animation,
-                                  alignment: Alignment.topCenter,
-                                  child: child,
-                                );
-                              },
-                              layoutBuilder: (currentChild, previousChildren) {
-                                return Stack(
-                                  alignment: .bottomCenter,
-                                  children: [
-                                    ...previousChildren,
-                                    ?currentChild,
-                                  ],
-                                );
-                              },
-                              child: showAudioBar
-                                  ? AudioMainBottomBar(
-                                      configs: configs,
-                                      controller: _videoController!,
-                                      audioEditorCallbacks:
-                                          audioEditorCallbacks,
-                                      onSelectAudioTrack: () => openAudioEditor(
-                                        enforceChooseTrackPage: true,
-                                      ),
-                                      onConfirmChanges: () {
-                                        _audioBottomBarNotifier.value = false;
-                                      },
-                                    )
-                                  : _buildBottomNavBar() ??
-                                        const SizedBox.shrink(),
-                            );
-                          },
-                        ),
-                      );
+                  )
+                  ..lastScreenSize = event.newContentSize;
+              },
+              onResizeEnd: (event) async {
+                await decodeImage();
+              },
+              child: AnnotatedRegion<SystemUiOverlayStyle>(
+                value: mainEditorConfigs.style.uiOverlayStyle,
+                child: Theme(
+                  data: _theme,
+                  child: SafeArea(
+                    top: mainEditorConfigs.safeArea.top,
+                    bottom: mainEditorConfigs.safeArea.bottom,
+                    left: mainEditorConfigs.safeArea.left,
+                    right: mainEditorConfigs.safeArea.right,
+                    child: LayoutBuilder(
+                      builder: (context, constraints) {
+                        sizesManager.editorSize = constraints.biggest;
+                        var scaffold = Scaffold(
+                          backgroundColor: mainEditorConfigs.style.background,
+                          resizeToAvoidBottomInset: false,
+                          appBar: _buildAppBar(),
+                          body: _buildBody(),
+                          bottomNavigationBar: ValueListenableBuilder(
+                            valueListenable: _audioBottomBarNotifier,
+                            builder: (_, showAudioBar, _) {
+                              return AnimatedSwitcher(
+                                duration: const Duration(milliseconds: 220),
+                                switchInCurve: Curves.ease,
+                                switchOutCurve: Curves.ease,
+                                transitionBuilder: (child, animation) {
+                                  return SizeTransition(
+                                    sizeFactor: animation,
+                                    alignment: Alignment.topCenter,
+                                    child: child,
+                                  );
+                                },
+                                layoutBuilder:
+                                    (currentChild, previousChildren) {
+                                      return Stack(
+                                        alignment: .bottomCenter,
+                                        children: [
+                                          ...previousChildren,
+                                          ?currentChild,
+                                        ],
+                                      );
+                                    },
+                                child: showAudioBar
+                                    ? AudioMainBottomBar(
+                                        configs: configs,
+                                        controller: _videoController!,
+                                        audioEditorCallbacks:
+                                            audioEditorCallbacks,
+                                        onSelectAudioTrack: () =>
+                                            openAudioEditor(
+                                              enforceChooseTrackPage: true,
+                                            ),
+                                        onConfirmChanges: () {
+                                          _audioBottomBarNotifier.value = false;
+                                        },
+                                      )
+                                    : _buildBottomNavBar() ??
+                                          const SizedBox.shrink(),
+                              );
+                            },
+                          ),
+                        );
 
-                      if (mainEditorConfigs.enableSubEditorPage) {
-                        return Stack(
-                          children: [
-                            scaffold,
-                            Positioned.fill(
-                              child: IgnorePointer(
-                                ignoring: !isSubEditorOpen,
-                                child: Navigator(
-                                  key: _navigatorKey,
-                                  onGenerateRoute: (settings) =>
-                                      PageRouteBuilder(
-                                        opaque: false,
-                                        pageBuilder: (context, _, _) =>
-                                            const SizedBox.shrink(),
-                                      ),
+                        if (mainEditorConfigs.enableSubEditorPage) {
+                          return Stack(
+                            children: [
+                              scaffold,
+                              Positioned.fill(
+                                child: IgnorePointer(
+                                  ignoring: !isSubEditorOpen,
+                                  child: Navigator(
+                                    key: _navigatorKey,
+                                    onGenerateRoute: (settings) =>
+                                        PageRouteBuilder(
+                                          opaque: false,
+                                          pageBuilder: (context, _, _) =>
+                                              const SizedBox.shrink(),
+                                        ),
+                                  ),
                                 ),
                               ),
-                            ),
-                          ],
-                        );
-                      }
+                            ],
+                          );
+                        }
 
-                      return scaffold;
-                    },
+                        return scaffold;
+                      },
+                    ),
                   ),
                 ),
               ),
             ),
           ),
         ),
-      ),
       ),
     );
   }

--- a/lib/features/tune_editor/models/tune_adjustment_matrix.dart
+++ b/lib/features/tune_editor/models/tune_adjustment_matrix.dart
@@ -91,6 +91,16 @@ class TuneAdjustmentMatrix {
   /// User-defined metadata that can be attached to this tune adjustment.
   final Map<String, dynamic> meta;
 
+  /// Whether this adjustment carries video-timeline scheduling.
+  ///
+  /// Timed entries can share an [id] with a global adjustment and must not be
+  /// collapsed together.
+  bool get hasTimeline =>
+      startTime != null ||
+      endTime != null ||
+      enterDuration != null ||
+      exitDuration != null;
+
   /// Converts this [TuneAdjustmentMatrix] instance into a [Map] representation.
   ///
   /// The map contains the [id], [value], and [matrix] as key-value pairs.

--- a/lib/features/tune_editor/tune_editor.dart
+++ b/lib/features/tune_editor/tune_editor.dart
@@ -377,34 +377,34 @@ class TuneEditorState extends State<TuneEditor>
   Widget build(BuildContext context) {
     return MaterialUiLocalizationsScope(
       child: Theme(
-      data: theme.copyWith(
-        tooltipTheme: theme.tooltipTheme.copyWith(preferBelow: true),
-      ),
-      child: ExtendedPopScope(
-        canPop: tuneEditorConfigs.enableGesturePop,
-        child: AnnotatedRegion<SystemUiOverlayStyle>(
-          value: tuneEditorConfigs.style.uiOverlayStyle,
-          child: SafeArea(
-            top: tuneEditorConfigs.safeArea.top,
-            bottom: tuneEditorConfigs.safeArea.bottom,
-            left: tuneEditorConfigs.safeArea.left,
-            right: tuneEditorConfigs.safeArea.right,
-            child: RecordInvisibleWidget(
-              controller: screenshotCtrl,
-              child: MediaQuery.removePadding(
-                context: context,
-                removeBottom: !tuneEditorConfigs.safeArea.bottom,
-                child: Scaffold(
-                  backgroundColor: tuneEditorConfigs.style.background,
-                  appBar: _buildAppBar(),
-                  body: _buildBody(),
-                  bottomNavigationBar: _buildBottomNavBar(),
+        data: theme.copyWith(
+          tooltipTheme: theme.tooltipTheme.copyWith(preferBelow: true),
+        ),
+        child: ExtendedPopScope(
+          canPop: tuneEditorConfigs.enableGesturePop,
+          child: AnnotatedRegion<SystemUiOverlayStyle>(
+            value: tuneEditorConfigs.style.uiOverlayStyle,
+            child: SafeArea(
+              top: tuneEditorConfigs.safeArea.top,
+              bottom: tuneEditorConfigs.safeArea.bottom,
+              left: tuneEditorConfigs.safeArea.left,
+              right: tuneEditorConfigs.safeArea.right,
+              child: RecordInvisibleWidget(
+                controller: screenshotCtrl,
+                child: MediaQuery.removePadding(
+                  context: context,
+                  removeBottom: !tuneEditorConfigs.safeArea.bottom,
+                  child: Scaffold(
+                    backgroundColor: tuneEditorConfigs.style.background,
+                    appBar: _buildAppBar(),
+                    body: _buildBody(),
+                    bottomNavigationBar: _buildBottomNavBar(),
+                  ),
                 ),
               ),
             ),
           ),
         ),
-      ),
       ),
     );
   }

--- a/lib/features/tune_editor/tune_editor.dart
+++ b/lib/features/tune_editor/tune_editor.dart
@@ -15,7 +15,9 @@ import '/pro_image_editor.dart';
 import '/shared/services/content_recorder/widgets/content_recorder.dart';
 import '/shared/utils/file_constructor_utils.dart';
 import '/shared/widgets/layer/layer_stack.dart';
+import '/shared/widgets/material_ui_localizations_scope.dart';
 import '/shared/widgets/transform/transformed_content_generator.dart';
+import 'utils/merge_tune_adjustments.dart';
 import 'utils/tune_presets.dart';
 import 'widgets/tune_editor_appbar.dart';
 
@@ -220,24 +222,16 @@ class TuneEditorState extends State<TuneEditor>
     var items =
         tuneEditorConfigs.tuneAdjustmentOptions ??
         tunePresets(icons: tuneEditorConfigs.icons, i18n: i18n.tuneEditor);
-    tuneAdjustmentList = items.map((item) {
-      return item.copyWith(
-        value: tuneAdjustmentMatrix
-            .firstWhere(
-              (el) => el.id == item.id,
-              orElse: () =>
-                  TuneAdjustmentMatrix(id: 'id', value: 0, matrix: []),
-            )
-            .value,
-      );
-    }).toList();
 
-    for (final item in items) {
-      int i = appliedTuneAdjustments.indexWhere((el) => el.id == item.id);
-      tuneAdjustmentMatrix.add(
-        i >= 0 ? appliedTuneAdjustments[i] : item.toMatrixItem(),
-      );
-    }
+    // Seed each slider from the latest untimed/global entry of that id so a
+    // stacked history still recovers, while timed/custom entries stay out of
+    // the slider list and are merged back on Done.
+    tuneAdjustmentMatrix = [
+      for (final item in items)
+        latestGlobalTuneAdjustment(appliedTuneAdjustments, item.id) ??
+            item.toMatrixItem(),
+    ];
+    tuneAdjustmentList = items;
 
     tuneEditorCallbacks?.onInit?.call();
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
@@ -261,12 +255,16 @@ class TuneEditorState extends State<TuneEditor>
   /// Handles the "Done" action, either by applying changes or closing the
   /// editor.
   void done() async {
+    final adjustments = mergeTuneEditorResult(
+      existing: appliedTuneAdjustments,
+      session: tuneAdjustmentMatrix,
+    );
     doneEditing(
       editorImage: editorImage,
-      returnValue: tuneAdjustmentMatrix,
+      returnValue: adjustments,
       blur: appliedBlurFactor,
       matrixFilterList: appliedFilters,
-      matrixTuneAdjustmentsList: tuneAdjustmentMatrix
+      matrixTuneAdjustmentsList: adjustments
           .map((item) => item.matrix)
           .toList(),
       transform: initialTransformConfigs,
@@ -377,7 +375,8 @@ class TuneEditorState extends State<TuneEditor>
 
   @override
   Widget build(BuildContext context) {
-    return Theme(
+    return MaterialUiLocalizationsScope(
+      child: Theme(
       data: theme.copyWith(
         tooltipTheme: theme.tooltipTheme.copyWith(preferBelow: true),
       ),
@@ -405,6 +404,7 @@ class TuneEditorState extends State<TuneEditor>
             ),
           ),
         ),
+      ),
       ),
     );
   }
@@ -491,7 +491,10 @@ class TuneEditorState extends State<TuneEditor>
               videoPlayer: videoController?.videoPlayer,
               blankSize: initConfigs.mainImageSize,
               filters: appliedFilters,
-              tuneAdjustments: tuneAdjustmentMatrix,
+              tuneAdjustments: mergeTuneEditorResult(
+                existing: appliedTuneAdjustments,
+                session: tuneAdjustmentMatrix,
+              ),
               blurFactor: appliedBlurFactor,
             );
           },

--- a/lib/features/tune_editor/utils/merge_tune_adjustments.dart
+++ b/lib/features/tune_editor/utils/merge_tune_adjustments.dart
@@ -1,0 +1,62 @@
+import '../models/tune_adjustment_matrix.dart';
+
+/// Latest untimed/global adjustment for [id], or `null` if none exist.
+///
+/// Duplicate global entries (from a session that stacked the same ids) are
+/// collapsed by taking the last write. Timed entries with the same [id] are
+/// ignored so they can keep coexisting with the global slot.
+TuneAdjustmentMatrix? latestGlobalTuneAdjustment(
+  Iterable<TuneAdjustmentMatrix> applied,
+  String id,
+) {
+  TuneAdjustmentMatrix? latest;
+  for (final adjustment in applied) {
+    if (adjustment.id == id && !adjustment.hasTimeline) {
+      latest = adjustment;
+    }
+  }
+  return latest;
+}
+
+/// Merges a TuneEditor session with previously applied adjustments.
+///
+/// TuneEditor only edits one untimed/global slot per known option id. This
+/// keeps timed entries and any id absent from [session] (order and duplicates
+/// included), replaces the matching global slots with [session], and drops
+/// leftover untimed duplicates of those known ids created by the old
+/// append-on-apply stacking bug.
+List<TuneAdjustmentMatrix> mergeTuneEditorResult({
+  required List<TuneAdjustmentMatrix> existing,
+  required List<TuneAdjustmentMatrix> session,
+}) {
+  final sessionById = <String, TuneAdjustmentMatrix>{
+    for (final item in session) item.id: item,
+  };
+  final result = <TuneAdjustmentMatrix>[];
+  final placedSessionIds = <String>{};
+
+  for (final item in existing) {
+    if (item.hasTimeline) {
+      result.add(item.copy());
+      continue;
+    }
+
+    final replacement = sessionById[item.id];
+    if (replacement != null) {
+      if (placedSessionIds.add(item.id)) {
+        result.add(replacement.copy());
+      }
+      continue;
+    }
+
+    result.add(item.copy());
+  }
+
+  for (final item in session) {
+    if (placedSessionIds.add(item.id)) {
+      result.add(item.copy());
+    }
+  }
+
+  return result;
+}

--- a/lib/features/tune_editor/widgets/tune_editor_bottombar.dart
+++ b/lib/features/tune_editor/widgets/tune_editor_bottombar.dart
@@ -124,7 +124,10 @@ class _TuneEditorBottombarState extends State<TuneEditorBottombar> {
                     widget.state,
                     widget.rebuildController.stream,
                     value,
-                    widget.onChanged,
+                    (val) {
+                      _sliderValue.value = val;
+                      widget.onChanged(val);
+                    },
                     widget.onChangedEnd,
                   ) ??
                   Slider(
@@ -169,10 +172,11 @@ class _TuneEditorBottombarState extends State<TuneEditorBottombar> {
                 index,
               ) {
                 var item = widget.tuneAdjustmentList[index];
-                var color = widget.selectedIndex == index
+                final isSelected = widget.selectedIndex == index;
+                var color = isSelected
                     ? widget.tuneEditorConfigs.style.bottomBarActiveItemColor
                     : widget.tuneEditorConfigs.style.bottomBarInactiveItemColor;
-                return FlatIconTextButton(
+                Widget button = FlatIconTextButton(
                   label: Text(
                     item.label,
                     style: _textStyle.copyWith(color: color),
@@ -180,6 +184,19 @@ class _TuneEditorBottombarState extends State<TuneEditorBottombar> {
                   icon: Icon(item.icon, size: _iconSize, color: color),
                   onPressed: () => widget.onSelect(index),
                 );
+                final decoration = isSelected
+                    ? widget
+                          .tuneEditorConfigs
+                          .style
+                          .bottomBarActiveItemDecoration
+                    : null;
+                if (decoration != null) {
+                  button = DecoratedBox(
+                    decoration: decoration,
+                    child: button,
+                  );
+                }
+                return button;
               }),
             ),
           ),

--- a/lib/features/tune_editor/widgets/tune_editor_bottombar.dart
+++ b/lib/features/tune_editor/widgets/tune_editor_bottombar.dart
@@ -191,10 +191,7 @@ class _TuneEditorBottombarState extends State<TuneEditorBottombar> {
                           .bottomBarActiveItemDecoration
                     : null;
                 if (decoration != null) {
-                  button = DecoratedBox(
-                    decoration: decoration,
-                    child: button,
-                  );
+                  button = DecoratedBox(decoration: decoration, child: button);
                 }
                 return button;
               }),

--- a/lib/shared/widgets/adaptive_dialog.dart
+++ b/lib/shared/widgets/adaptive_dialog.dart
@@ -5,6 +5,7 @@ import 'package:material_ui/material_ui.dart';
 // Project imports:
 import '/core/enums/design_mode.dart';
 import '/core/models/styles/adaptive_dialog_style.dart';
+import 'material_ui_localizations_scope.dart';
 
 /// A dialog that adapts its appearance based on the design mode.
 class AdaptiveDialog extends StatefulWidget {
@@ -76,10 +77,12 @@ class _AdaptiveDialogState extends State<AdaptiveDialog> {
       );
     } else {
       // Return a Material-style dialog for other design modes.
-      return AlertDialog(
-        title: widget.title,
-        content: widget.content,
-        actions: widget.actions,
+      return MaterialUiLocalizationsScope(
+        child: AlertDialog(
+          title: widget.title,
+          content: widget.content,
+          actions: widget.actions,
+        ),
       );
     }
   }

--- a/lib/shared/widgets/material_ui_localizations_scope.dart
+++ b/lib/shared/widgets/material_ui_localizations_scope.dart
@@ -1,0 +1,49 @@
+import 'package:material_ui/material_ui.dart';
+
+/// Provides `package:material_ui` [MaterialLocalizations] when the host app
+/// still uses the SDK `MaterialApp`.
+///
+/// Overlay dialogs and sub-editor routes sit under the host navigator, so they
+/// cannot see a theme wrapper around [ProImageEditor] alone.
+///
+/// An existing host [MaterialLocalizations] is left alone, including regional
+/// locales such as `en_GB`. A fallback is inserted only when the lookup
+/// misses:
+/// - [GlobalMaterialLocalizations] when that delegate supports the ambient
+///   locale
+/// - otherwise [DefaultMaterialLocalizations] (US English)
+class MaterialUiLocalizationsScope extends StatelessWidget {
+  /// Creates a [MaterialUiLocalizationsScope].
+  const MaterialUiLocalizationsScope({super.key, required this.child});
+
+  /// The subtree that needs material_ui localizations.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (Localizations.of<MaterialLocalizations>(
+          context,
+          MaterialLocalizations,
+        ) !=
+        null) {
+      return child;
+    }
+
+    final locale = Localizations.maybeLocaleOf(context) ?? const Locale('en');
+    final useGlobal = GlobalMaterialLocalizations.delegate.isSupported(locale);
+
+    return Localizations.override(
+      context: context,
+      // DefaultMaterialLocalizations.delegate only accepts English. Keep the
+      // ambient locale when the global catalog can serve it; otherwise load
+      // US English so the fallback delegate is not skipped.
+      locale: useGlobal ? locale : const Locale('en'),
+      delegates: [
+        useGlobal
+            ? GlobalMaterialLocalizations.delegate
+            : DefaultMaterialLocalizations.delegate,
+      ],
+      child: child,
+    );
+  }
+}

--- a/lib/shared/widgets/overlays/loading_dialog/loading_dialog.dart
+++ b/lib/shared/widgets/overlays/loading_dialog/loading_dialog.dart
@@ -6,6 +6,7 @@ import 'package:material_ui/material_ui.dart';
 // Project imports:
 import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '../../../styles/platform_text_styles.dart';
+import '../../material_ui_localizations_scope.dart';
 import '../../platform/platform_circular_progress_indicator.dart';
 import 'animations/loading_dialog_opacity_animation.dart';
 import 'models/loading_dialog_overlay_details.dart';
@@ -159,14 +160,16 @@ class LoadingDialog extends ChangeNotifier {
     required ThemeData theme,
     required Widget content,
   }) {
-    return Theme(
-      data: theme,
-      child: AlertDialog(
-        contentPadding: const EdgeInsets.symmetric(
-          vertical: 16,
-          horizontal: 20,
+    return MaterialUiLocalizationsScope(
+      child: Theme(
+        data: theme,
+        child: AlertDialog(
+          contentPadding: const EdgeInsets.symmetric(
+            vertical: 16,
+            horizontal: 20,
+          ),
+          content: content,
         ),
-        content: content,
       ),
     );
   }

--- a/test/features/main_editor_test.dart
+++ b/test/features/main_editor_test.dart
@@ -423,4 +423,135 @@ void main() {
       );
     });
   });
+
+  testWidgets(
+    're-applying tune adjustments replaces the previous session',
+    (WidgetTester tester) async {
+      final key = GlobalKey<ProImageEditorState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ProImageEditor.memory(
+            mockMemoryImage,
+            key: key,
+            configs: configs,
+            callbacks: ProImageEditorCallbacks(
+              onImageEditingComplete: (Uint8List bytes) async {},
+            ),
+          ),
+        ),
+      );
+
+      Future<void> applyTune(double brightness) async {
+        final openBtn = find.byKey(const ValueKey('open-tune-editor-btn'));
+        expect(openBtn, findsOneWidget);
+        await tester.tap(openBtn);
+        await tester.pumpAndSettle();
+
+        final TuneEditorState tuneState = tester.state(find.byType(TuneEditor));
+        tuneState
+          ..onChangedStart(brightness)
+          ..onChanged(brightness)
+          ..onChangedEnd(brightness);
+        await tester.pump();
+
+        await tester.tap(find.byTooltip('Done'));
+        await tester.pumpAndSettle();
+      }
+
+      await applyTune(-0.4);
+      final firstPass = List<TuneAdjustmentMatrix>.from(
+        key.currentState!.stateManager.activeTuneAdjustments,
+      );
+      expect(firstPass.where((item) => item.id == 'brightness').length, 1);
+      expect(
+        firstPass.firstWhere((item) => item.id == 'brightness').value,
+        -0.4,
+      );
+
+      await applyTune(-0.4);
+      final secondPass = key.currentState!.stateManager.activeTuneAdjustments;
+      expect(
+        secondPass.where((item) => item.id == 'brightness').length,
+        1,
+      );
+      expect(secondPass.length, firstPass.length);
+      expect(
+        secondPass.firstWhere((item) => item.id == 'brightness').value,
+        -0.4,
+      );
+    },
+  );
+
+  testWidgets(
+    're-applying tune keeps timed and unknown adjustments',
+    (WidgetTester tester) async {
+      final key = GlobalKey<ProImageEditorState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ProImageEditor.memory(
+            mockMemoryImage,
+            key: key,
+            configs: configs,
+            callbacks: ProImageEditorCallbacks(
+              onImageEditingComplete: (Uint8List bytes) async {},
+            ),
+          ),
+        ),
+      );
+
+      final timedBrightness = TuneAdjustmentMatrix(
+        id: 'brightness',
+        value: -0.2,
+        matrix: ColorFilterAddons.brightness(-0.2),
+        startTime: const Duration(seconds: 1),
+        endTime: const Duration(seconds: 4),
+      );
+      final custom = TuneAdjustmentMatrix(
+        id: 'custom-vignette',
+        value: 0.5,
+        matrix: ColorFilterAddons.brightness(0.5),
+      );
+      key.currentState!.addHistory(
+        tuneAdjustments: [timedBrightness, custom],
+      );
+      await tester.pump();
+
+      final openBtn = find.byKey(const ValueKey('open-tune-editor-btn'));
+      expect(openBtn, findsOneWidget);
+      await tester.tap(openBtn);
+      await tester.pumpAndSettle();
+
+      final TuneEditorState tuneState = tester.state(find.byType(TuneEditor));
+      tuneState
+        ..onChangedStart(-0.4)
+        ..onChanged(-0.4)
+        ..onChangedEnd(-0.4);
+      await tester.pump();
+
+      await tester.tap(find.byTooltip('Done'));
+      await tester.pumpAndSettle();
+
+      final result = key.currentState!.stateManager.activeTuneAdjustments;
+      expect(
+        result.where((item) => item.id == 'brightness' && item.hasTimeline),
+        [timedBrightness],
+      );
+      expect(
+        result.where((item) => item.id == 'custom-vignette'),
+        [custom],
+      );
+      expect(
+        result
+            .where((item) => item.id == 'brightness' && !item.hasTimeline)
+            .length,
+        1,
+      );
+      expect(
+        result
+            .firstWhere((item) => item.id == 'brightness' && !item.hasTimeline)
+            .value,
+        -0.4,
+      );
+    },
+  );
 }

--- a/test/features/main_editor_test.dart
+++ b/test/features/main_editor_test.dart
@@ -424,98 +424,24 @@ void main() {
     });
   });
 
-  testWidgets(
-    're-applying tune adjustments replaces the previous session',
-    (WidgetTester tester) async {
-      final key = GlobalKey<ProImageEditorState>();
-      await tester.pumpWidget(
-        MaterialApp(
-          home: ProImageEditor.memory(
-            mockMemoryImage,
-            key: key,
-            configs: configs,
-            callbacks: ProImageEditorCallbacks(
-              onImageEditingComplete: (Uint8List bytes) async {},
-            ),
+  testWidgets('re-applying tune adjustments replaces the previous session', (
+    WidgetTester tester,
+  ) async {
+    final key = GlobalKey<ProImageEditorState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ProImageEditor.memory(
+          mockMemoryImage,
+          key: key,
+          configs: configs,
+          callbacks: ProImageEditorCallbacks(
+            onImageEditingComplete: (Uint8List bytes) async {},
           ),
         ),
-      );
+      ),
+    );
 
-      Future<void> applyTune(double brightness) async {
-        final openBtn = find.byKey(const ValueKey('open-tune-editor-btn'));
-        expect(openBtn, findsOneWidget);
-        await tester.tap(openBtn);
-        await tester.pumpAndSettle();
-
-        final TuneEditorState tuneState = tester.state(find.byType(TuneEditor));
-        tuneState
-          ..onChangedStart(brightness)
-          ..onChanged(brightness)
-          ..onChangedEnd(brightness);
-        await tester.pump();
-
-        await tester.tap(find.byTooltip('Done'));
-        await tester.pumpAndSettle();
-      }
-
-      await applyTune(-0.4);
-      final firstPass = List<TuneAdjustmentMatrix>.from(
-        key.currentState!.stateManager.activeTuneAdjustments,
-      );
-      expect(firstPass.where((item) => item.id == 'brightness').length, 1);
-      expect(
-        firstPass.firstWhere((item) => item.id == 'brightness').value,
-        -0.4,
-      );
-
-      await applyTune(-0.4);
-      final secondPass = key.currentState!.stateManager.activeTuneAdjustments;
-      expect(
-        secondPass.where((item) => item.id == 'brightness').length,
-        1,
-      );
-      expect(secondPass.length, firstPass.length);
-      expect(
-        secondPass.firstWhere((item) => item.id == 'brightness').value,
-        -0.4,
-      );
-    },
-  );
-
-  testWidgets(
-    're-applying tune keeps timed and unknown adjustments',
-    (WidgetTester tester) async {
-      final key = GlobalKey<ProImageEditorState>();
-      await tester.pumpWidget(
-        MaterialApp(
-          home: ProImageEditor.memory(
-            mockMemoryImage,
-            key: key,
-            configs: configs,
-            callbacks: ProImageEditorCallbacks(
-              onImageEditingComplete: (Uint8List bytes) async {},
-            ),
-          ),
-        ),
-      );
-
-      final timedBrightness = TuneAdjustmentMatrix(
-        id: 'brightness',
-        value: -0.2,
-        matrix: ColorFilterAddons.brightness(-0.2),
-        startTime: const Duration(seconds: 1),
-        endTime: const Duration(seconds: 4),
-      );
-      final custom = TuneAdjustmentMatrix(
-        id: 'custom-vignette',
-        value: 0.5,
-        matrix: ColorFilterAddons.brightness(0.5),
-      );
-      key.currentState!.addHistory(
-        tuneAdjustments: [timedBrightness, custom],
-      );
-      await tester.pump();
-
+    Future<void> applyTune(double brightness) async {
       final openBtn = find.byKey(const ValueKey('open-tune-editor-btn'));
       expect(openBtn, findsOneWidget);
       await tester.tap(openBtn);
@@ -523,35 +449,96 @@ void main() {
 
       final TuneEditorState tuneState = tester.state(find.byType(TuneEditor));
       tuneState
-        ..onChangedStart(-0.4)
-        ..onChanged(-0.4)
-        ..onChangedEnd(-0.4);
+        ..onChangedStart(brightness)
+        ..onChanged(brightness)
+        ..onChangedEnd(brightness);
       await tester.pump();
 
       await tester.tap(find.byTooltip('Done'));
       await tester.pumpAndSettle();
+    }
 
-      final result = key.currentState!.stateManager.activeTuneAdjustments;
-      expect(
-        result.where((item) => item.id == 'brightness' && item.hasTimeline),
-        [timedBrightness],
-      );
-      expect(
-        result.where((item) => item.id == 'custom-vignette'),
-        [custom],
-      );
-      expect(
-        result
-            .where((item) => item.id == 'brightness' && !item.hasTimeline)
-            .length,
-        1,
-      );
-      expect(
-        result
-            .firstWhere((item) => item.id == 'brightness' && !item.hasTimeline)
-            .value,
-        -0.4,
-      );
-    },
-  );
+    await applyTune(-0.4);
+    final firstPass = List<TuneAdjustmentMatrix>.from(
+      key.currentState!.stateManager.activeTuneAdjustments,
+    );
+    expect(firstPass.where((item) => item.id == 'brightness').length, 1);
+    expect(firstPass.firstWhere((item) => item.id == 'brightness').value, -0.4);
+
+    await applyTune(-0.4);
+    final secondPass = key.currentState!.stateManager.activeTuneAdjustments;
+    expect(secondPass.where((item) => item.id == 'brightness').length, 1);
+    expect(secondPass.length, firstPass.length);
+    expect(
+      secondPass.firstWhere((item) => item.id == 'brightness').value,
+      -0.4,
+    );
+  });
+
+  testWidgets('re-applying tune keeps timed and unknown adjustments', (
+    WidgetTester tester,
+  ) async {
+    final key = GlobalKey<ProImageEditorState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ProImageEditor.memory(
+          mockMemoryImage,
+          key: key,
+          configs: configs,
+          callbacks: ProImageEditorCallbacks(
+            onImageEditingComplete: (Uint8List bytes) async {},
+          ),
+        ),
+      ),
+    );
+
+    final timedBrightness = TuneAdjustmentMatrix(
+      id: 'brightness',
+      value: -0.2,
+      matrix: ColorFilterAddons.brightness(-0.2),
+      startTime: const Duration(seconds: 1),
+      endTime: const Duration(seconds: 4),
+    );
+    final custom = TuneAdjustmentMatrix(
+      id: 'custom-vignette',
+      value: 0.5,
+      matrix: ColorFilterAddons.brightness(0.5),
+    );
+    key.currentState!.addHistory(tuneAdjustments: [timedBrightness, custom]);
+    await tester.pump();
+
+    final openBtn = find.byKey(const ValueKey('open-tune-editor-btn'));
+    expect(openBtn, findsOneWidget);
+    await tester.tap(openBtn);
+    await tester.pumpAndSettle();
+
+    final TuneEditorState tuneState = tester.state(find.byType(TuneEditor));
+    tuneState
+      ..onChangedStart(-0.4)
+      ..onChanged(-0.4)
+      ..onChangedEnd(-0.4);
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('Done'));
+    await tester.pumpAndSettle();
+
+    final result = key.currentState!.stateManager.activeTuneAdjustments;
+    expect(
+      result.where((item) => item.id == 'brightness' && item.hasTimeline),
+      [timedBrightness],
+    );
+    expect(result.where((item) => item.id == 'custom-vignette'), [custom]);
+    expect(
+      result
+          .where((item) => item.id == 'brightness' && !item.hasTimeline)
+          .length,
+      1,
+    );
+    expect(
+      result
+          .firstWhere((item) => item.id == 'brightness' && !item.hasTimeline)
+          .value,
+      -0.4,
+    );
+  });
 }

--- a/test/features/tune_editor/merge_tune_adjustments_test.dart
+++ b/test/features/tune_editor/merge_tune_adjustments_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pro_image_editor/features/filter_editor/utils/filter_generator/filter_addons.dart';
+import 'package:pro_image_editor/features/tune_editor/models/tune_adjustment_matrix.dart';
+import 'package:pro_image_editor/features/tune_editor/utils/merge_tune_adjustments.dart';
+
+TuneAdjustmentMatrix _brightness(
+  double value, {
+  Duration? startTime,
+  Duration? endTime,
+  Duration? enterDuration,
+}) {
+  return TuneAdjustmentMatrix(
+    id: 'brightness',
+    value: value,
+    matrix: ColorFilterAddons.brightness(value),
+    startTime: startTime,
+    endTime: endTime,
+    enterDuration: enterDuration,
+  );
+}
+
+TuneAdjustmentMatrix _custom(String id, double value) {
+  return TuneAdjustmentMatrix(
+    id: id,
+    value: value,
+    matrix: ColorFilterAddons.brightness(value),
+  );
+}
+
+void main() {
+  group('latestGlobalTuneAdjustment', () {
+    test('returns the last untimed entry for an id', () {
+      final latest = latestGlobalTuneAdjustment([
+        _brightness(-0.1),
+        _brightness(-0.4),
+      ], 'brightness');
+
+      expect(latest?.value, -0.4);
+    });
+
+    test('ignores timed entries with the same id', () {
+      final latest = latestGlobalTuneAdjustment([
+        _brightness(
+          -0.9,
+          startTime: const Duration(seconds: 1),
+          endTime: const Duration(seconds: 3),
+        ),
+        _brightness(-0.2),
+      ], 'brightness');
+
+      expect(latest?.value, -0.2);
+      expect(latest?.hasTimeline, isFalse);
+    });
+
+    test('returns null when only timed entries exist', () {
+      expect(
+        latestGlobalTuneAdjustment([
+          _brightness(
+            -0.9,
+            startTime: const Duration(seconds: 1),
+            endTime: const Duration(seconds: 3),
+          ),
+        ], 'brightness'),
+        isNull,
+      );
+    });
+  });
+
+  group('mergeTuneEditorResult', () {
+    test('replaces stacked global ids with the session values', () {
+      final merged = mergeTuneEditorResult(
+        existing: [_brightness(-0.1), _brightness(-0.4)],
+        session: [_brightness(-0.2), _custom('contrast', 0.1)],
+      );
+
+      expect(merged.where((item) => item.id == 'brightness').length, 1);
+      expect(
+        merged.firstWhere((item) => item.id == 'brightness').value,
+        -0.2,
+      );
+      expect(merged.firstWhere((item) => item.id == 'contrast').value, 0.1);
+    });
+
+    test('keeps timed entries and unknown custom ids', () {
+      final timed = _brightness(
+        -0.9,
+        startTime: const Duration(seconds: 1),
+        endTime: const Duration(seconds: 4),
+      );
+      final custom = _custom('custom-vignette', 0.5);
+
+      final merged = mergeTuneEditorResult(
+        existing: [timed, custom, _brightness(-0.4)],
+        session: [_brightness(0.1)],
+      );
+
+      expect(merged, [
+        timed,
+        custom,
+        _brightness(0.1),
+      ]);
+    });
+
+    test('keeps repeated timed entries of the same id', () {
+      final firstRange = _brightness(
+        -0.2,
+        startTime: const Duration(seconds: 0),
+        endTime: const Duration(seconds: 2),
+      );
+      final secondRange = _brightness(
+        0.3,
+        startTime: const Duration(seconds: 3),
+        endTime: const Duration(seconds: 5),
+      );
+
+      final merged = mergeTuneEditorResult(
+        existing: [firstRange, secondRange, _brightness(-0.1)],
+        session: [_brightness(0)],
+      );
+
+      expect(merged.where((item) => item.id == 'brightness').length, 3);
+      expect(merged.where((item) => item.hasTimeline).toList(), [
+        firstRange,
+        secondRange,
+      ]);
+    });
+
+    test('treats enterDuration as timeline and preserves it', () {
+      final fading = _brightness(
+        -0.5,
+        enterDuration: const Duration(milliseconds: 250),
+      );
+
+      final merged = mergeTuneEditorResult(
+        existing: [fading, _brightness(-0.1)],
+        session: [_brightness(0.2)],
+      );
+
+      expect(merged.where((item) => item.hasTimeline).single, fading);
+      expect(
+        merged.firstWhere((item) => !item.hasTimeline).value,
+        0.2,
+      );
+    });
+
+    test('preserves unknown ids including order and duplicates', () {
+      final first = _custom('custom-vignette', 0.2);
+      final second = _custom('custom-vignette', 0.5);
+
+      final merged = mergeTuneEditorResult(
+        existing: [first, second],
+        session: [_brightness(0)],
+      );
+
+      expect(merged.where((item) => item.id == 'custom-vignette').toList(), [
+        first,
+        second,
+      ]);
+    });
+  });
+}

--- a/test/features/tune_editor/merge_tune_adjustments_test.dart
+++ b/test/features/tune_editor/merge_tune_adjustments_test.dart
@@ -74,10 +74,7 @@ void main() {
       );
 
       expect(merged.where((item) => item.id == 'brightness').length, 1);
-      expect(
-        merged.firstWhere((item) => item.id == 'brightness').value,
-        -0.2,
-      );
+      expect(merged.firstWhere((item) => item.id == 'brightness').value, -0.2);
       expect(merged.firstWhere((item) => item.id == 'contrast').value, 0.1);
     });
 
@@ -94,11 +91,7 @@ void main() {
         session: [_brightness(0.1)],
       );
 
-      expect(merged, [
-        timed,
-        custom,
-        _brightness(0.1),
-      ]);
+      expect(merged, [timed, custom, _brightness(0.1)]);
     });
 
     test('keeps repeated timed entries of the same id', () {
@@ -137,10 +130,7 @@ void main() {
       );
 
       expect(merged.where((item) => item.hasTimeline).single, fading);
-      expect(
-        merged.firstWhere((item) => !item.hasTimeline).value,
-        0.2,
-      );
+      expect(merged.firstWhere((item) => !item.hasTimeline).value, 0.2);
     });
 
     test('preserves unknown ids including order and duplicates', () {

--- a/test/features/tune_editor_test.dart
+++ b/test/features/tune_editor_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:mockito/mockito.dart';
@@ -161,5 +163,177 @@ void main() {
       expect(state.canUndo, isTrue);
       expect(state.canRedo, isFalse);
     });
+
+    testWidgets('seeds sliders from appliedTuneAdjustments', (
+      WidgetTester tester,
+    ) async {
+      const brightnessValue = -0.4;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TuneEditor.memory(
+            mockMemoryImage,
+            initConfigs: TuneEditorInitConfigs(
+              theme: ThemeData(),
+              appliedTuneAdjustments: [
+                TuneAdjustmentMatrix(
+                  id: 'brightness',
+                  value: brightnessValue,
+                  matrix: ColorFilterAddons.brightness(brightnessValue),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final TuneEditorState state = tester.state(find.byType(TuneEditor));
+      expect(
+        state.tuneAdjustmentMatrix
+            .firstWhere((item) => item.id == 'brightness')
+            .value,
+        brightnessValue,
+      );
+    });
+
+    testWidgets('uses the last untimed value when ids are duplicated', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TuneEditor.memory(
+            mockMemoryImage,
+            initConfigs: TuneEditorInitConfigs(
+              theme: ThemeData(),
+              appliedTuneAdjustments: [
+                TuneAdjustmentMatrix(
+                  id: 'brightness',
+                  value: -0.1,
+                  matrix: ColorFilterAddons.brightness(-0.1),
+                ),
+                TuneAdjustmentMatrix(
+                  id: 'brightness',
+                  value: -0.4,
+                  matrix: ColorFilterAddons.brightness(-0.4),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final TuneEditorState state = tester.state(find.byType(TuneEditor));
+      expect(
+        state.tuneAdjustmentMatrix
+            .where((item) => item.id == 'brightness')
+            .length,
+        1,
+      );
+      expect(
+        state.tuneAdjustmentMatrix
+            .firstWhere((item) => item.id == 'brightness')
+            .value,
+        -0.4,
+      );
+    });
+
+    testWidgets('does not seed sliders from timed adjustments', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TuneEditor.memory(
+            mockMemoryImage,
+            initConfigs: TuneEditorInitConfigs(
+              theme: ThemeData(),
+              appliedTuneAdjustments: [
+                TuneAdjustmentMatrix(
+                  id: 'brightness',
+                  value: -0.9,
+                  matrix: ColorFilterAddons.brightness(-0.9),
+                  startTime: const Duration(seconds: 1),
+                  endTime: const Duration(seconds: 4),
+                ),
+                TuneAdjustmentMatrix(
+                  id: 'brightness',
+                  value: -0.2,
+                  matrix: ColorFilterAddons.brightness(-0.2),
+                ),
+                TuneAdjustmentMatrix(
+                  id: 'custom-vignette',
+                  value: 0.5,
+                  matrix: ColorFilterAddons.brightness(0.5),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final TuneEditorState state = tester.state(find.byType(TuneEditor));
+      expect(
+        state.tuneAdjustmentMatrix.length,
+        state.tuneAdjustmentList.length,
+      );
+      expect(
+        state.tuneAdjustmentMatrix.any(
+          (item) => item.id == 'custom-vignette',
+        ),
+        isFalse,
+      );
+      expect(
+        state.tuneAdjustmentMatrix
+            .firstWhere((item) => item.id == 'brightness')
+            .value,
+        -0.2,
+      );
+    });
+
+    testWidgets(
+      'custom slider advances from onChanged instead of a stale value',
+      (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TuneEditor.memory(
+            mockMemoryImage,
+            initConfigs: TuneEditorInitConfigs(
+              theme: ThemeData(),
+              configs: const ProImageEditorConfigs(
+                tuneEditor: TuneEditorConfigs(
+                  widgets: TuneEditorWidgets(
+                    slider: _staleCapturedValueSlider,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.widget<Slider>(find.byType(Slider)).value, 0);
+
+      await tester.drag(find.byType(Slider), const Offset(80, 0));
+      await tester.pump();
+
+      expect(tester.widget<Slider>(find.byType(Slider)).value, isNot(0));
+    });
   });
+}
+
+ReactiveWidget _staleCapturedValueSlider(
+  TuneEditorState editorState,
+  Stream<void> rebuildStream,
+  double value,
+  Function(double value) onChanged,
+  Function(double value) onChangeEnd,
+) {
+  return ReactiveWidget(
+    stream: rebuildStream,
+    builder: (_) => Slider(
+      min: -0.5,
+      max: 0.5,
+      value: value,
+      onChanged: onChanged,
+      onChangeEnd: onChangeEnd,
+    ),
+  );
 }

--- a/test/features/tune_editor_test.dart
+++ b/test/features/tune_editor_test.dart
@@ -275,9 +275,7 @@ void main() {
         state.tuneAdjustmentList.length,
       );
       expect(
-        state.tuneAdjustmentMatrix.any(
-          (item) => item.id == 'custom-vignette',
-        ),
+        state.tuneAdjustmentMatrix.any((item) => item.id == 'custom-vignette'),
         isFalse,
       );
       expect(
@@ -291,31 +289,32 @@ void main() {
     testWidgets(
       'custom slider advances from onChanged instead of a stale value',
       (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: TuneEditor.memory(
-            mockMemoryImage,
-            initConfigs: TuneEditorInitConfigs(
-              theme: ThemeData(),
-              configs: const ProImageEditorConfigs(
-                tuneEditor: TuneEditorConfigs(
-                  widgets: TuneEditorWidgets(
-                    slider: _staleCapturedValueSlider,
+        await tester.pumpWidget(
+          MaterialApp(
+            home: TuneEditor.memory(
+              mockMemoryImage,
+              initConfigs: TuneEditorInitConfigs(
+                theme: ThemeData(),
+                configs: const ProImageEditorConfigs(
+                  tuneEditor: TuneEditorConfigs(
+                    widgets: TuneEditorWidgets(
+                      slider: _staleCapturedValueSlider,
+                    ),
                   ),
                 ),
               ),
             ),
           ),
-        ),
-      );
+        );
 
-      expect(tester.widget<Slider>(find.byType(Slider)).value, 0);
+        expect(tester.widget<Slider>(find.byType(Slider)).value, 0);
 
-      await tester.drag(find.byType(Slider), const Offset(80, 0));
-      await tester.pump();
+        await tester.drag(find.byType(Slider), const Offset(80, 0));
+        await tester.pump();
 
-      expect(tester.widget<Slider>(find.byType(Slider)).value, isNot(0));
-    });
+        expect(tester.widget<Slider>(find.byType(Slider)).value, isNot(0));
+      },
+    );
   });
 }
 

--- a/test/shared/widgets/material_ui_localizations_scope_test.dart
+++ b/test/shared/widgets/material_ui_localizations_scope_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:pro_image_editor/shared/widgets/material_ui_localizations_scope.dart';
+
+void main() {
+  testWidgets('keeps a host regional MaterialLocalizations instance', (
+    WidgetTester tester,
+  ) async {
+    late MaterialLocalizations localizations;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('en', 'GB'),
+        supportedLocales: const [Locale('en', 'GB')],
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        home: MaterialUiLocalizationsScope(
+          child: Builder(
+            builder: (context) {
+              localizations = MaterialLocalizations.of(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(localizations, isA<GlobalMaterialLocalizations>());
+    expect(localizations.firstDayOfWeekIndex, 1);
+  });
+
+  testWidgets('falls back when material_ui localizations are missing', (
+    WidgetTester tester,
+  ) async {
+    late MaterialLocalizations localizations;
+
+    await tester.pumpWidget(
+      WidgetsApp(
+        color: const Color(0xFF000000),
+        builder: (context, _) {
+          return MaterialUiLocalizationsScope(
+            child: Builder(
+              builder: (context) {
+                localizations = MaterialLocalizations.of(context);
+                return const SizedBox.shrink();
+              },
+            ),
+          );
+        },
+      ),
+    );
+
+    expect(localizations, isA<MaterialLocalizations>());
+  });
+
+  testWidgets(
+    'supplies English material resources for an unsupported locale',
+    (WidgetTester tester) async {
+      late MaterialLocalizations localizations;
+
+      await tester.pumpWidget(
+        Localizations(
+          locale: const Locale('xx'),
+          delegates: const [DefaultWidgetsLocalizations.delegate],
+          child: MaterialUiLocalizationsScope(
+            child: Builder(
+              key: const ValueKey('unsupported-locale'),
+              builder: (context) {
+                localizations = MaterialLocalizations.of(context);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(localizations, isA<DefaultMaterialLocalizations>());
+      expect(
+        Localizations.localeOf(
+          tester.element(find.byKey(const ValueKey('unsupported-locale'))),
+        ),
+        const Locale('en'),
+      );
+    },
+  );
+}

--- a/test/shared/widgets/material_ui_localizations_scope_test.dart
+++ b/test/shared/widgets/material_ui_localizations_scope_test.dart
@@ -52,34 +52,33 @@ void main() {
     expect(localizations, isA<MaterialLocalizations>());
   });
 
-  testWidgets(
-    'supplies English material resources for an unsupported locale',
-    (WidgetTester tester) async {
-      late MaterialLocalizations localizations;
+  testWidgets('supplies English material resources for an unsupported locale', (
+    WidgetTester tester,
+  ) async {
+    late MaterialLocalizations localizations;
 
-      await tester.pumpWidget(
-        Localizations(
-          locale: const Locale('xx'),
-          delegates: const [DefaultWidgetsLocalizations.delegate],
-          child: MaterialUiLocalizationsScope(
-            child: Builder(
-              key: const ValueKey('unsupported-locale'),
-              builder: (context) {
-                localizations = MaterialLocalizations.of(context);
-                return const SizedBox.shrink();
-              },
-            ),
+    await tester.pumpWidget(
+      Localizations(
+        locale: const Locale('xx'),
+        delegates: const [DefaultWidgetsLocalizations.delegate],
+        child: MaterialUiLocalizationsScope(
+          child: Builder(
+            key: const ValueKey('unsupported-locale'),
+            builder: (context) {
+              localizations = MaterialLocalizations.of(context);
+              return const SizedBox.shrink();
+            },
           ),
         ),
-      );
+      ),
+    );
 
-      expect(localizations, isA<DefaultMaterialLocalizations>());
-      expect(
-        Localizations.localeOf(
-          tester.element(find.byKey(const ValueKey('unsupported-locale'))),
-        ),
-        const Locale('en'),
-      );
-    },
-  );
+    expect(localizations, isA<DefaultMaterialLocalizations>());
+    expect(
+      Localizations.localeOf(
+        tester.element(find.byKey(const ValueKey('unsupported-locale'))),
+      ),
+      const Locale('en'),
+    );
+  });
 }


### PR DESCRIPTION
## Description

Hello, I've discovered the tune editor was stacking changes instead of restoring the state. This PR was AI-assisted and includes a bundle of related issues discovered during the testing process.

Tune no longer stacks a full extra set of global matrices on every Done. Re-apply used to append the session on top of history, which could crush the image (often to black). `mergeTuneAdjustments` keeps timed and custom entries, replaces only this session's untimed globals, and the sliders are seeded from the latest global per id.

A custom `TuneEditorWidgets.slider` now receives the value it reported through `onChanged` instead of the value from the last drag end.

Adds `TuneEditorStyle.bottomBarActiveItemDecoration` so hosts can mark the selected Tune attribute without forking the bottom bar.

**Maintainer edit (rebased onto `stable`, review commits on top):** the `MaterialUiLocalizationsScope` shim was dropped. It only wrapped the main editor, the tune editor and two dialogs, but sub-editors, bottom sheets and the loading overlay are built under the host navigator, so in a host that still uses `package:flutter/material.dart` the paint, text, filter and blur editors kept failing with `No MaterialLocalizations found`. The host owns that fix: adding material_ui's `GlobalMaterialLocalizations.delegates` to the SDK `MaterialApp` makes the localizations visible to every route and overlay, verified against all sub-editors, the close-warning dialog and the loading dialog. The README setup section now documents it.

**Related Issue:** Closes #

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
