### PR TITLE
fix(layers): keep a slide's start point in step with the layer on canvas resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 14.1.1
+- **FIX**(layers): A slide animation's `slideFrom` point now follows the layer when the canvas is resized or a state history recorded at another size is imported. Only `Layer.offset` was rescaled before, so the preview travelled a different distance than the one the point was placed for.
+
 ## 14.1.0
 - **FEAT**(layers): Add `LayerAnimation.slideFrom` to start a slide from a point of your own instead of a canvas edge. It uses the same coordinates as `Layer.offset`, may sit outside the canvas, and overrides `slideDirection`.
 - **FIX**(layers): The timeline preview recomputes a layer's slide when the layer moves or the canvas resizes, instead of keeping the displacement it measured for the old geometry.

--- a/lib/core/models/layers/layer.dart
+++ b/lib/core/models/layers/layer.dart
@@ -260,6 +260,31 @@ class Layer {
     ];
   }
 
+  /// Multiplies every [LayerAnimation.slideFrom] in [animations] by [scaleX]
+  /// and [scaleY], the way [offset] is multiplied when the canvas is resized.
+  ///
+  /// `slideFrom` is measured in the same canvas pixels as [offset], so a
+  /// resize that rescales the offset and not the point changes the distance
+  /// the slide covers. Call this wherever [offset] is rescaled.
+  ///
+  /// [copyWith] shares the [animations] list between copies, so the list is
+  /// replaced rather than mutated in place — a copy that is rescaled
+  /// separately must not see the point scaled twice. Animations without a
+  /// point are kept as they are.
+  void scaleSlideFrom(double scaleX, double scaleY) {
+    if (animations.every((animation) => animation.slideFrom == null)) return;
+
+    animations = [
+      for (final animation in animations)
+        if (animation.slideFrom case final from?)
+          animation.copyWith(
+            slideFrom: Offset(from.dx * scaleX, from.dy * scaleY),
+          )
+        else
+          animation,
+    ];
+  }
+
   /// Global key associated with the Layer instance, used for accessing the
   /// widget tree.
   GlobalKey key;

--- a/lib/features/main_editor/services/main_editor_state_history_service.dart
+++ b/lib/features/main_editor/services/main_editor_state_history_service.dart
@@ -137,7 +137,8 @@ class MainEditorStateHistoryService {
             ..offset = Offset(
               layer.offset.dx * scaleWidth,
               layer.offset.dy * scaleHeight,
-            );
+            )
+            ..scaleSlideFrom(scaleWidth, scaleHeight);
         }
 
         if (import.version == ExportImportVersion.version_1_0_0) {

--- a/lib/features/main_editor/services/sizes_manager.dart
+++ b/lib/features/main_editor/services/sizes_manager.dart
@@ -171,7 +171,8 @@ class SizesManager {
           if (!processed.add(layer)) continue;
           layer
             ..scale /= scaleFactor
-            ..offset /= scaleFactor;
+            ..offset /= scaleFactor
+            ..scaleSlideFrom(1 / scaleFactor, 1 / scaleFactor);
         }
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 14.1.0
+version: 14.1.1
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/core/models/layers/layer_test.dart
+++ b/test/core/models/layers/layer_test.dart
@@ -362,6 +362,52 @@ void main() {
       expect(derived[1].curve, AnimationCurve.easeOut);
     });
 
+    group('scaleSlideFrom', () {
+      const pointSlide = LayerAnimation(
+        type: LayerAnimationType.slide,
+        phase: AnimationPhase.animateIn,
+        duration: Duration(milliseconds: 400),
+        slideFrom: Offset(50, 100),
+      );
+      const edgeSlide = LayerAnimation(
+        type: LayerAnimationType.slide,
+        phase: AnimationPhase.animateOut,
+        duration: Duration(milliseconds: 400),
+        slideDirection: SlideDirection.left,
+      );
+
+      test('scales every point per axis and keeps direction slides', () {
+        final layer = TextLayer(
+          text: 'hi',
+          animations: const [pointSlide, edgeSlide],
+        )..scaleSlideFrom(2, 0.5);
+
+        expect(layer.animations, hasLength(2));
+        expect(layer.animations.first.slideFrom, const Offset(100, 50));
+        expect(layer.animations.first.slideDirection, isNull);
+        expect(layer.animations.last, same(edgeSlide));
+      });
+
+      test('replaces the list so a copy sharing it is not scaled too', () {
+        final layer = TextLayer(text: 'hi', animations: const [pointSlide]);
+        final copy = layer.copyWith();
+        expect(copy.animations, same(layer.animations));
+
+        layer.scaleSlideFrom(2, 2);
+
+        expect(layer.animations.single.slideFrom, const Offset(100, 200));
+        expect(copy.animations.single.slideFrom, const Offset(50, 100));
+      });
+
+      test('keeps the list untouched when no animation has a point', () {
+        final animations = [edgeSlide];
+        final layer = TextLayer(text: 'hi', animations: animations)
+          ..scaleSlideFrom(2, 2);
+
+        expect(layer.animations, same(animations));
+      });
+    });
+
     test('default animations list is growable and mutable', () {
       final layer = Layer();
       expect(

--- a/test/features/main_editor/sizes_manager_test.dart
+++ b/test/features/main_editor/sizes_manager_test.dart
@@ -145,6 +145,51 @@ void main() {
     );
 
     testWidgets(
+      'rescales a slide animation\'s start point together with the offset',
+      (tester) async {
+        final sizesManager = await buildSizesManager(tester);
+
+        const edgeSlide = LayerAnimation(
+          type: LayerAnimationType.slide,
+          phase: AnimationPhase.animateOut,
+          duration: Duration(milliseconds: 400),
+          slideDirection: SlideDirection.left,
+        );
+        final textLayer = TextLayer(
+          text: 'Hello',
+          scale: initialScale,
+          offset: initialOffset,
+          animations: const [
+            LayerAnimation(
+              type: LayerAnimationType.slide,
+              phase: AnimationPhase.animateIn,
+              duration: Duration(milliseconds: 400),
+              slideFrom: Offset(50, 100),
+            ),
+            edgeSlide,
+          ],
+        );
+
+        sizesManager.recalculateLayerPosition(
+          history: [
+            EditorStateHistory(layers: [textLayer]),
+          ],
+          resizeEvent: resizeEvent,
+        );
+
+        // `slideFrom` shares the offset's canvas pixels, so it must move by
+        // the same factor — otherwise the preview travels a different
+        // distance than the one the point was placed for.
+        expect(textLayer.offset, initialOffset / scaleFactor);
+        expect(
+          textLayer.animations.first.slideFrom,
+          const Offset(50, 100) / scaleFactor,
+        );
+        expect(textLayer.animations.last, same(edgeSlide));
+      },
+    );
+
+    testWidgets(
       'still rescales every distinct copy in the normal per-entry-copy case',
       (tester) async {
         final sizesManager = await buildSizesManager(tester);

--- a/test/shared/services/import_export/import_export_test.dart
+++ b/test/shared/services/import_export/import_export_test.dart
@@ -225,5 +225,55 @@ void main() {
         expect(editor.stateManager.historyPointer, 1);
       });
     });
+
+    testWidgets(
+      'rescales a slide animation\'s start point with the offset when the '
+      'history was recorded at another size',
+      (WidgetTester tester) async {
+        await tester.runAsync(() async {
+          final editor = await pumpTestEditor(tester);
+
+          const slideFrom = Offset(50, 100);
+          editor.addLayer(
+            TextLayer(
+              text: 'slides in',
+              offset: const Offset(20, 40),
+              animations: const [
+                LayerAnimation(
+                  type: LayerAnimationType.slide,
+                  phase: AnimationPhase.animateIn,
+                  duration: Duration(milliseconds: 400),
+                  slideFrom: slideFrom,
+                ),
+              ],
+            ),
+          );
+
+          final history = await editor.exportStateHistory(
+            configs: const ExportEditorConfigs(
+              enableMinify: false,
+              historySpan: ExportHistorySpan.current,
+            ),
+          );
+          final map = await history.toMap();
+          // Pretend the history was recorded on a canvas half this size, so
+          // the import has to scale every layer up by 2 on both axes.
+          final recorded = map['lastRenderedImgSize'] as Map<String, dynamic>;
+          map['lastRenderedImgSize'] = {
+            'width': (recorded['width'] as num) / 2,
+            'height': (recorded['height'] as num) / 2,
+          };
+
+          editor.removeAllLayers();
+          await editor.importStateHistory(
+            ImportStateHistory.fromMap(map, configs: importConfigs),
+          );
+
+          final imported = editor.activeLayers.single;
+          expect(imported.offset, const Offset(40, 80));
+          expect(imported.animations.single.slideFrom, slideFrom * 2);
+        });
+      },
+    );
   });
 }


### PR DESCRIPTION
Follow-up to #865. Bumps the package to 14.1.1.

## What

`LayerAnimation.slideFrom` is measured in the same canvas pixels as `Layer.offset`, but when the canvas changed size the editor rescaled the offset alone and left the point where it was. The preview then travelled a different distance after every resize — a sub-editor opening, the host collapsing a timeline, or a state history recorded on another screen being imported. On a 200×400 → 400×800 resize the offset moved from (20,40) to (40,80) while the point stayed at (50,100) instead of (100,200).

## How

`Layer.scaleSlideFrom(scaleX, scaleY)` applies the same per-axis factor to every `slideFrom` in `Layer.animations`, and both rescale sites call it next to the offset: `SizesManager.recalculateLayerPosition` (uniform, on a canvas resize) and the history import's size recalculation (per axis, on `recalculateSizeAndPosition`). It replaces the animations list instead of mutating it — `copyWith` shares the list between copies, and a shared-instance history rescales each copy on its own, so an in-place mutation would scale a point twice. Animations without a point are kept as they are.

## Testing

`flutter analyze` clean, `dart format` clean, all 601 tests pass. New: three `scaleSlideFrom` unit cases (per-axis scaling with direction slides untouched, list replacement leaving a sharing copy alone, no-op when no point is set), a `recalculateLayerPosition` regression with the numbers above, and an import regression that halves `lastRenderedImgSize` in an exported history and expects offset and point to double together. Both regressions fail on 14.1.0.
