### PR TITLE
perf(layers): draw static paint layers from a cached raster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 14.2.0
+- **PERF**(layers): Add `MainEditorConfigs.enablePaintLayerRasterCache` (opt-in). Static paint layers are composited into one cached image per z-run and drawn from it until one of them changes, instead of being re-stroked by the engine on every frame — which on a video canvas is every frame, and costs in proportion to the ink on screen. A layer that is selected, dragged, scaled or rotated, mid-animation, or outside its timeline window renders live so it stays pixel-exact, and rejoins the cache once released; the cache also steps aside while the editor is zoomed, during a partial erase, and for every layer capture. Hit-testing, selection and layer keys are untouched. Measured with 150 freestyle strokes on a video canvas: raster 3.1ms -> 1.0ms per frame during playback and 1.7ms -> 0.6ms while retiming a layer.
+
 ## 14.1.1
 - **FIX**(layers): A slide animation's `slideFrom` point now follows the layer when the canvas is resized or a state history recorded at another size is imported. Only `Layer.offset` was rescaled before, so the preview travelled a different distance than the one the point was placed for.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 14.2.0
-- **PERF**(layers): Add `MainEditorConfigs.enablePaintLayerRasterCache` (opt-in). Static paint layers are composited into one cached image per z-run and drawn from it until one of them changes, instead of being re-stroked by the engine on every frame — which on a video canvas is every frame, and costs in proportion to the ink on screen. A layer that is selected, dragged, scaled or rotated, mid-animation, or outside its timeline window renders live so it stays pixel-exact, and rejoins the cache once released; the cache also steps aside while the editor is zoomed, during a partial erase, and for every layer capture. Hit-testing, selection and layer keys are untouched. Measured with 150 freestyle strokes on a video canvas: raster 3.1ms -> 1.0ms per frame during playback and 1.7ms -> 0.6ms while retiming a layer.
+- **PERF**(layers): Add the opt-in `MainEditorConfigs.enablePaintLayerRasterCache`, which draws static paint layers from a cached raster instead of re-stroking them on every frame.
+- **FIX**(paint-editor): A full-stroke erase no longer leaves an empty undo step behind, and a partial erase that turns into a pinch is closed properly.
 
 ## 14.1.1
 - **FIX**(layers): A slide animation's `slideFrom` point now follows the layer when the canvas is resized or a state history recorded at another size is imported. Only `Layer.offset` was rescaled before, so the preview travelled a different distance than the one the point was placed for.

--- a/lib/core/models/editor_configs/main_editor_configs.dart
+++ b/lib/core/models/editor_configs/main_editor_configs.dart
@@ -126,9 +126,17 @@ class MainEditorConfigs extends ZoomConfigs {
   /// once into a single image and that image is drawn until one of them
   /// changes. A layer that is selected, dragged, scaled or rotated, or that is
   /// mid-animation, keeps rendering live so it stays pixel-exact while it
-  /// moves; once released it joins the cache again. The cache is bypassed
-  /// while the editor is zoomed and during every capture, so
-  /// [captureLayersOnDone] and `captureAllLayersWithMeta` are unaffected.
+  /// moves; once released it joins the cache again. The cache also steps
+  /// aside while the editor is zoomed, during a partial erase and during
+  /// sub-editor transitions.
+  ///
+  /// Captures are unaffected: every screenshot the editor takes of its canvas
+  /// — the state history, [captureImageOnDone], thumbnails — waits for a frame
+  /// in which the layers paint live, and [captureLayersOnDone],
+  /// `captureAllLayersWithMeta` and [Layer.captureAsPng] render a cached
+  /// layer from its model. Measured with 150 freestyle strokes on a video
+  /// canvas, raster time per frame drops from 3.1 ms to 1.0 ms during
+  /// playback and from 1.7 ms to 0.6 ms while retiming a layer.
   ///
   /// Hit-testing, selection and the layer keys stay on the live widgets, so
   /// the editor behaves the same; only the paint is cached.

--- a/lib/core/models/editor_configs/main_editor_configs.dart
+++ b/lib/core/models/editor_configs/main_editor_configs.dart
@@ -46,6 +46,7 @@ class MainEditorConfigs extends ZoomConfigs {
     this.enableSubEditorPage = false,
     this.captureImageOnDone = true,
     this.captureLayersOnDone = false,
+    this.enablePaintLayerRasterCache = false,
     this.style = const MainEditorStyle(),
     this.icons = const MainEditorIcons(),
     this.widgets = const MainEditorWidgets(),
@@ -113,6 +114,28 @@ class MainEditorConfigs extends ZoomConfigs {
   /// for further processing (e.g. video rendering).
   final bool captureLayersOnDone;
 
+  /// Whether static paint layers are drawn from a cached raster instead of
+  /// being re-stroked on every frame.
+  ///
+  /// Every paint layer is a vector path the engine has to rasterize again for
+  /// each frame it appears in. That cost grows with the amount of ink on the
+  /// canvas, not with the number of layers, and on a video canvas — where the
+  /// background changes every frame — a doodle-heavy edit spends most of its
+  /// frame budget re-stroking drawings that did not change. With this enabled,
+  /// consecutive paint layers that are not being interacted with are rendered
+  /// once into a single image and that image is drawn until one of them
+  /// changes. A layer that is selected, dragged, scaled or rotated, or that is
+  /// mid-animation, keeps rendering live so it stays pixel-exact while it
+  /// moves; once released it joins the cache again. The cache is bypassed
+  /// while the editor is zoomed and during every capture, so
+  /// [captureLayersOnDone] and `captureAllLayersWithMeta` are unaffected.
+  ///
+  /// Hit-testing, selection and the layer keys stay on the live widgets, so
+  /// the editor behaves the same; only the paint is cached.
+  ///
+  /// Defaults to `false`.
+  final bool enablePaintLayerRasterCache;
+
   /// Whether to generate the final image bytes via `captureEditorImage()` when
   /// [doneEditing] is called.
   ///
@@ -175,12 +198,15 @@ class MainEditorConfigs extends ZoomConfigs {
     bool? enableSubEditorPage,
     bool? captureImageOnDone,
     bool? captureLayersOnDone,
+    bool? enablePaintLayerRasterCache,
     Clip? interactiveViewerClipBehavior,
   }) {
     return MainEditorConfigs(
       enableSubEditorPage: enableSubEditorPage ?? this.enableSubEditorPage,
       captureImageOnDone: captureImageOnDone ?? this.captureImageOnDone,
       captureLayersOnDone: captureLayersOnDone ?? this.captureLayersOnDone,
+      enablePaintLayerRasterCache:
+          enablePaintLayerRasterCache ?? this.enablePaintLayerRasterCache,
       enableCloseButton: enableCloseButton ?? this.enableCloseButton,
       enableKeyboardShortcuts:
           enableKeyboardShortcuts ?? this.enableKeyboardShortcuts,

--- a/lib/core/models/layers/layer.dart
+++ b/lib/core/models/layers/layer.dart
@@ -22,6 +22,7 @@ import '/shared/utils/parser/bool_parser.dart';
 import '/shared/utils/parser/curve_parser.dart';
 import '/shared/utils/parser/double_parser.dart';
 import '/shared/utils/unique_id_generator.dart';
+import '/shared/widgets/layer/widgets/layer_repaint_boundary.dart';
 import '../editor_image.dart';
 import 'emoji_layer.dart';
 import 'exported_layer.dart';
@@ -433,10 +434,13 @@ class Layer {
   /// Captures the visual content of this layer as a PNG-encoded byte array.
   ///
   /// The layer must be mounted in the widget tree with its
-  /// [repaintBoundaryKey] attached to a [RepaintBoundary]. The [pixelRatio]
-  /// controls the resolution of the output image. When `null`, it defaults
-  /// to `devicePixelRatio * scale` to preserve sharpness for scaled and
-  /// rotated layers.
+  /// [repaintBoundaryKey] attached to a [RepaintBoundary]. A paint layer that
+  /// is currently drawn from the editor's raster cache paints nothing into
+  /// that boundary; its content is then rendered from the model, so the
+  /// result is the same either way. The [pixelRatio] controls the resolution
+  /// of the output image. When `null`, it defaults to
+  /// `devicePixelRatio * scale` to preserve sharpness for scaled and rotated
+  /// layers.
   ///
   /// The [format] controls the output byte format and defaults to PNG for
   /// backward compatibility.
@@ -460,8 +464,15 @@ class Layer {
         basePixelRatio ?? MediaQuery.maybeDevicePixelRatioOf(context) ?? 3.0;
     final effectivePixelRatio = pixelRatio ?? dpr;
 
-    final boundary = context.findRenderObject() as RenderRepaintBoundary;
-    final rawImage = await boundary.toImage(pixelRatio: effectivePixelRatio);
+    final boundaryWidget = repaintBoundaryKey.currentWidget;
+    final renderContent = boundaryWidget is LayerRepaintBoundary
+        ? boundaryWidget.renderContent
+        : null;
+    final rawImage = renderContent != null
+        ? await renderContent(effectivePixelRatio)
+        : await (context.findRenderObject() as RenderRepaintBoundary).toImage(
+            pixelRatio: effectivePixelRatio,
+          );
 
     final bool needsTransform =
         applyTransforms && (rotation != 0 || flipX || flipY);

--- a/lib/features/crop_rotate_editor/crop_rotate_editor.dart
+++ b/lib/features/crop_rotate_editor/crop_rotate_editor.dart
@@ -2993,6 +2993,11 @@ class CropRotateEditorState extends State<CropRotateEditor>
                       layers: _rawLayers,
                       clipBehavior: Clip.none,
                       overlayColor: cropRotateEditorConfigs.style.background,
+                      // The stack sits under the user zoom, the crop scale
+                      // and the rotation, flip and tilt transforms, all of
+                      // them animated; a raster rendered for scale 1 would
+                      // be resampled most of the time.
+                      suspendPaintLayerRasterCache: true,
                     ),
                   ),
               ],
@@ -3045,6 +3050,8 @@ class CropRotateEditorState extends State<CropRotateEditor>
                   layers: _layers,
                   clipBehavior: Clip.none,
                   overlayColor: cropRotateEditorConfigs.style.background,
+                  // Only shown for the hero flight, which renders live.
+                  suspendPaintLayerRasterCache: true,
                 ),
             ],
           );

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -482,13 +482,6 @@ class ProImageEditorState extends State<ProImageEditor>
   /// Flag to track if editing is completed.
   bool _isProcessingFinalImage = false;
 
-  /// How many layer captures are in progress.
-  ///
-  /// While above zero the paint-layer raster cache is suspended so every
-  /// layer paints into its own repaint boundary, which is where a capture
-  /// reads from. See [MainEditorConfigs.enablePaintLayerRasterCache].
-  int _layerCaptureDepth = 0;
-
   /// The pixel ratio of the device's screen.
   ImageInfos? _imageInfos;
 
@@ -2850,31 +2843,20 @@ class ProImageEditorState extends State<ProImageEditor>
       if (!mounted) return <ExportedLayer>[];
     }
 
+    // Ensure the current frame with layers is fully rendered before capture.
+    await WidgetsBinding.instance.endOfFrame;
     if (!mounted) return <ExportedLayer>[];
 
-    // A cached paint layer paints nothing into its own repaint boundary, so
-    // the cache has to step aside — and a frame has to render with every
-    // layer live — before the boundaries are read.
-    setState(() => _layerCaptureDepth++);
-    try {
-      // Ensure the current frame with layers is fully rendered before capture.
-      await WidgetsBinding.instance.endOfFrame;
-      if (!mounted) return <ExportedLayer>[];
-
-      return await Layer.captureAllLayers(
-        layers: activeLayers,
-        pixelRatio: pixelRatio,
-        basePixelRatio: basePixelRatio,
-        applyTransforms: applyTransforms,
-        format: format,
-        recorder: format == ui.ImageByteFormat.png
-            ? _controllers.screenshot
-            : null,
-      );
-    } finally {
-      _layerCaptureDepth--;
-      if (mounted) setState(() {});
-    }
+    return Layer.captureAllLayers(
+      layers: activeLayers,
+      pixelRatio: pixelRatio,
+      basePixelRatio: basePixelRatio,
+      applyTransforms: applyTransforms,
+      format: format,
+      recorder: format == ui.ImageByteFormat.png
+          ? _controllers.screenshot
+          : null,
+    );
   }
 
   /// Closes all active sub-editors within the main editor, including paint,
@@ -3519,8 +3501,6 @@ class ProImageEditorState extends State<ProImageEditor>
       dragSelectionService: _layerDragSelectionService,
       mouseService: _mouseService,
       playTimeNotifier: _videoController?.playTimeNotifier,
-      suspendPaintLayerRasterCache:
-          _isProcessingFinalImage || _layerCaptureDepth > 0,
       onContextMenuToggled: (isOpen) {
         _isContextMenuOpen = isOpen;
       },

--- a/lib/features/main_editor/main_editor.dart
+++ b/lib/features/main_editor/main_editor.dart
@@ -482,6 +482,13 @@ class ProImageEditorState extends State<ProImageEditor>
   /// Flag to track if editing is completed.
   bool _isProcessingFinalImage = false;
 
+  /// How many layer captures are in progress.
+  ///
+  /// While above zero the paint-layer raster cache is suspended so every
+  /// layer paints into its own repaint boundary, which is where a capture
+  /// reads from. See [MainEditorConfigs.enablePaintLayerRasterCache].
+  int _layerCaptureDepth = 0;
+
   /// The pixel ratio of the device's screen.
   ImageInfos? _imageInfos;
 
@@ -2843,20 +2850,31 @@ class ProImageEditorState extends State<ProImageEditor>
       if (!mounted) return <ExportedLayer>[];
     }
 
-    // Ensure the current frame with layers is fully rendered before capture.
-    await WidgetsBinding.instance.endOfFrame;
     if (!mounted) return <ExportedLayer>[];
 
-    return Layer.captureAllLayers(
-      layers: activeLayers,
-      pixelRatio: pixelRatio,
-      basePixelRatio: basePixelRatio,
-      applyTransforms: applyTransforms,
-      format: format,
-      recorder: format == ui.ImageByteFormat.png
-          ? _controllers.screenshot
-          : null,
-    );
+    // A cached paint layer paints nothing into its own repaint boundary, so
+    // the cache has to step aside — and a frame has to render with every
+    // layer live — before the boundaries are read.
+    setState(() => _layerCaptureDepth++);
+    try {
+      // Ensure the current frame with layers is fully rendered before capture.
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted) return <ExportedLayer>[];
+
+      return await Layer.captureAllLayers(
+        layers: activeLayers,
+        pixelRatio: pixelRatio,
+        basePixelRatio: basePixelRatio,
+        applyTransforms: applyTransforms,
+        format: format,
+        recorder: format == ui.ImageByteFormat.png
+            ? _controllers.screenshot
+            : null,
+      );
+    } finally {
+      _layerCaptureDepth--;
+      if (mounted) setState(() {});
+    }
   }
 
   /// Closes all active sub-editors within the main editor, including paint,
@@ -3501,6 +3519,8 @@ class ProImageEditorState extends State<ProImageEditor>
       dragSelectionService: _layerDragSelectionService,
       mouseService: _mouseService,
       playTimeNotifier: _videoController?.playTimeNotifier,
+      suspendPaintLayerRasterCache:
+          _isProcessingFinalImage || _layerCaptureDepth > 0,
       onContextMenuToggled: (isOpen) {
         _isContextMenuOpen = isOpen;
       },

--- a/lib/features/main_editor/services/paint_layer_raster_cache.dart
+++ b/lib/features/main_editor/services/paint_layer_raster_cache.dart
@@ -1,0 +1,605 @@
+// Dart imports:
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+// Flutter imports:
+import 'package:flutter/widgets.dart';
+
+import '/core/models/editor_configs/paint_editor/paint_editor_configs.dart';
+import '/core/models/layers/layer.dart';
+
+/// A contiguous z-run of paint layers that is drawn from one cached image.
+///
+/// Runs never span another layer type: a text or sticker layer that sits
+/// between two drawings splits them into two runs, so the stacking order of
+/// everything on the canvas stays exactly what it was with live rendering.
+@immutable
+class PaintLayerRasterRun {
+  /// Creates a run.
+  const PaintLayerRasterRun({
+    required this.layers,
+    required this.insertIndex,
+    required this.key,
+    required this.bounds,
+  });
+
+  /// The paint layers of this run, bottom-most first.
+  final List<PaintLayer> layers;
+
+  /// The index in the editor's layer list at which the first member sits.
+  ///
+  /// The cached image is inserted right before that member so it paints at
+  /// the run's z-position.
+  final int insertIndex;
+
+  /// Identifies the exact pixels of this run.
+  ///
+  /// It encodes the pixel ratio and every property that changes how a member
+  /// paints — geometry, opacity, stroke set — but not the timeline window,
+  /// so retiming a layer keeps its raster.
+  final String key;
+
+  /// The area the image covers, in editor body coordinates (logical pixels).
+  final Rect bounds;
+
+  /// The ids of the member layers.
+  Iterable<String> get layerIds => layers.map((layer) => layer.id);
+}
+
+/// The result of [PaintLayerRasterCache.plan]: which layers the cache may
+/// draw, grouped into runs.
+@immutable
+class PaintLayerRasterPlan {
+  /// Creates a plan.
+  const PaintLayerRasterPlan({required this.runs});
+
+  /// A plan that caches nothing.
+  static const PaintLayerRasterPlan none = PaintLayerRasterPlan(runs: []);
+
+  /// The cacheable runs, in z-order.
+  final List<PaintLayerRasterRun> runs;
+}
+
+/// Draws static paint layers from cached images instead of re-stroking their
+/// paths on every frame.
+///
+/// Rendering a paint layer costs the engine a full rasterization of its path
+/// per frame. Nothing about that is cached between frames, so a canvas with a
+/// few hundred strokes re-renders all of them whenever anything on it changes,
+/// which on a video canvas is every frame. That cost scales with the amount of
+/// ink, not with the layer count, and it is the same whether the strokes live
+/// in one merged layer or in one layer each.
+///
+/// This cache composites consecutive static paint layers into a single
+/// [ui.Image] once and lets the editor draw that image until a member
+/// changes. Which layers qualify is decided per build by [plan]: a layer that
+/// is selected or being transformed, one that is mid-animation, one outside
+/// its timeline window, and one whose appearance the composite could not
+/// reproduce exactly stay live. Layers keep their widgets either way — the
+/// cache only replaces their paint, never their hit-testing, selection or
+/// keys — so the editor behaves the same with it enabled.
+///
+/// Rasterization runs asynchronously. Until an image lands, the run renders
+/// live, so the canvas is never blank and a moved layer is pixel-exact the
+/// moment it is released; the cached copy takes over a frame or two later.
+class PaintLayerRasterCache extends ChangeNotifier {
+  /// Creates a cache.
+  PaintLayerRasterCache({
+    this.maxPixels = 8 * 1024 * 1024,
+    this.maxTotalPixels = 16 * 1024 * 1024,
+    this.maxImages = 4,
+  });
+
+  /// The pixel budget of a single run's image.
+  ///
+  /// A run whose bounds exceed it at the current pixel ratio is not cached and
+  /// renders live. The default of 8 M pixels is 32 MB of RGBA — three times a
+  /// full-screen canvas on a 3× phone (about 2.5 M pixels), so a run that
+  /// spills past the canvas still fits while a pathological one cannot claim
+  /// a giant texture.
+  final int maxPixels;
+
+  /// The pixel budget of all kept images together.
+  ///
+  /// Scrubbing back and forth across a layer's timeline edge alternates
+  /// between two run keys; keeping a few recent images avoids re-rendering
+  /// each time. The oldest images are disposed first once the total goes
+  /// over this budget (64 MB of RGBA by default) or over [maxImages].
+  final int maxTotalPixels;
+
+  /// The most images kept at once, whatever their size.
+  final int maxImages;
+
+  final Map<String, ui.Image> _images = <String, ui.Image>{};
+  final List<String> _recentKeys = <String>[];
+
+  /// The key being rendered right now. Only one image renders at a time: a
+  /// burst of changes — every pointer move of an erase, say — would otherwise
+  /// queue a render per change, each as expensive as a live frame. A request
+  /// that arrives while busy just marks [_hasPendingRequest]; once the current
+  /// render lands, listeners are told and re-plan against the latest state.
+  String? _inFlightKey;
+  bool _hasPendingRequest = false;
+  bool _isDisposed = false;
+
+  /// Whether [layer] can be drawn from a cached raster at [playTime].
+  ///
+  /// [excludedIds] are layers the caller wants live regardless — the selected
+  /// and interacting ones. A layer with a timeline animation stays live even
+  /// outside its animation window, because it would otherwise flip between
+  /// cached and live at every window edge; the same goes for the legacy
+  /// enter/exit fade.
+  static bool isCacheable(
+    Layer layer, {
+    required Set<String> excludedIds,
+    required Duration? playTime,
+    required PaintEditorConfigs paintEditorConfigs,
+  }) {
+    if (layer is! PaintLayer) return false;
+    if (excludedIds.contains(layer.id)) return false;
+    if (layer.isCensor) return false;
+    if (layer.boxConstraints != null) return false;
+    if (layer.animations.isNotEmpty) return false;
+    if (_isPositive(layer.enterDuration) || _isPositive(layer.exitDuration)) {
+      return false;
+    }
+    if (layer.transitionBuilder != null) return false;
+    if (playTime != null) {
+      final start = layer.startTime;
+      final end = layer.endTime;
+      if (start != null && playTime < start) return false;
+      if (end != null && playTime > end) return false;
+    }
+    // A merged layer with a layer opacity below 1 fades the composed stack
+    // through an Opacity widget; reproducing that needs an offscreen per
+    // layer, which is the cost this cache exists to avoid.
+    if (layer.items.length > 1 && layer.opacity < 1.0) return false;
+    for (final item in layer.items) {
+      // A custom builder may draw anything; its opacity path goes through an
+      // Opacity widget as well.
+      if (paintEditorConfigs.customPathBuilders.containsKey(item.mode)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static bool _isPositive(Duration? duration) =>
+      duration != null && duration > Duration.zero;
+
+  /// Groups the cacheable members of [layers] into runs.
+  ///
+  /// [editorBodySize] and [fractionalOffset] place each layer the way
+  /// `LayerWidget` does; [pixelRatio] is the device pixel ratio the images are
+  /// rendered at. A run whose image would exceed [maxPixels] is left out, and
+  /// so is everything beyond [maxImages] runs, so the cache never holds more
+  /// than it is allowed to.
+  PaintLayerRasterPlan plan({
+    required List<Layer> layers,
+    required Set<String> excludedIds,
+    required Duration? playTime,
+    required Size editorBodySize,
+    required Offset fractionalOffset,
+    required double pixelRatio,
+    required PaintEditorConfigs paintEditorConfigs,
+  }) {
+    final runs = <PaintLayerRasterRun>[];
+    var members = <PaintLayer>[];
+    var insertIndex = 0;
+
+    void flush() {
+      if (members.isEmpty) return;
+      final run = _buildRun(
+        members,
+        insertIndex: insertIndex,
+        editorBodySize: editorBodySize,
+        fractionalOffset: fractionalOffset,
+        pixelRatio: pixelRatio,
+      );
+      if (run != null && runs.length < maxImages) runs.add(run);
+      members = <PaintLayer>[];
+    }
+
+    for (var i = 0; i < layers.length; i++) {
+      final layer = layers[i];
+      final cacheable = isCacheable(
+        layer,
+        excludedIds: excludedIds,
+        playTime: playTime,
+        paintEditorConfigs: paintEditorConfigs,
+      );
+      if (!cacheable) {
+        flush();
+        continue;
+      }
+      if (members.isEmpty) insertIndex = i;
+      members.add(layer as PaintLayer);
+    }
+    flush();
+
+    return PaintLayerRasterPlan(runs: runs);
+  }
+
+  PaintLayerRasterRun? _buildRun(
+    List<PaintLayer> members, {
+    required int insertIndex,
+    required Size editorBodySize,
+    required Offset fractionalOffset,
+    required double pixelRatio,
+  }) {
+    Rect? bounds;
+    final keyBuffer = StringBuffer()
+      ..write(pixelRatio.toStringAsFixed(3))
+      ..write('|')
+      ..write(fractionalOffset.dx)
+      ..write(',')
+      ..write(fractionalOffset.dy)
+      ..write('|')
+      ..write(editorBodySize.width)
+      ..write('x')
+      ..write(editorBodySize.height);
+
+    for (final layer in members) {
+      final rect = layerBounds(
+        layer,
+        editorBodySize: editorBodySize,
+        fractionalOffset: fractionalOffset,
+      );
+      bounds = bounds == null ? rect : bounds.expandToInclude(rect);
+      keyBuffer
+        ..write('|')
+        ..write(layerKey(layer));
+    }
+    if (bounds == null || bounds.isEmpty) return null;
+
+    // Snap to whole logical pixels so the image maps 1:1 onto the screen.
+    final snapped = Rect.fromLTRB(
+      bounds.left.floorToDouble(),
+      bounds.top.floorToDouble(),
+      bounds.right.ceilToDouble(),
+      bounds.bottom.ceilToDouble(),
+    );
+    final pixels =
+        (snapped.width * pixelRatio).ceil() *
+        (snapped.height * pixelRatio).ceil();
+    if (pixels <= 0 || pixels > maxPixels) return null;
+
+    return PaintLayerRasterRun(
+      layers: List<PaintLayer>.unmodifiable(members),
+      insertIndex: insertIndex,
+      key: keyBuffer.toString(),
+      bounds: snapped,
+    );
+  }
+
+  /// The part of a run key contributed by [layer]: everything that changes
+  /// its pixels, nothing that does not.
+  ///
+  /// Stroke content is described by its shape parameters and point counts
+  /// rather than hashed point-by-point: strokes are never edited in place —
+  /// the paint editor hands back new layers — and the partial eraser only
+  /// ever appends erased offsets, so the counts move whenever the ink does.
+  @visibleForTesting
+  static String layerKey(PaintLayer layer) {
+    final buffer = StringBuffer()
+      ..write(layer.id)
+      ..write(':')
+      ..write(layer.offset.dx)
+      ..write(',')
+      ..write(layer.offset.dy)
+      ..write(':')
+      ..write(layer.scale)
+      ..write(':')
+      ..write(layer.rotation)
+      ..write(':')
+      ..write(layer.flipX ? 1 : 0)
+      ..write(layer.flipY ? 1 : 0)
+      ..write(':')
+      ..write(layer.opacity)
+      ..write(':')
+      ..write(layer.rawSize.width)
+      ..write('x')
+      ..write(layer.rawSize.height);
+    for (final item in layer.items) {
+      buffer
+        ..write(':')
+        ..write(item.mode.index)
+        ..write(',')
+        ..write(item.color.toARGB32())
+        ..write(',')
+        ..write(item.strokeWidth)
+        ..write(',')
+        ..write(item.opacity)
+        ..write(',')
+        ..write(item.fill ? 1 : 0)
+        ..write(',')
+        ..write(item.offsets.length)
+        ..write(',')
+        ..write(item.erasedOffsets.length);
+    }
+    return buffer.toString();
+  }
+
+  /// The axis-aligned area [layer] paints into, in editor body coordinates.
+  ///
+  /// Mirrors `LayerWidget`: the layer's box is placed at `offset` shifted by
+  /// [fractionalOffset] of its size, then rotated about the box center. The
+  /// box is padded by half the widest stroke, because a stroke's round caps
+  /// reach past the points the box was sized from.
+  @visibleForTesting
+  static Rect layerBounds(
+    PaintLayer layer, {
+    required Size editorBodySize,
+    required Offset fractionalOffset,
+  }) {
+    final size = layer.size;
+    final topLeft = Offset(
+      editorBodySize.width / 2 +
+          layer.offset.dx +
+          fractionalOffset.dx * size.width,
+      editorBodySize.height / 2 +
+          layer.offset.dy +
+          fractionalOffset.dy * size.height,
+    );
+    var padding = 0.0;
+    for (final item in layer.items) {
+      padding = math.max(padding, item.strokeWidth * layer.scale / 2);
+    }
+    final box = Rect.fromLTWH(
+      topLeft.dx,
+      topLeft.dy,
+      size.width,
+      size.height,
+    ).inflate(padding + 1);
+    if (layer.rotation == 0) return box;
+
+    final center = box.center;
+    final cosR = math.cos(layer.rotation);
+    final sinR = math.sin(layer.rotation);
+    Offset rotate(Offset point) {
+      final local = point - center;
+      return center +
+          Offset(
+            local.dx * cosR - local.dy * sinR,
+            local.dx * sinR + local.dy * cosR,
+          );
+    }
+
+    final corners = [
+      rotate(box.topLeft),
+      rotate(box.topRight),
+      rotate(box.bottomLeft),
+      rotate(box.bottomRight),
+    ];
+    var minX = double.infinity;
+    var minY = double.infinity;
+    var maxX = double.negativeInfinity;
+    var maxY = double.negativeInfinity;
+    for (final corner in corners) {
+      minX = math.min(minX, corner.dx);
+      minY = math.min(minY, corner.dy);
+      maxX = math.max(maxX, corner.dx);
+      maxY = math.max(maxY, corner.dy);
+    }
+    return Rect.fromLTRB(minX, minY, maxX, maxY);
+  }
+
+  /// The cached image for [run], or `null` while it has not been rendered.
+  ui.Image? imageFor(PaintLayerRasterRun run) {
+    final image = _images[run.key];
+    if (image != null) _touch(run.key);
+    return image;
+  }
+
+  /// Whether [run] has a cached image.
+  bool contains(PaintLayerRasterRun run) => _images.containsKey(run.key);
+
+  /// Whether an image is currently being rendered.
+  @visibleForTesting
+  bool get isRendering => _inFlightKey != null;
+
+  /// Starts rendering [run] unless its image exists or is already in flight.
+  ///
+  /// Listeners are notified once the image is available.
+  void ensure(
+    PaintLayerRasterRun run, {
+    required Size editorBodySize,
+    required Offset fractionalOffset,
+    required double pixelRatio,
+    required PaintEditorConfigs paintEditorConfigs,
+  }) {
+    if (_isDisposed) return;
+    if (_images.containsKey(run.key) || _inFlightKey == run.key) return;
+    if (_inFlightKey != null) {
+      _hasPendingRequest = true;
+      return;
+    }
+    _inFlightKey = run.key;
+    unawaited(
+      _rasterize(
+        run,
+        editorBodySize: editorBodySize,
+        fractionalOffset: fractionalOffset,
+        pixelRatio: pixelRatio,
+        paintEditorConfigs: paintEditorConfigs,
+      ),
+    );
+  }
+
+  Future<void> _rasterize(
+    PaintLayerRasterRun run, {
+    required Size editorBodySize,
+    required Offset fractionalOffset,
+    required double pixelRatio,
+    required PaintEditorConfigs paintEditorConfigs,
+  }) async {
+    ui.Image? image;
+    try {
+      final picture = recordRun(
+        run,
+        editorBodySize: editorBodySize,
+        fractionalOffset: fractionalOffset,
+        pixelRatio: pixelRatio,
+        paintEditorConfigs: paintEditorConfigs,
+      );
+      try {
+        image = await picture.toImage(
+          (run.bounds.width * pixelRatio).ceil(),
+          (run.bounds.height * pixelRatio).ceil(),
+        );
+      } finally {
+        picture.dispose();
+      }
+    } catch (error, stackTrace) {
+      // Rendering into an image can fail when the engine is short of GPU
+      // memory or the view is being torn down. The run then simply stays
+      // live, which is the behavior without a cache.
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          library: 'pro_image_editor',
+          context: ErrorDescription('while rasterizing a paint layer run'),
+        ),
+      );
+    } finally {
+      _inFlightKey = null;
+    }
+    if (_isDisposed) {
+      image?.dispose();
+      return;
+    }
+    if (image != null) {
+      _images[run.key]?.dispose();
+      _images[run.key] = image;
+      _touch(run.key);
+      _evict();
+    }
+    // Notify even when this render failed or was superseded: the listener
+    // re-plans, which starts whatever is needed now.
+    final hadPending = _hasPendingRequest;
+    _hasPendingRequest = false;
+    if (image != null || hadPending) notifyListeners();
+  }
+
+  /// Records [run] the way its live widgets paint it.
+  ///
+  /// Each member is placed and transformed exactly like `LayerWidget` places
+  /// it — box at `offset` shifted by [fractionalOffset], flips and rotation
+  /// about the box center — and stroked through the same path builders with
+  /// the same baked opacity, so the image matches the live render pixel for
+  /// pixel. The recording is translated so the run's
+  /// [PaintLayerRasterRun.bounds] start at the origin and scaled by
+  /// [pixelRatio].
+  @visibleForTesting
+  static ui.Picture recordRun(
+    PaintLayerRasterRun run, {
+    required Size editorBodySize,
+    required Offset fractionalOffset,
+    required double pixelRatio,
+    required PaintEditorConfigs paintEditorConfigs,
+  }) {
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder)
+      ..scale(pixelRatio)
+      ..translate(-run.bounds.left, -run.bounds.top);
+
+    for (final layer in run.layers) {
+      final size = layer.size;
+      canvas
+        ..save()
+        ..translate(
+          editorBodySize.width / 2 +
+              layer.offset.dx +
+              fractionalOffset.dx * size.width,
+          editorBodySize.height / 2 +
+              layer.offset.dy +
+              fractionalOffset.dy * size.height,
+        )
+        // LayerWidget composes `Rx(flipY)·Ry(flipX)·Rz(rotation)` about the
+        // box center: the rotation is applied to the geometry first, then the
+        // mirroring. Canvas transforms compose the same way when issued in
+        // that order.
+        ..translate(size.width / 2, size.height / 2)
+        ..scale(layer.flipX ? -1 : 1, layer.flipY ? -1 : 1)
+        ..rotate(layer.rotation)
+        ..translate(-size.width / 2, -size.height / 2);
+
+      if (layer.items.length == 1) {
+        _drawItem(
+          canvas,
+          layer.items.first,
+          size: size,
+          scale: layer.scale,
+          opacity: layer.opacity,
+          paintEditorConfigs: paintEditorConfigs,
+        );
+      } else {
+        for (final item in layer.items) {
+          _drawItem(
+            canvas,
+            item,
+            size: size,
+            scale: layer.scale,
+            opacity: item.opacity,
+            paintEditorConfigs: paintEditorConfigs,
+          );
+        }
+      }
+      canvas.restore();
+    }
+
+    return recorder.endRecording();
+  }
+
+  static void _drawItem(
+    Canvas canvas,
+    PaintedModel item, {
+    required Size size,
+    required double scale,
+    required double opacity,
+    required PaintEditorConfigs paintEditorConfigs,
+  }) {
+    PathBuilderBase.fromMode(
+        item: item,
+        scale: scale,
+        paintEditorConfigs: paintEditorConfigs,
+      )
+      ..opacity = opacity
+      ..draw(canvas: canvas, size: size);
+  }
+
+  void _touch(String key) {
+    _recentKeys
+      ..remove(key)
+      ..add(key);
+  }
+
+  int get _totalPixels =>
+      _images.values.fold(0, (sum, image) => sum + image.width * image.height);
+
+  void _evict() {
+    while (_recentKeys.length > 1 &&
+        (_recentKeys.length > maxImages || _totalPixels > maxTotalPixels)) {
+      final stale = _recentKeys.removeAt(0);
+      _images.remove(stale)?.dispose();
+    }
+  }
+
+  /// Drops every cached image.
+  void clear() {
+    for (final image in _images.values) {
+      image.dispose();
+    }
+    _images.clear();
+    _recentKeys.clear();
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    clear();
+    super.dispose();
+  }
+}

--- a/lib/features/main_editor/services/paint_layer_raster_cache.dart
+++ b/lib/features/main_editor/services/paint_layer_raster_cache.dart
@@ -1,13 +1,13 @@
 // Dart imports:
 import 'dart:async';
-import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 // Flutter imports:
 import 'package:flutter/widgets.dart';
 
-import '/core/models/editor_configs/paint_editor/paint_editor_configs.dart';
+import '/core/models/editor_configs/pro_image_editor_configs.dart';
 import '/core/models/layers/layer.dart';
+import '/features/paint_editor/enums/paint_editor_enum.dart';
 
 /// A contiguous z-run of paint layers that is drawn from one cached image.
 ///
@@ -22,6 +22,7 @@ class PaintLayerRasterRun {
     required this.insertIndex,
     required this.key,
     required this.bounds,
+    required this.pixels,
   });
 
   /// The paint layers of this run, bottom-most first.
@@ -42,6 +43,9 @@ class PaintLayerRasterRun {
 
   /// The area the image covers, in editor body coordinates (logical pixels).
   final Rect bounds;
+
+  /// The number of device pixels of the image.
+  final int pixels;
 
   /// The ids of the member layers.
   Iterable<String> get layerIds => layers.map((layer) => layer.id);
@@ -83,6 +87,9 @@ class PaintLayerRasterPlan {
 /// Rasterization runs asynchronously. Until an image lands, the run renders
 /// live, so the canvas is never blank and a moved layer is pixel-exact the
 /// moment it is released; the cached copy takes over a frame or two later.
+///
+/// Widgets that stack layers use it through `PaintLayerRasterCacheHost`,
+/// which owns the cache and knows when it has to step aside.
 class PaintLayerRasterCache extends ChangeNotifier {
   /// Creates a cache.
   PaintLayerRasterCache({
@@ -106,7 +113,9 @@ class PaintLayerRasterCache extends ChangeNotifier {
   /// Scrubbing back and forth across a layer's timeline edge alternates
   /// between two run keys; keeping a few recent images avoids re-rendering
   /// each time. The oldest images are disposed first once the total goes
-  /// over this budget (64 MB of RGBA by default) or over [maxImages].
+  /// over this budget (64 MB of RGBA by default) or over [maxImages]. The
+  /// runs of a single [plan] never claim more than this together; whatever
+  /// does not fit renders live.
   final int maxTotalPixels;
 
   /// The most images kept at once, whatever their size.
@@ -123,6 +132,10 @@ class PaintLayerRasterCache extends ChangeNotifier {
 
   final Map<String, ui.Image> _images = <String, ui.Image>{};
   final List<String> _recentKeys = <String>[];
+
+  /// The keys of the runs in the most recent [plan]. Those images are what
+  /// the host draws right now, so eviction leaves them alone.
+  Set<String> _plannedKeys = const <String>{};
 
   /// Runs whose render failed. They render live and are not retried: `ensure`
   /// runs on every build, so without this a run the GPU cannot render — one
@@ -148,12 +161,14 @@ class PaintLayerRasterCache extends ChangeNotifier {
   /// and interacting ones. A layer with a timeline animation stays live even
   /// outside its animation window, because it would otherwise flip between
   /// cached and live at every window edge; the same goes for the legacy
-  /// enter/exit fade.
+  /// enter/exit fade and for a timeline layer under a custom
+  /// [LayerTimelineConfigs.transitionBuilder], which may decorate the layer
+  /// even at full progress.
   static bool isCacheable(
     Layer layer, {
     required Set<String> excludedIds,
     required Duration? playTime,
-    required PaintEditorConfigs paintEditorConfigs,
+    required ProImageEditorConfigs configs,
   }) {
     if (layer is! PaintLayer) return false;
     if (excludedIds.contains(layer.id)) return false;
@@ -164,11 +179,16 @@ class PaintLayerRasterCache extends ChangeNotifier {
       return false;
     }
     if (layer.transitionBuilder != null) return false;
+    final start = layer.startTime;
+    final end = layer.endTime;
     if (playTime != null) {
-      final start = layer.startTime;
-      final end = layer.endTime;
       if (start != null && playTime < start) return false;
       if (end != null && playTime > end) return false;
+      if ((start != null || end != null) &&
+          configs.videoEditor.layerTimeline.transitionBuilder !=
+              LayerTimelineConfigs.defaultFadeTransition) {
+        return false;
+      }
     }
     // A merged layer with a layer opacity below 1 fades the composed stack
     // through an Opacity widget; reproducing that needs an offscreen per
@@ -177,7 +197,7 @@ class PaintLayerRasterCache extends ChangeNotifier {
     for (final item in layer.items) {
       // A custom builder may draw anything; its opacity path goes through an
       // Opacity widget as well.
-      if (paintEditorConfigs.customPathBuilders.containsKey(item.mode)) {
+      if (configs.paintEditor.customPathBuilders.containsKey(item.mode)) {
         return false;
       }
     }
@@ -189,23 +209,23 @@ class PaintLayerRasterCache extends ChangeNotifier {
 
   /// Groups the cacheable members of [layers] into runs.
   ///
-  /// [editorBodySize] and [fractionalOffset] place each layer the way
-  /// `LayerWidget` does; [pixelRatio] is the device pixel ratio the images are
-  /// rendered at. A run whose image would exceed [maxPixels] is left out, and
-  /// so is everything beyond [maxImages] runs, so the cache never holds more
-  /// than it is allowed to.
+  /// [editorBodySize] places each layer the way `LayerWidget` does;
+  /// [pixelRatio] is the device pixel ratio the images are rendered at. A run
+  /// whose image would exceed [maxPixels] is left out, and so is everything
+  /// beyond [maxImages] runs or [maxTotalPixels] in total, so the cache never
+  /// holds more than it is allowed to.
   PaintLayerRasterPlan plan({
     required List<Layer> layers,
     required Set<String> excludedIds,
     required Duration? playTime,
     required Size editorBodySize,
-    required Offset fractionalOffset,
     required double pixelRatio,
-    required PaintEditorConfigs paintEditorConfigs,
+    required ProImageEditorConfigs configs,
   }) {
     final runs = <PaintLayerRasterRun>[];
     var members = <PaintLayer>[];
     var insertIndex = 0;
+    var budget = maxTotalPixels;
 
     void flush() {
       if (members.isEmpty) return;
@@ -213,10 +233,13 @@ class PaintLayerRasterCache extends ChangeNotifier {
         members,
         insertIndex: insertIndex,
         editorBodySize: editorBodySize,
-        fractionalOffset: fractionalOffset,
+        fractionalOffset: configs.paintEditor.layerFractionalOffset,
         pixelRatio: pixelRatio,
       );
-      if (run != null && runs.length < maxImages) runs.add(run);
+      if (run != null && runs.length < maxImages && run.pixels <= budget) {
+        runs.add(run);
+        budget -= run.pixels;
+      }
       members = <PaintLayer>[];
     }
 
@@ -226,7 +249,7 @@ class PaintLayerRasterCache extends ChangeNotifier {
         layer,
         excludedIds: excludedIds,
         playTime: playTime,
-        paintEditorConfigs: paintEditorConfigs,
+        configs: configs,
       );
       if (!cacheable) {
         flush();
@@ -237,6 +260,7 @@ class PaintLayerRasterCache extends ChangeNotifier {
     }
     flush();
 
+    _plannedKeys = {for (final run in runs) run.key};
     return PaintLayerRasterPlan(runs: runs);
   }
 
@@ -265,12 +289,13 @@ class PaintLayerRasterCache extends ChangeNotifier {
         editorBodySize: editorBodySize,
         fractionalOffset: fractionalOffset,
       );
+      if (rect.isEmpty) continue;
       bounds = bounds == null ? rect : bounds.expandToInclude(rect);
       keyBuffer
         ..write('|')
         ..write(layerKey(layer));
     }
-    if (bounds == null || bounds.isEmpty) return null;
+    if (bounds == null) return null;
 
     // Snap to whole logical pixels so the image maps 1:1 onto the screen.
     final snapped = Rect.fromLTRB(
@@ -290,16 +315,18 @@ class PaintLayerRasterCache extends ChangeNotifier {
       insertIndex: insertIndex,
       key: keyBuffer.toString(),
       bounds: snapped,
+      pixels: pixels,
     );
   }
 
   /// The part of a run key contributed by [layer]: everything that changes
   /// its pixels, nothing that does not.
   ///
-  /// Stroke content is described by its shape parameters and point counts
-  /// rather than hashed point-by-point: strokes are never edited in place —
-  /// the paint editor hands back new layers — and the partial eraser only
-  /// ever appends erased offsets, so the counts move whenever the ink does.
+  /// The stroke points and erased spots go in as a hash of their content, not
+  /// as a count: a layer keeps its id across history entries, so two states
+  /// of it can hold the same number of points at different positions — an
+  /// erase that is undone and redone elsewhere, say — and must not share an
+  /// image.
   @visibleForTesting
   static String layerKey(PaintLayer layer) {
     final buffer = StringBuffer()
@@ -335,24 +362,46 @@ class PaintLayerRasterCache extends ChangeNotifier {
         ..write(item.fill ? 1 : 0)
         ..write(',')
         ..write(item.offsets.length)
+        ..write('/')
+        ..write(Object.hashAll(item.offsets))
         ..write(',')
-        ..write(item.erasedOffsets.length);
+        ..write(item.erasedOffsets.length)
+        ..write('/')
+        ..write(Object.hashAll(item.erasedOffsets));
     }
     return buffer.toString();
   }
 
   /// The axis-aligned area [layer] paints into, in editor body coordinates.
   ///
-  /// Mirrors `LayerWidget`: the layer's box is placed at `offset` shifted by
-  /// [fractionalOffset] of its size, then rotated about the box center. The
-  /// box is padded by half the widest stroke, because a stroke's round caps
-  /// reach past the points the box was sized from.
+  /// Each stroke's extent is its [PaintedModel.bounds] — the same box hit
+  /// testing uses, which already covers round caps and the arrowheads that
+  /// reach past the outermost point — scaled by the layer, plus room for the
+  /// miter joins of the shape modes. The union is placed and transformed the
+  /// way `LayerWidget` places the layer: the box at `offset` shifted by
+  /// [fractionalOffset] of its size, then flipped and rotated about the box
+  /// center. An empty rect means the layer draws nothing.
   @visibleForTesting
   static Rect layerBounds(
     PaintLayer layer, {
     required Size editorBodySize,
     required Offset fractionalOffset,
   }) {
+    final scale = layer.scale;
+    Rect? extent;
+    for (final item in layer.items) {
+      final bounds = item.bounds;
+      if (bounds.isEmpty) continue;
+      final rect = Rect.fromLTRB(
+        bounds.left * scale,
+        bounds.top * scale,
+        bounds.right * scale,
+        bounds.bottom * scale,
+      ).inflate(_miterPadding(item) * scale);
+      extent = extent == null ? rect : extent.expandToInclude(rect);
+    }
+    if (extent == null) return Rect.zero;
+
     final size = layer.size;
     final topLeft = Offset(
       editorBodySize.width / 2 +
@@ -362,47 +411,33 @@ class PaintLayerRasterCache extends ChangeNotifier {
           layer.offset.dy +
           fractionalOffset.dy * size.height,
     );
-    var padding = 0.0;
-    for (final item in layer.items) {
-      padding = math.max(padding, item.strokeWidth * layer.scale / 2);
-    }
-    final box = Rect.fromLTWH(
-      topLeft.dx,
-      topLeft.dy,
-      size.width,
-      size.height,
-    ).inflate(padding + 1);
-    if (layer.rotation == 0) return box;
+    // One pixel for the anti-aliased edge.
+    final box = extent.shift(topLeft).inflate(1);
+    if (layer.rotation == 0 && !layer.flipX && !layer.flipY) return box;
 
-    final center = box.center;
-    final cosR = math.cos(layer.rotation);
-    final sinR = math.sin(layer.rotation);
-    Offset rotate(Offset point) {
-      final local = point - center;
-      return center +
-          Offset(
-            local.dx * cosR - local.dy * sinR,
-            local.dx * sinR + local.dy * cosR,
-          );
-    }
+    final center = topLeft + size.center(Offset.zero);
+    final transform = Matrix4.translationValues(center.dx, center.dy, 0)
+      ..scaleByDouble(layer.flipX ? -1 : 1, layer.flipY ? -1 : 1, 1, 1)
+      ..rotateZ(layer.rotation)
+      ..translateByDouble(-center.dx, -center.dy, 0, 1);
+    return MatrixUtils.transformRect(transform, box);
+  }
 
-    final corners = [
-      rotate(box.topLeft),
-      rotate(box.topRight),
-      rotate(box.bottomLeft),
-      rotate(box.bottomRight),
-    ];
-    var minX = double.infinity;
-    var minY = double.infinity;
-    var maxX = double.negativeInfinity;
-    var maxY = double.negativeInfinity;
-    for (final corner in corners) {
-      minX = math.min(minX, corner.dx);
-      minY = math.min(minY, corner.dy);
-      maxX = math.max(maxX, corner.dx);
-      maxY = math.max(maxY, corner.dy);
+  /// How far a miter join may draw past [PaintedModel.bounds].
+  ///
+  /// The shape modes stroke their corners with the default miter join, whose
+  /// tip reaches up to `strokeMiterLimit` (4) half-strokes from the corner;
+  /// `bounds` only covers half a stroke. The freestyle modes use round joins
+  /// and the arrow modes' padding already covers the head's miters.
+  static double _miterPadding(PaintedModel item) {
+    switch (item.mode) {
+      case PaintMode.rect:
+      case PaintMode.polygon:
+      case PaintMode.hexagon:
+        return item.strokeWidth * 1.5;
+      default:
+        return 0;
     }
-    return Rect.fromLTRB(minX, minY, maxX, maxY);
   }
 
   /// The cached image for [run], or `null` while it has not been rendered.
@@ -429,9 +464,8 @@ class PaintLayerRasterCache extends ChangeNotifier {
   void ensure(
     PaintLayerRasterRun run, {
     required Size editorBodySize,
-    required Offset fractionalOffset,
     required double pixelRatio,
-    required PaintEditorConfigs paintEditorConfigs,
+    required ProImageEditorConfigs configs,
   }) {
     if (_isDisposed) return;
     if (_images.containsKey(run.key) || _inFlightKey == run.key) return;
@@ -445,9 +479,8 @@ class PaintLayerRasterCache extends ChangeNotifier {
       _rasterize(
         run,
         editorBodySize: editorBodySize,
-        fractionalOffset: fractionalOffset,
         pixelRatio: pixelRatio,
-        paintEditorConfigs: paintEditorConfigs,
+        configs: configs,
       ),
     );
   }
@@ -455,18 +488,16 @@ class PaintLayerRasterCache extends ChangeNotifier {
   Future<void> _rasterize(
     PaintLayerRasterRun run, {
     required Size editorBodySize,
-    required Offset fractionalOffset,
     required double pixelRatio,
-    required PaintEditorConfigs paintEditorConfigs,
+    required ProImageEditorConfigs configs,
   }) async {
     ui.Image? image;
     try {
       final picture = recordRun(
         run,
         editorBodySize: editorBodySize,
-        fractionalOffset: fractionalOffset,
         pixelRatio: pixelRatio,
-        paintEditorConfigs: paintEditorConfigs,
+        configs: configs,
       );
       try {
         image = await toImage(
@@ -524,20 +555,20 @@ class PaintLayerRasterCache extends ChangeNotifier {
   /// Records [run] the way its live widgets paint it.
   ///
   /// Each member is placed and transformed exactly like `LayerWidget` places
-  /// it — box at `offset` shifted by [fractionalOffset], flips and rotation
-  /// about the box center — and stroked through the same path builders with
-  /// the same baked opacity, so the image matches the live render pixel for
-  /// pixel. The recording is translated so the run's
+  /// it — box at `offset` shifted by the paint editor's fractional offset,
+  /// flips and rotation about the box center — and stroked through the same
+  /// path builders with the same baked opacity, so the image matches the live
+  /// render pixel for pixel. The recording is translated so the run's
   /// [PaintLayerRasterRun.bounds] start at the origin and scaled by
   /// [pixelRatio].
   @visibleForTesting
   static ui.Picture recordRun(
     PaintLayerRasterRun run, {
     required Size editorBodySize,
-    required Offset fractionalOffset,
     required double pixelRatio,
-    required PaintEditorConfigs paintEditorConfigs,
+    required ProImageEditorConfigs configs,
   }) {
+    final fractionalOffset = configs.paintEditor.layerFractionalOffset;
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder)
       ..scale(pixelRatio)
@@ -563,32 +594,69 @@ class PaintLayerRasterCache extends ChangeNotifier {
         ..scale(layer.flipX ? -1 : 1, layer.flipY ? -1 : 1)
         ..rotate(layer.rotation)
         ..translate(-size.width / 2, -size.height / 2);
-
-      if (layer.items.length == 1) {
-        _drawItem(
-          canvas,
-          layer.items.first,
-          size: size,
-          scale: layer.scale,
-          opacity: layer.opacity,
-          paintEditorConfigs: paintEditorConfigs,
-        );
-      } else {
-        for (final item in layer.items) {
-          _drawItem(
-            canvas,
-            item,
-            size: size,
-            scale: layer.scale,
-            opacity: item.opacity,
-            paintEditorConfigs: paintEditorConfigs,
-          );
-        }
-      }
+      _drawLayer(canvas, layer, paintEditorConfigs: configs.paintEditor);
       canvas.restore();
     }
 
     return recorder.endRecording();
+  }
+
+  /// Renders the content of [layer] alone — what its own repaint boundary
+  /// holds while it paints live — into an image of its size at [pixelRatio].
+  ///
+  /// `Layer.captureAsPng` reads this while the layer is drawn from the cache,
+  /// because the boundary paints nothing then. The cache only admits layers
+  /// whose paint it reproduces exactly, so the result is what the boundary
+  /// would have captured.
+  static Future<ui.Image> renderLayerContent(
+    PaintLayer layer, {
+    required double pixelRatio,
+    required PaintEditorConfigs paintEditorConfigs,
+  }) async {
+    final size = layer.size;
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder)..scale(pixelRatio);
+    _drawLayer(canvas, layer, paintEditorConfigs: paintEditorConfigs);
+    final picture = recorder.endRecording();
+    try {
+      return await picture.toImage(
+        (size.width * pixelRatio).ceil(),
+        (size.height * pixelRatio).ceil(),
+      );
+    } finally {
+      picture.dispose();
+    }
+  }
+
+  /// Strokes [layer]'s items in its own box coordinates, with the opacity
+  /// baked the way `LayerWidgetPaintItem` bakes it.
+  static void _drawLayer(
+    Canvas canvas,
+    PaintLayer layer, {
+    required PaintEditorConfigs paintEditorConfigs,
+  }) {
+    final size = layer.size;
+    if (layer.items.length == 1) {
+      _drawItem(
+        canvas,
+        layer.items.first,
+        size: size,
+        scale: layer.scale,
+        opacity: layer.opacity,
+        paintEditorConfigs: paintEditorConfigs,
+      );
+      return;
+    }
+    for (final item in layer.items) {
+      _drawItem(
+        canvas,
+        item,
+        size: size,
+        scale: layer.scale,
+        opacity: item.opacity,
+        paintEditorConfigs: paintEditorConfigs,
+      );
+    }
   }
 
   static void _drawItem(
@@ -608,6 +676,60 @@ class PaintLayerRasterCache extends ChangeNotifier {
       ..draw(canvas: canvas, size: size);
   }
 
+  /// Plans this build's runs, starts rendering any missing image and returns
+  /// the stack children: every layer of [layers] in z-order through
+  /// [buildLayer], with each run whose image is ready preceded by that image
+  /// and its members built with `isRasterCached` set, so they skip their own
+  /// paint. A run whose image is still rendering stays live.
+  ///
+  /// [pixelRatio] is the ratio the images are rendered at — the device pixel
+  /// ratio times whatever scale the stack is drawn under.
+  List<Widget> buildChildren({
+    required List<Layer> layers,
+    required Set<String> excludedIds,
+    required Duration? playTime,
+    required Size editorBodySize,
+    required double pixelRatio,
+    required ProImageEditorConfigs configs,
+    required Widget Function(Layer layer, {required bool isRasterCached})
+    buildLayer,
+  }) {
+    final plan = this.plan(
+      layers: layers,
+      excludedIds: excludedIds,
+      playTime: playTime,
+      editorBodySize: editorBodySize,
+      pixelRatio: pixelRatio,
+      configs: configs,
+    );
+
+    final imagesByInsertIndex = <int, Widget>{};
+    final cachedIds = <String>{};
+    for (final run in plan.runs) {
+      ensure(
+        run,
+        editorBodySize: editorBodySize,
+        pixelRatio: pixelRatio,
+        configs: configs,
+      );
+      final image = imageFor(run);
+      if (image == null) continue;
+      imagesByInsertIndex[run.insertIndex] = PaintRunImage(
+        key: ValueKey<String>(run.key),
+        image: image,
+        bounds: run.bounds,
+      );
+      cachedIds.addAll(run.layerIds);
+    }
+
+    return [
+      for (var i = 0; i < layers.length; i++) ...[
+        ?imagesByInsertIndex[i],
+        buildLayer(layers[i], isRasterCached: cachedIds.contains(layers[i].id)),
+      ],
+    ];
+  }
+
   void _touch(String key) {
     _recentKeys
       ..remove(key)
@@ -617,11 +739,23 @@ class PaintLayerRasterCache extends ChangeNotifier {
   int get _totalPixels =>
       _images.values.fold(0, (sum, image) => sum + image.width * image.height);
 
+  /// Disposes the least recently used images until the rest fit the budget.
+  ///
+  /// Images of the current plan are skipped: the host draws them right now,
+  /// and evicting one would only make it render again, land again and evict
+  /// the next. [plan] keeps them within [maxImages] and [maxTotalPixels] on
+  /// its own, so the loop always ends.
   void _evict() {
-    while (_recentKeys.length > 1 &&
+    var index = 0;
+    while (index < _recentKeys.length &&
         (_recentKeys.length > maxImages || _totalPixels > maxTotalPixels)) {
-      final stale = _recentKeys.removeAt(0);
-      _images.remove(stale)?.dispose();
+      final key = _recentKeys[index];
+      if (_plannedKeys.contains(key)) {
+        index++;
+        continue;
+      }
+      _recentKeys.removeAt(index);
+      _images.remove(key)?.dispose();
     }
   }
 
@@ -642,5 +776,43 @@ class PaintLayerRasterCache extends ChangeNotifier {
     _isDisposed = true;
     clear();
     super.dispose();
+  }
+}
+
+/// One run's cached image, placed where its bottom-most member paints.
+///
+/// Pointer events pass through: the members' own widgets stay mounted and
+/// keep hit-testing the real strokes.
+class PaintRunImage extends StatelessWidget {
+  /// Creates the image widget for a cached run.
+  const PaintRunImage({super.key, required this.image, required this.bounds});
+
+  /// The rendered run.
+  final ui.Image image;
+
+  /// Where the run paints, in editor body coordinates.
+  final Rect bounds;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: bounds.left,
+      top: bounds.top,
+      width: bounds.width,
+      height: bounds.height,
+      child: IgnorePointer(
+        // The image is rendered at exactly the device pixel ratio, so at an
+        // integral ratio this is a 1:1 blit; bilinear filtering only matters
+        // on fractional ratios, where nearest-neighbour would shift edges by
+        // a pixel.
+        child: RawImage(
+          image: image,
+          width: bounds.width,
+          height: bounds.height,
+          fit: BoxFit.fill,
+          filterQuality: FilterQuality.low,
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/main_editor/services/paint_layer_raster_cache.dart
+++ b/lib/features/main_editor/services/paint_layer_raster_cache.dart
@@ -89,6 +89,7 @@ class PaintLayerRasterCache extends ChangeNotifier {
     this.maxPixels = 8 * 1024 * 1024,
     this.maxTotalPixels = 16 * 1024 * 1024,
     this.maxImages = 4,
+    this.maxDimension = 4096,
   });
 
   /// The pixel budget of a single run's image.
@@ -111,8 +112,26 @@ class PaintLayerRasterCache extends ChangeNotifier {
   /// The most images kept at once, whatever their size.
   final int maxImages;
 
+  /// The longest side an image may have, in device pixels.
+  ///
+  /// A run whose image would be wider or taller than this at the current
+  /// pixel ratio is not cached, even when it fits [maxPixels]: the GPU refuses
+  /// textures beyond its limit, and Flutter does not expose that limit. 4096
+  /// is what older mobile GPUs guarantee; a run only gets that large when its
+  /// layers spill far past the canvas.
+  final int maxDimension;
+
   final Map<String, ui.Image> _images = <String, ui.Image>{};
   final List<String> _recentKeys = <String>[];
+
+  /// Runs whose render failed. They render live and are not retried: `ensure`
+  /// runs on every build, so without this a run the GPU cannot render — one
+  /// past its texture limit, say — would be attempted again on every frame,
+  /// each attempt as expensive as a live frame and each reported as an error.
+  /// A key stops mattering once any member changes, so the set is small and
+  /// bounded anyway.
+  final Set<String> _failedKeys = <String>{};
+  static const int _maxFailedKeys = 32;
 
   /// The key being rendered right now. Only one image renders at a time: a
   /// burst of changes — every pointer move of an erase, say — would otherwise
@@ -260,10 +279,11 @@ class PaintLayerRasterCache extends ChangeNotifier {
       bounds.right.ceilToDouble(),
       bounds.bottom.ceilToDouble(),
     );
-    final pixels =
-        (snapped.width * pixelRatio).ceil() *
-        (snapped.height * pixelRatio).ceil();
+    final width = (snapped.width * pixelRatio).ceil();
+    final height = (snapped.height * pixelRatio).ceil();
+    final pixels = width * height;
     if (pixels <= 0 || pixels > maxPixels) return null;
+    if (width > maxDimension || height > maxDimension) return null;
 
     return PaintLayerRasterRun(
       layers: List<PaintLayer>.unmodifiable(members),
@@ -395,6 +415,10 @@ class PaintLayerRasterCache extends ChangeNotifier {
   /// Whether [run] has a cached image.
   bool contains(PaintLayerRasterRun run) => _images.containsKey(run.key);
 
+  /// Whether rendering [run] failed, so it stays live and is not retried.
+  @visibleForTesting
+  bool hasFailed(PaintLayerRasterRun run) => _failedKeys.contains(run.key);
+
   /// Whether an image is currently being rendered.
   @visibleForTesting
   bool get isRendering => _inFlightKey != null;
@@ -411,6 +435,7 @@ class PaintLayerRasterCache extends ChangeNotifier {
   }) {
     if (_isDisposed) return;
     if (_images.containsKey(run.key) || _inFlightKey == run.key) return;
+    if (_failedKeys.contains(run.key)) return;
     if (_inFlightKey != null) {
       _hasPendingRequest = true;
       return;
@@ -444,7 +469,8 @@ class PaintLayerRasterCache extends ChangeNotifier {
         paintEditorConfigs: paintEditorConfigs,
       );
       try {
-        image = await picture.toImage(
+        image = await toImage(
+          picture,
           (run.bounds.width * pixelRatio).ceil(),
           (run.bounds.height * pixelRatio).ceil(),
         );
@@ -454,7 +480,11 @@ class PaintLayerRasterCache extends ChangeNotifier {
     } catch (error, stackTrace) {
       // Rendering into an image can fail when the engine is short of GPU
       // memory or the view is being torn down. The run then simply stays
-      // live, which is the behavior without a cache.
+      // live, which is the behavior without a cache, and is not retried.
+      _failedKeys.add(run.key);
+      if (_failedKeys.length > _maxFailedKeys) {
+        _failedKeys.remove(_failedKeys.first);
+      }
       FlutterError.reportError(
         FlutterErrorDetails(
           exception: error,
@@ -482,6 +512,14 @@ class PaintLayerRasterCache extends ChangeNotifier {
     _hasPendingRequest = false;
     if (image != null || hadPending) notifyListeners();
   }
+
+  /// Renders [picture] into a [width]×[height] image.
+  ///
+  /// Overridable so tests can make a render fail.
+  @protected
+  @visibleForTesting
+  Future<ui.Image> toImage(ui.Picture picture, int width, int height) =>
+      picture.toImage(width, height);
 
   /// Records [run] the way its live widgets paint it.
   ///
@@ -588,6 +626,9 @@ class PaintLayerRasterCache extends ChangeNotifier {
   }
 
   /// Drops every cached image.
+  ///
+  /// Failed runs stay remembered: what made them fail — a texture past the
+  /// GPU's limit — does not change with the cache contents.
   void clear() {
     for (final image in _images.values) {
       image.dispose();

--- a/lib/features/main_editor/widgets/main_editor_layers.dart
+++ b/lib/features/main_editor/widgets/main_editor_layers.dart
@@ -12,12 +12,11 @@ import '/features/main_editor/services/layer_interaction_manager.dart';
 import '/features/main_editor/services/sizes_manager.dart';
 import '/plugins/defer_pointer/defer_pointer.dart';
 import '/shared/widgets/extended/mouse_region/extended_rebuild_mouse_region.dart';
-import '/shared/widgets/layer/layer_stack.dart' show PaintRunImage;
 import '/shared/widgets/layer/layer_widget.dart';
+import '/shared/widgets/layer/paint_layer_raster_cache_host.dart';
 import '../main_editor.dart';
 import '../services/layer_drag_selection_service.dart';
 import '../services/main_editor_layers_service.dart';
-import '../services/paint_layer_raster_cache.dart';
 
 /// A widget that manages and displays layers in the main editor, handling
 /// interactions, configurations, and callbacks for user actions.
@@ -42,7 +41,6 @@ class MainEditorLayers extends StatefulWidget {
     required this.mouseService,
     required this.dragSelectionService,
     this.playTimeNotifier,
-    this.suspendPaintLayerRasterCache = false,
   });
 
   /// Represents the current state of the editor.
@@ -99,26 +97,17 @@ class MainEditorLayers extends StatefulWidget {
   /// animated in/out based on the current time.
   final ValueNotifier<Duration>? playTimeNotifier;
 
-  /// Forces every paint layer to render live even when
-  /// `MainEditorConfigs.enablePaintLayerRasterCache` is on.
-  ///
-  /// Set while layers are captured to images: a cached layer's own repaint
-  /// boundary paints nothing, so a capture taken from it would be empty.
-  final bool suspendPaintLayerRasterCache;
-
   @override
   State<MainEditorLayers> createState() => _MainEditorLayersState();
 }
 
-class _MainEditorLayersState extends State<MainEditorLayers> {
+class _MainEditorLayersState extends State<MainEditorLayers>
+    with PaintLayerRasterCacheHost {
+  @override
+  ProImageEditorConfigs get configs => widget.configs;
+
   /// Represents the dimensions of the body.
   Size _editorBodySize = Size.infinite;
-
-  /// The raster cache, or `null` when the feature is off.
-  late final PaintLayerRasterCache? _rasterCache =
-      widget.configs.mainEditor.enablePaintLayerRasterCache
-      ? PaintLayerRasterCache()
-      : null;
 
   /// A hash of the layers the cache could draw at the last play time it saw.
   /// Only a change in that set — a layer crossing its timeline edge — is
@@ -153,8 +142,7 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
   @override
   void initState() {
     super.initState();
-    if (_rasterCache != null) {
-      _rasterCache.addListener(_onRasterCacheChanged);
+    if (rasterCache != null) {
       widget.playTimeNotifier?.addListener(_onPlayTimeChanged);
       _zoomSubscription = widget.controllers.cropLayerPainterCtrl.stream.listen(
         (_) => _onZoomMaybeChanged(),
@@ -165,7 +153,8 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
   @override
   void didUpdateWidget(covariant MainEditorLayers oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (_rasterCache == null) return;
+    final cache = rasterCache;
+    if (cache == null) return;
     if (oldWidget.playTimeNotifier != widget.playTimeNotifier) {
       oldWidget.playTimeNotifier?.removeListener(_onPlayTimeChanged);
       widget.playTimeNotifier?.addListener(_onPlayTimeChanged);
@@ -175,7 +164,7 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
     // here would only sit in GPU memory until it closes. One re-render on
     // return is cheaper than holding two canvases' worth of textures.
     if (widget.isSubEditorOpen && !oldWidget.isSubEditorOpen) {
-      _rasterCache.clear();
+      cache.clear();
     }
   }
 
@@ -183,13 +172,7 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
   void dispose() {
     _zoomSubscription?.cancel();
     widget.playTimeNotifier?.removeListener(_onPlayTimeChanged);
-    _rasterCache?.removeListener(_onRasterCacheChanged);
-    _rasterCache?.dispose();
     super.dispose();
-  }
-
-  void _onRasterCacheChanged() {
-    if (mounted) setState(() {});
   }
 
   /// Rebuilds when a layer enters or leaves its timeline window, which moves
@@ -210,10 +193,8 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
     setState(() {});
   }
 
-  bool get _isZoomed {
-    final scale = widget.state.interactiveViewer.currentState?.scaleFactor;
-    return scale != null && (scale - 1.0).abs() > 1e-6;
-  }
+  bool get _isZoomed =>
+      widget.state.interactiveViewer.currentState?.isZoomed ?? false;
 
   int _computeTimelineSignature() {
     final playTime = widget.playTimeNotifier?.value;
@@ -231,82 +212,28 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
     return signature;
   }
 
-  /// Whether the cache may draw anything for this build.
-  bool get _isRasterCacheActive =>
-      _rasterCache != null &&
-      !widget.suspendPaintLayerRasterCache &&
-      !widget.isSubEditorOpen &&
-      !_isZoomed;
-
-  /// Plans the cached runs for this build and kicks off any missing image.
-  PaintLayerRasterPlan _planRasterRuns(BuildContext context) {
-    final cache = _rasterCache;
-    if (cache == null || !_isRasterCacheActive) {
-      return PaintLayerRasterPlan.none;
-    }
-
-    final excluded = <String>{
-      ..._layerInteractionManager.selectedLayerIds,
-      if (_layerInteractionManager.activeInteractionLayer != null)
-        _layerInteractionManager.activeInteractionLayer!.id,
-    };
-    final paintEditorConfigs = widget.configs.paintEditor;
-    final pixelRatio = MediaQuery.devicePixelRatioOf(context);
-    final plan = cache.plan(
+  /// The stack children, with static paint layers drawn from the cache.
+  ///
+  /// Selected and interacting layers stay live so they are pixel-exact while
+  /// they move; so does everything while a sub-editor is open (hero flights
+  /// need painted sources) and while the editor is zoomed (the image would be
+  /// upscaled).
+  List<Widget> _buildLayerChildren(BuildContext context) {
+    final children = buildRasterCachedLayers(
       layers: widget.activeLayers,
-      excludedIds: excluded,
+      excludedIds: {
+        ..._layerInteractionManager.selectedLayerIds,
+        if (_layerInteractionManager.activeInteractionLayer != null)
+          _layerInteractionManager.activeInteractionLayer!.id,
+      },
       playTime: widget.playTimeNotifier?.value,
       editorBodySize: _editorBodySize,
-      fractionalOffset: paintEditorConfigs.layerFractionalOffset,
-      pixelRatio: pixelRatio,
-      paintEditorConfigs: paintEditorConfigs,
+      pixelRatio: MediaQuery.devicePixelRatioOf(context),
+      suspend: widget.isSubEditorOpen || _isZoomed,
+      buildLayer: _buildLayerWidget,
     );
-    for (final run in plan.runs) {
-      cache.ensure(
-        run,
-        editorBodySize: _editorBodySize,
-        fractionalOffset: paintEditorConfigs.layerFractionalOffset,
-        pixelRatio: pixelRatio,
-        paintEditorConfigs: paintEditorConfigs,
-      );
-    }
     _timelineSignature = _computeTimelineSignature();
-    return plan;
-  }
-
-  /// The stack children: every layer widget in z-order, with each run that
-  /// has an image ready preceded by that image and its members told to skip
-  /// their own paint. A run whose image is still rendering stays live.
-  List<Widget> _buildLayerChildren(BuildContext context) {
-    final plan = _planRasterRuns(context);
-    if (plan.runs.isEmpty) {
-      return [
-        for (final layer in widget.activeLayers) _buildLayerWidget(layer),
-      ];
-    }
-
-    final imagesByInsertIndex = <int, PaintRunImage>{};
-    final cachedIds = <String>{};
-    for (final run in plan.runs) {
-      final image = _rasterCache!.imageFor(run);
-      if (image == null) continue;
-      imagesByInsertIndex[run.insertIndex] = PaintRunImage(
-        key: ValueKey<String>(run.key),
-        image: image,
-        bounds: run.bounds,
-      );
-      cachedIds.addAll(run.layerIds);
-    }
-
-    return [
-      for (var i = 0; i < widget.activeLayers.length; i++) ...[
-        ?imagesByInsertIndex[i],
-        _buildLayerWidget(
-          widget.activeLayers[i],
-          isRasterCached: cachedIds.contains(widget.activeLayers[i].id),
-        ),
-      ],
-    ];
+    return children;
   }
 
   @override

--- a/lib/features/main_editor/widgets/main_editor_layers.dart
+++ b/lib/features/main_editor/widgets/main_editor_layers.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:material_ui/material_ui.dart';
 
 import '/core/models/editor_callbacks/pro_image_editor_callbacks.dart';
@@ -10,10 +12,12 @@ import '/features/main_editor/services/layer_interaction_manager.dart';
 import '/features/main_editor/services/sizes_manager.dart';
 import '/plugins/defer_pointer/defer_pointer.dart';
 import '/shared/widgets/extended/mouse_region/extended_rebuild_mouse_region.dart';
+import '/shared/widgets/layer/layer_stack.dart' show PaintRunImage;
 import '/shared/widgets/layer/layer_widget.dart';
 import '../main_editor.dart';
 import '../services/layer_drag_selection_service.dart';
 import '../services/main_editor_layers_service.dart';
+import '../services/paint_layer_raster_cache.dart';
 
 /// A widget that manages and displays layers in the main editor, handling
 /// interactions, configurations, and callbacks for user actions.
@@ -38,6 +42,7 @@ class MainEditorLayers extends StatefulWidget {
     required this.mouseService,
     required this.dragSelectionService,
     this.playTimeNotifier,
+    this.suspendPaintLayerRasterCache = false,
   });
 
   /// Represents the current state of the editor.
@@ -94,6 +99,13 @@ class MainEditorLayers extends StatefulWidget {
   /// animated in/out based on the current time.
   final ValueNotifier<Duration>? playTimeNotifier;
 
+  /// Forces every paint layer to render live even when
+  /// `MainEditorConfigs.enablePaintLayerRasterCache` is on.
+  ///
+  /// Set while layers are captured to images: a cached layer's own repaint
+  /// boundary paints nothing, so a capture taken from it would be empty.
+  final bool suspendPaintLayerRasterCache;
+
   @override
   State<MainEditorLayers> createState() => _MainEditorLayersState();
 }
@@ -101,6 +113,23 @@ class MainEditorLayers extends StatefulWidget {
 class _MainEditorLayersState extends State<MainEditorLayers> {
   /// Represents the dimensions of the body.
   Size _editorBodySize = Size.infinite;
+
+  /// The raster cache, or `null` when the feature is off.
+  late final PaintLayerRasterCache? _rasterCache =
+      widget.configs.mainEditor.enablePaintLayerRasterCache
+      ? PaintLayerRasterCache()
+      : null;
+
+  /// A hash of the layers the cache could draw at the last play time it saw.
+  /// Only a change in that set — a layer crossing its timeline edge — is
+  /// worth a rebuild; the play time itself moves every frame.
+  int _timelineSignature = 0;
+
+  /// Whether the editor was zoomed at the last matrix change. Zooming scales
+  /// the cached image, so the cache steps aside while the editor is zoomed.
+  bool _wasZoomed = false;
+
+  StreamSubscription<void>? _zoomSubscription;
 
   late final _layerInteractionManager = widget.layerInteractionManager;
   late final _layersService = MainEditorLayersService(
@@ -120,6 +149,158 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
     onTextLayerTap: widget.onTextLayerTap,
     onEditPaintLayer: widget.onEditPaintLayer,
   );
+
+  @override
+  void initState() {
+    super.initState();
+    if (_rasterCache != null) {
+      _rasterCache.addListener(_onRasterCacheChanged);
+      widget.playTimeNotifier?.addListener(_onPlayTimeChanged);
+      _zoomSubscription = widget.controllers.cropLayerPainterCtrl.stream.listen(
+        (_) => _onZoomMaybeChanged(),
+      );
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant MainEditorLayers oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_rasterCache != null &&
+        oldWidget.playTimeNotifier != widget.playTimeNotifier) {
+      oldWidget.playTimeNotifier?.removeListener(_onPlayTimeChanged);
+      widget.playTimeNotifier?.addListener(_onPlayTimeChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    _zoomSubscription?.cancel();
+    widget.playTimeNotifier?.removeListener(_onPlayTimeChanged);
+    _rasterCache?.removeListener(_onRasterCacheChanged);
+    _rasterCache?.dispose();
+    super.dispose();
+  }
+
+  void _onRasterCacheChanged() {
+    if (mounted) setState(() {});
+  }
+
+  /// Rebuilds when a layer enters or leaves its timeline window, which moves
+  /// it between the cache and live rendering.
+  void _onPlayTimeChanged() {
+    if (!mounted) return;
+    final signature = _computeTimelineSignature();
+    if (signature == _timelineSignature) return;
+    _timelineSignature = signature;
+    setState(() {});
+  }
+
+  void _onZoomMaybeChanged() {
+    if (!mounted) return;
+    final isZoomed = _isZoomed;
+    if (isZoomed == _wasZoomed) return;
+    _wasZoomed = isZoomed;
+    setState(() {});
+  }
+
+  bool get _isZoomed {
+    final scale = widget.state.interactiveViewer.currentState?.scaleFactor;
+    return scale != null && (scale - 1.0).abs() > 1e-6;
+  }
+
+  int _computeTimelineSignature() {
+    final playTime = widget.playTimeNotifier?.value;
+    var signature = 17;
+    for (final layer in widget.activeLayers) {
+      if (layer is! PaintLayer) continue;
+      final start = layer.startTime;
+      final end = layer.endTime;
+      final visible =
+          playTime == null ||
+          ((start == null || playTime >= start) &&
+              (end == null || playTime <= end));
+      signature = Object.hash(signature, layer.id, visible);
+    }
+    return signature;
+  }
+
+  /// Whether the cache may draw anything for this build.
+  bool get _isRasterCacheActive =>
+      _rasterCache != null &&
+      !widget.suspendPaintLayerRasterCache &&
+      !widget.isSubEditorOpen &&
+      !_isZoomed;
+
+  /// Plans the cached runs for this build and kicks off any missing image.
+  PaintLayerRasterPlan _planRasterRuns(BuildContext context) {
+    final cache = _rasterCache;
+    if (cache == null || !_isRasterCacheActive) {
+      return PaintLayerRasterPlan.none;
+    }
+
+    final excluded = <String>{
+      ..._layerInteractionManager.selectedLayerIds,
+      if (_layerInteractionManager.activeInteractionLayer != null)
+        _layerInteractionManager.activeInteractionLayer!.id,
+    };
+    final paintEditorConfigs = widget.configs.paintEditor;
+    final pixelRatio = MediaQuery.devicePixelRatioOf(context);
+    final plan = cache.plan(
+      layers: widget.activeLayers,
+      excludedIds: excluded,
+      playTime: widget.playTimeNotifier?.value,
+      editorBodySize: _editorBodySize,
+      fractionalOffset: paintEditorConfigs.layerFractionalOffset,
+      pixelRatio: pixelRatio,
+      paintEditorConfigs: paintEditorConfigs,
+    );
+    for (final run in plan.runs) {
+      cache.ensure(
+        run,
+        editorBodySize: _editorBodySize,
+        fractionalOffset: paintEditorConfigs.layerFractionalOffset,
+        pixelRatio: pixelRatio,
+        paintEditorConfigs: paintEditorConfigs,
+      );
+    }
+    _timelineSignature = _computeTimelineSignature();
+    return plan;
+  }
+
+  /// The stack children: every layer widget in z-order, with each run that
+  /// has an image ready preceded by that image and its members told to skip
+  /// their own paint. A run whose image is still rendering stays live.
+  List<Widget> _buildLayerChildren(BuildContext context) {
+    final plan = _planRasterRuns(context);
+    if (plan.runs.isEmpty) {
+      return [
+        for (final layer in widget.activeLayers) _buildLayerWidget(layer),
+      ];
+    }
+
+    final imagesByInsertIndex = <int, PaintRunImage>{};
+    final cachedIds = <String>{};
+    for (final run in plan.runs) {
+      final image = _rasterCache!.imageFor(run);
+      if (image == null) continue;
+      imagesByInsertIndex[run.insertIndex] = PaintRunImage(
+        key: ValueKey<String>(run.key),
+        image: image,
+        bounds: run.bounds,
+      );
+      cachedIds.addAll(run.layerIds);
+    }
+
+    return [
+      for (var i = 0; i < widget.activeLayers.length; i++) ...[
+        ?imagesByInsertIndex[i],
+        _buildLayerWidget(
+          widget.activeLayers[i],
+          isRasterCached: cachedIds.contains(widget.activeLayers[i].id),
+        ),
+      ],
+    ];
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -166,10 +347,7 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
                   },
                   child: Stack(
                     clipBehavior: Clip.none,
-                    children: [
-                      for (Layer layer in widget.activeLayers)
-                        _buildLayerWidget(layer),
-                    ],
+                    children: _buildLayerChildren(context),
                   ),
                 );
               },
@@ -181,10 +359,11 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
   }
 
   /// Builds a single layer widget
-  Widget _buildLayerWidget(Layer layer) {
+  Widget _buildLayerWidget(Layer layer, {bool isRasterCached = false}) {
     return LayerWidget(
       key: layer.key,
       layer: layer,
+      isRasterCached: isRasterCached,
       configs: widget.configs,
       callbacks: widget.callbacks,
       layersService: _layersService,

--- a/lib/features/main_editor/widgets/main_editor_layers.dart
+++ b/lib/features/main_editor/widgets/main_editor_layers.dart
@@ -165,10 +165,17 @@ class _MainEditorLayersState extends State<MainEditorLayers> {
   @override
   void didUpdateWidget(covariant MainEditorLayers oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (_rasterCache != null &&
-        oldWidget.playTimeNotifier != widget.playTimeNotifier) {
+    if (_rasterCache == null) return;
+    if (oldWidget.playTimeNotifier != widget.playTimeNotifier) {
       oldWidget.playTimeNotifier?.removeListener(_onPlayTimeChanged);
       widget.playTimeNotifier?.addListener(_onPlayTimeChanged);
+    }
+    // A sub-editor renders these layers live (hero flights need painted
+    // sources) and its `LayerStack` brings a cache of its own, so the images
+    // here would only sit in GPU memory until it closes. One re-render on
+    // return is cheaper than holding two canvases' worth of textures.
+    if (widget.isSubEditorOpen && !oldWidget.isSubEditorOpen) {
+      _rasterCache.clear();
     }
   }
 

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -661,10 +661,7 @@ class PaintEditorState extends State<PaintEditor>
   ///
   /// A cached paint-layer raster is rendered for scale 1; zoomed in, it would
   /// be upscaled, so the layer stack renders live while this holds.
-  bool get _isViewerZoomed {
-    final scale = interactiveViewer.currentState?.scaleFactor ?? 1.0;
-    return (scale - 1.0).abs() > 1e-6;
-  }
+  bool get _isViewerZoomed => interactiveViewer.currentState?.isZoomed ?? false;
 
   bool _wasViewerZoomed = false;
 

--- a/lib/features/paint_editor/paint_editor.dart
+++ b/lib/features/paint_editor/paint_editor.dart
@@ -650,7 +650,28 @@ class PaintEditorState extends State<PaintEditor>
   void _onPaintViewerMatrixChanged(Matrix4 value) {
     _paintCanvas.currentState?.cancelActiveDrawing();
     callbacks.paintEditorCallbacks?.onEditorZoomMatrix4Change?.call(value);
+    final isZoomed = _isViewerZoomed;
+    if (isZoomed != _wasViewerZoomed) {
+      _wasViewerZoomed = isZoomed;
+      _layerStackStream.add(null);
+    }
   }
+
+  /// Whether the viewer is zoomed away from its resting scale.
+  ///
+  /// A cached paint-layer raster is rendered for scale 1; zoomed in, it would
+  /// be upscaled, so the layer stack renders live while this holds.
+  bool get _isViewerZoomed {
+    final scale = interactiveViewer.currentState?.scaleFactor ?? 1.0;
+    return (scale - 1.0).abs() > 1e-6;
+  }
+
+  bool _wasViewerZoomed = false;
+
+  /// Whether a partial erase is in progress. The eraser mutates strokes on
+  /// every pointer move, so the layer stack renders live until it ends
+  /// instead of re-rendering a cached raster per move.
+  bool _isPartialErasing = false;
 
   /// Whether the gesture the viewer is currently reporting can move the view.
   bool _viewerGestureNavigates = false;
@@ -1117,6 +1138,8 @@ class PaintEditorState extends State<PaintEditor>
                           overlayColor: paintEditorConfigs.style.background,
                           clipBehavior: Clip.none,
                           enableLayerKey: true,
+                          suspendPaintLayerRasterCache:
+                              _isPartialErasing || _isViewerZoomed,
                         );
                       },
                     ),
@@ -1239,6 +1262,7 @@ class PaintEditorState extends State<PaintEditor>
         });
       },
       onRemovePartialStart: () {
+        _isPartialErasing = true;
         LayerCopyManager copyManager = LayerCopyManager();
 
         final updatedList = activeHistory.layers.map((layer) {
@@ -1259,6 +1283,8 @@ class PaintEditorState extends State<PaintEditor>
         WidgetsBinding.instance.drawFrame();
       },
       onRemovePartialEnd: (hasRemovedAreas) {
+        _isPartialErasing = false;
+        _layerStackStream.add(null);
         if (!hasRemovedAreas) {
           historyPointer--;
           stateHistory.removeLast();

--- a/lib/features/paint_editor/widgets/draw_paint_item.dart
+++ b/lib/features/paint_editor/widgets/draw_paint_item.dart
@@ -15,6 +15,7 @@ class DrawPaintItem extends CustomPainter {
     this.scale = 1,
     this.opacity = 1,
     this.enabledHitDetection = false,
+    this.skipPaint = false,
   });
 
   /// The model containing information about the painting.
@@ -33,6 +34,14 @@ class DrawPaintItem extends CustomPainter {
   /// The current erasing behavior applied by the tool.
   final PaintEditorConfigs paintEditorConfigs;
 
+  /// Whether [paint] draws nothing.
+  ///
+  /// Set while the item's pixels come from a cached raster (see
+  /// `MainEditorConfigs.enablePaintLayerRasterCache`). Hit-testing keeps
+  /// working on the real path, so the layer stays selectable and draggable;
+  /// only the per-frame stroking is skipped.
+  final bool skipPaint;
+
   /// Enables or disables hit detection.
   /// When `true`, allows detecting user interactions with the interface.
   bool enabledHitDetection = true;
@@ -50,6 +59,7 @@ class DrawPaintItem extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
+    if (skipPaint) return;
     PathBuilderBase.fromMode(
         item: item,
         scale: scale,
@@ -61,7 +71,9 @@ class DrawPaintItem extends CustomPainter {
 
   @override
   bool shouldRepaint(DrawPaintItem oldDelegate) {
-    return oldDelegate.item != item || oldDelegate.opacity != opacity;
+    return oldDelegate.item != item ||
+        oldDelegate.opacity != opacity ||
+        oldDelegate.skipPaint != skipPaint;
   }
 
   @override

--- a/lib/features/paint_editor/widgets/paint_canvas.dart
+++ b/lib/features/paint_editor/widgets/paint_canvas.dart
@@ -140,6 +140,11 @@ class PaintCanvasState extends State<PaintCanvas> {
 
   final Set<int> _navigationPointers = <int>{};
 
+  /// Whether a partial-erase session is open:
+  /// [PaintCanvas.onRemovePartialStart] has been reported and
+  /// [PaintCanvas.onRemovePartialEnd] has not.
+  bool _isPartialEraseActive = false;
+
   bool get _isPartialEraser => widget.eraserMode == EraserMode.partial;
   bool get _isFreeStyleMode =>
       _paintCtrl.mode == PaintMode.freeStyle ||
@@ -172,12 +177,25 @@ class PaintCanvasState extends State<PaintCanvas> {
   }
 
   void _discardActiveStroke() {
+    _endPartialErase();
     if (_paintCtrl.busy || _paintCtrl.start != null) {
       _paintCtrl
         ..setInProgress(false)
         ..reset();
       _activePaintStreamCtrl.add(null);
     }
+  }
+
+  /// Closes the partial-erase session, if one is open.
+  ///
+  /// Reported from the normal pointer-up as well as from every path that
+  /// discards a gesture — a second finger, a pointer cancel, a viewport
+  /// change — so the editor never waits for an end that is not coming. The
+  /// spots erased so far stay erased.
+  void _endPartialErase() {
+    if (!_isPartialEraseActive) return;
+    _isPartialEraseActive = false;
+    widget.onRemovePartialEnd(_hasPartialErasedAreas);
   }
 
   bool get _auxiliaryMousePansView =>
@@ -227,8 +245,13 @@ class PaintCanvasState extends State<PaintCanvas> {
       case PaintMode.moveAndZoom:
         return;
       case PaintMode.eraser:
-        _hasPartialErasedAreas = false;
-        widget.onRemovePartialStart();
+        // Only the partial eraser mutates strokes and needs the pre-erase
+        // copy; a full-stroke erase records its removals as it goes.
+        if (_isPartialEraser) {
+          _hasPartialErasedAreas = false;
+          _isPartialEraseActive = true;
+          widget.onRemovePartialStart();
+        }
         setState(() {});
         return;
       case PaintMode.polygon:
@@ -330,7 +353,7 @@ class PaintCanvasState extends State<PaintCanvas> {
     } else if (widget.paintCtrl.mode == PaintMode.eraser) {
       // Eraser mode doesn't create paintings - it only removes existing ones.
       // The removal is handled during pointer move via _processEraserInputAt.
-      if (_isPartialEraser) widget.onRemovePartialEnd(_hasPartialErasedAreas);
+      _endPartialErase();
       return;
     }
 

--- a/lib/shared/services/content_recorder/controllers/content_recorder_controller.dart
+++ b/lib/shared/services/content_recorder/controllers/content_recorder_controller.dart
@@ -68,6 +68,10 @@ class ContentRecorderController {
   /// A stream for sending widgets to the recorder for drawing.
   late final StreamController<Widget?> recorderStream;
 
+  /// The captures currently waiting for a frame in which every layer under
+  /// the recorder paints live. See [LiveLayerRequests].
+  final LiveLayerRequests liveLayerRequests = LiveLayerRequests();
+
   /// Ensures that the widget has completed rendering before proceeding.
   Completer<bool> recordReadyHelper = Completer();
 
@@ -104,6 +108,7 @@ class ContentRecorderController {
       recordReadyHelper.complete(true);
     }
 
+    liveLayerRequests.dispose();
     _threadManager.destroy();
   }
 
@@ -404,17 +409,37 @@ class ContentRecorderController {
   /// Retrieves the raw rendered dart ui image from the widget tree based on the
   /// provided `ImageInfos`. This method supports capturing images at
   /// different pixel ratios and optional thumbnail generation.
+  ///
+  /// When a layer host under the recorder draws paint layers from a raster
+  /// cache, the container is read only after a frame in which every layer
+  /// painted live: the cached image is rendered at the device pixel ratio,
+  /// and a capture at the output ratio would upscale it.
   Future<ui.Image?> getRawRenderedImage({
     required ImageInfos imageInfos,
     bool? useThumbnailSize,
     GlobalKey? widgetKey,
   }) async {
-    return _imageRenderService.getRawRenderedImage(
+    Future<ui.Image?> read() => _imageRenderService.getRawRenderedImage(
       imageInfos: imageInfos,
       containerKey: containerKey,
       widgetKey: widgetKey,
       useThumbnailSize: useThumbnailSize ?? enableThumbnailGeneration,
     );
+
+    // A widget handed to the invisible recorder holds no layer host.
+    if (widgetKey != null || !liveLayerRequests.hasHost) return read();
+
+    liveLayerRequests.value++;
+    try {
+      // The hosts rebuild for the next frame; `endOfFrame` completes once it
+      // has painted. `ensureVisualUpdate` schedules that frame even from a
+      // post-frame callback, where `endOfFrame` alone would not.
+      WidgetsBinding.instance.ensureVisualUpdate();
+      await WidgetsBinding.instance.endOfFrame;
+      return await read();
+    } finally {
+      liveLayerRequests.value--;
+    }
   }
 
   /// Adds a placeholder screenshot entry to the provided list of
@@ -446,5 +471,38 @@ class ContentRecorderController {
       pngFilter: _configs.pngFilter,
       pngLevel: _configs.pngLevel,
     );
+  }
+}
+
+/// Counts the captures waiting for a frame in which every layer paints live.
+///
+/// A host that draws paint layers from a raster cache (see
+/// `MainEditorConfigs.enablePaintLayerRasterCache`) listens to the recorder's
+/// instance and renders every layer live while the count is above zero. A
+/// capture only waits for that frame when such a host is listening, so an
+/// editor without the cache captures exactly as before.
+///
+/// The controller may be destroyed while a capture is still waiting for its
+/// frame; the counter then just stops reporting.
+class LiveLayerRequests extends ValueNotifier<int> {
+  /// Creates the counter at zero.
+  LiveLayerRequests() : super(0);
+
+  bool _isDisposed = false;
+
+  /// Whether a raster-cache host is listening for requests.
+  bool get hasHost => !_isDisposed && hasListeners;
+
+  @override
+  set value(int newValue) {
+    if (_isDisposed) return;
+    super.value = newValue;
+  }
+
+  @override
+  void dispose() {
+    if (_isDisposed) return;
+    _isDisposed = true;
+    super.dispose();
   }
 }

--- a/lib/shared/services/content_recorder/widgets/content_recorder.dart
+++ b/lib/shared/services/content_recorder/widgets/content_recorder.dart
@@ -32,6 +32,18 @@ class ContentRecorder extends StatefulWidget {
   /// The [ContentRecorderController] instance used for recording.
   final ContentRecorderController controller;
 
+  /// The controller of the nearest [ContentRecorder] above [context], or
+  /// `null` when the subtree is not recorded.
+  ///
+  /// A widget whose paint a capture depends on — a layer host drawing from
+  /// a raster cache — uses it to hear when the recorder is about to read the
+  /// tree (see [ContentRecorderController.liveLayerRequests]).
+  static ContentRecorderController? maybeControllerOf(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<_ContentRecorderScope>()
+        ?.controller;
+  }
+
   @override
   State<ContentRecorder> createState() => ContentRecorderState();
 }
@@ -54,9 +66,22 @@ class ContentRecorderState extends State<ContentRecorder> {
 
   @override
   Widget build(BuildContext context) {
-    return ExtendedRepaintBoundary(
-      key: _controller.containerKey,
-      child: widget.child,
+    return _ContentRecorderScope(
+      controller: _controller,
+      child: ExtendedRepaintBoundary(
+        key: _controller.containerKey,
+        child: widget.child,
+      ),
     );
   }
+}
+
+class _ContentRecorderScope extends InheritedWidget {
+  const _ContentRecorderScope({required this.controller, required super.child});
+
+  final ContentRecorderController controller;
+
+  @override
+  bool updateShouldNotify(_ContentRecorderScope oldWidget) =>
+      controller != oldWidget.controller;
 }

--- a/lib/shared/widgets/extended/interactive_viewer/extended_interactive_viewer.dart
+++ b/lib/shared/widgets/extended/interactive_viewer/extended_interactive_viewer.dart
@@ -302,6 +302,9 @@ class ExtendedInteractiveViewerState extends State<ExtendedInteractiveViewer>
     return _transformCtrl.value.getMaxScaleOnAxis();
   }
 
+  /// Whether the view is zoomed away from its resting scale of 1.
+  bool get isZoomed => (scaleFactor - 1.0).abs() > 1e-6;
+
   /// The current translation offset applied to the transformation.
   /// Returns an [Offset] representing the translation values on the x and y
   /// axes.

--- a/lib/shared/widgets/layer/layer_stack.dart
+++ b/lib/shared/widgets/layer/layer_stack.dart
@@ -1,3 +1,6 @@
+// Dart imports:
+import 'dart:ui' as ui;
+
 // Flutter imports:
 import 'package:material_ui/material_ui.dart';
 
@@ -6,6 +9,7 @@ import '/core/models/layers/layer.dart';
 import '/core/models/transform_helper.dart';
 import '/features/crop_rotate_editor/enums/crop_mode.enum.dart';
 import '/features/crop_rotate_editor/widgets/crop_layer_painter.dart';
+import '/features/main_editor/services/paint_layer_raster_cache.dart';
 import 'layer_widget.dart';
 
 /// A stateful widget that represents a stack of layers in an image editing
@@ -14,7 +18,7 @@ import 'layer_widget.dart';
 /// This widget manages the display and transformation of multiple layers,
 /// allowing for complex image editing operations such as cropping, rotating,
 /// and layering effects.
-class LayerStack extends StatelessWidget {
+class LayerStack extends StatefulWidget {
   /// Creates a [LayerStack].
   ///
   /// This widget is responsible for rendering a collection of layers within a
@@ -43,6 +47,7 @@ class LayerStack extends StatelessWidget {
       mainImageSize: Size.zero,
     ),
     this.clipBehavior = Clip.hardEdge,
+    this.suspendPaintLayerRasterCache = false,
   });
 
   /// The outside overlay color for layers.
@@ -84,35 +89,66 @@ class LayerStack extends StatelessWidget {
   /// disabled.
   final bool enableLayerKey;
 
+  /// Forces every paint layer to render live even when
+  /// [MainEditorConfigs.enablePaintLayerRasterCache] is on.
+  ///
+  /// Sub-editors set this while a layer is changing continuously — the paint
+  /// editor's partial eraser mutates strokes on every pointer move — and while
+  /// the editor is zoomed, where a cached image would be upscaled.
+  final bool suspendPaintLayerRasterCache;
+
+  @override
+  State<LayerStack> createState() => _LayerStackState();
+}
+
+class _LayerStackState extends State<LayerStack> {
+  /// The raster cache, or `null` when the feature is off.
+  late final PaintLayerRasterCache? _rasterCache =
+      widget.configs.mainEditor.enablePaintLayerRasterCache
+      ? PaintLayerRasterCache()
+      : null;
+
+  @override
+  void initState() {
+    super.initState();
+    _rasterCache?.addListener(_onRasterCacheChanged);
+  }
+
+  @override
+  void dispose() {
+    _rasterCache?.removeListener(_onRasterCacheChanged);
+    _rasterCache?.dispose();
+    super.dispose();
+  }
+
+  void _onRasterCacheChanged() {
+    if (mounted) setState(() {});
+  }
+
   bool get _cutOutsideImageArea =>
-      cutOutsideImageArea ?? configs.imageGeneration.cropToImageBounds;
+      widget.cutOutsideImageArea ??
+      widget.configs.imageGeneration.cropToImageBounds;
 
   TransformConfigs? get _transformConfigs =>
-      transformHelper.transformConfigs?.isNotEmpty == true
-      ? transformHelper.transformConfigs
+      widget.transformHelper.transformConfigs?.isNotEmpty == true
+      ? widget.transformHelper.transformConfigs
       : null;
+
   @override
   Widget build(BuildContext context) {
     return IgnorePointer(
       child: Stack(
         children: [
           Transform.scale(
-            scale: transformHelper.scale,
+            scale: widget.transformHelper.scale,
             child: Stack(
               fit: StackFit.expand,
               alignment: Alignment.center,
-              clipBehavior: clipBehavior,
-              children: layers.map((layerItem) {
-                return LayerWidget(
-                  key: enableLayerKey ? layerItem.key : null,
-                  layer: layerItem,
-                  configs: configs,
-                  editorBodySize: transformHelper.editorBodySize,
-                );
-              }).toList(),
+              clipBehavior: widget.clipBehavior,
+              children: _buildLayerChildren(context),
             ),
           ),
-          if (configs.imageGeneration.cropToImageBounds)
+          if (widget.configs.imageGeneration.cropToImageBounds)
             RepaintBoundary(
               child: Hero(
                 tag: 'crop_layer_painter_hero',
@@ -129,21 +165,127 @@ class LayerStack extends StatelessWidget {
     );
   }
 
+  /// The stack children: every layer widget in z-order, with each cached run
+  /// preceded by its image and its members told to skip their own paint.
+  ///
+  /// The stack sits under a `Transform.scale`, so the images are rendered at
+  /// the device pixel ratio times that scale to stay one raster pixel per
+  /// device pixel.
+  List<Widget> _buildLayerChildren(BuildContext context) {
+    final cache = _rasterCache;
+    final layers = widget.layers;
+    if (cache == null || widget.suspendPaintLayerRasterCache) {
+      return [for (final layer in layers) _buildLayerWidget(layer)];
+    }
+
+    final paintEditorConfigs = widget.configs.paintEditor;
+    final editorBodySize = widget.transformHelper.editorBodySize;
+    final pixelRatio =
+        MediaQuery.devicePixelRatioOf(context) * widget.transformHelper.scale;
+    final plan = cache.plan(
+      layers: layers,
+      excludedIds: const {},
+      playTime: null,
+      editorBodySize: editorBodySize,
+      fractionalOffset: paintEditorConfigs.layerFractionalOffset,
+      pixelRatio: pixelRatio,
+      paintEditorConfigs: paintEditorConfigs,
+    );
+
+    final imagesByInsertIndex = <int, Widget>{};
+    final cachedIds = <String>{};
+    for (final run in plan.runs) {
+      cache.ensure(
+        run,
+        editorBodySize: editorBodySize,
+        fractionalOffset: paintEditorConfigs.layerFractionalOffset,
+        pixelRatio: pixelRatio,
+        paintEditorConfigs: paintEditorConfigs,
+      );
+      final image = cache.imageFor(run);
+      if (image == null) continue;
+      imagesByInsertIndex[run.insertIndex] = PaintRunImage(
+        key: ValueKey<String>(run.key),
+        image: image,
+        bounds: run.bounds,
+      );
+      cachedIds.addAll(run.layerIds);
+    }
+
+    return [
+      for (var i = 0; i < layers.length; i++) ...[
+        ?imagesByInsertIndex[i],
+        _buildLayerWidget(
+          layers[i],
+          isRasterCached: cachedIds.contains(layers[i].id),
+        ),
+      ],
+    ];
+  }
+
+  Widget _buildLayerWidget(Layer layer, {bool isRasterCached = false}) {
+    return LayerWidget(
+      key: widget.enableLayerKey ? layer.key : null,
+      layer: layer,
+      configs: widget.configs,
+      editorBodySize: widget.transformHelper.editorBodySize,
+      isRasterCached: isRasterCached,
+    );
+  }
+
   CustomPainter _buildCropPainter() {
     final imgRatio =
         _transformConfigs?.cropRect.size.aspectRatio ??
-        configs.cropRotateEditor.initialOvalCropAspectRatio ??
-        transformHelper.mainImageSize.aspectRatio;
+        widget.configs.cropRotateEditor.initialOvalCropAspectRatio ??
+        widget.transformHelper.mainImageSize.aspectRatio;
     final isRoundCropper =
         _transformConfigs?.isOvalCropper ??
-        configs.cropRotateEditor.initialCropMode == CropMode.oval;
+        widget.configs.cropRotateEditor.initialCropMode == CropMode.oval;
 
     return CropLayerPainter(
-      opacity: configs.mainEditor.style.outsideCaptureAreaLayerOpacity,
-      backgroundColor: overlayColor,
+      opacity: widget.configs.mainEditor.style.outsideCaptureAreaLayerOpacity,
+      backgroundColor: widget.overlayColor,
       imgRatio: imgRatio,
       isRoundCropper: isRoundCropper,
       is90DegRotated: _transformConfigs?.is90DegRotated ?? false,
+    );
+  }
+}
+
+/// One run's cached image, placed where its bottom-most member paints.
+///
+/// Pointer events pass through: the members' own widgets stay mounted and
+/// keep hit-testing the real strokes.
+class PaintRunImage extends StatelessWidget {
+  /// Creates the image widget for a cached run.
+  const PaintRunImage({super.key, required this.image, required this.bounds});
+
+  /// The rendered run.
+  final ui.Image image;
+
+  /// Where the run paints, in editor body coordinates.
+  final Rect bounds;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: bounds.left,
+      top: bounds.top,
+      width: bounds.width,
+      height: bounds.height,
+      child: IgnorePointer(
+        // The image is rendered at exactly the device pixel ratio, so at an
+        // integral ratio this is a 1:1 blit; bilinear filtering only matters
+        // on fractional ratios, where nearest-neighbour would shift edges by
+        // a pixel.
+        child: RawImage(
+          image: image,
+          width: bounds.width,
+          height: bounds.height,
+          fit: BoxFit.fill,
+          filterQuality: FilterQuality.low,
+        ),
+      ),
     );
   }
 }

--- a/lib/shared/widgets/layer/layer_stack.dart
+++ b/lib/shared/widgets/layer/layer_stack.dart
@@ -1,6 +1,3 @@
-// Dart imports:
-import 'dart:ui' as ui;
-
 // Flutter imports:
 import 'package:material_ui/material_ui.dart';
 
@@ -9,8 +6,8 @@ import '/core/models/layers/layer.dart';
 import '/core/models/transform_helper.dart';
 import '/features/crop_rotate_editor/enums/crop_mode.enum.dart';
 import '/features/crop_rotate_editor/widgets/crop_layer_painter.dart';
-import '/features/main_editor/services/paint_layer_raster_cache.dart';
 import 'layer_widget.dart';
+import 'paint_layer_raster_cache_host.dart';
 
 /// A stateful widget that represents a stack of layers in an image editing
 /// application.
@@ -93,37 +90,21 @@ class LayerStack extends StatefulWidget {
   /// [MainEditorConfigs.enablePaintLayerRasterCache] is on.
   ///
   /// Sub-editors set this while a layer is changing continuously — the paint
-  /// editor's partial eraser mutates strokes on every pointer move — and while
-  /// the editor is zoomed, where a cached image would be upscaled.
+  /// editor's partial eraser mutates strokes on every pointer move — and
+  /// while the stack is drawn under a scale the cache does not know about,
+  /// such as the paint editor's zoom or the crop editor's animated
+  /// transforms, where a cached image would be resampled. Captures and route
+  /// transitions are handled by the stack itself.
   final bool suspendPaintLayerRasterCache;
 
   @override
   State<LayerStack> createState() => _LayerStackState();
 }
 
-class _LayerStackState extends State<LayerStack> {
-  /// The raster cache, or `null` when the feature is off.
-  late final PaintLayerRasterCache? _rasterCache =
-      widget.configs.mainEditor.enablePaintLayerRasterCache
-      ? PaintLayerRasterCache()
-      : null;
-
+class _LayerStackState extends State<LayerStack>
+    with PaintLayerRasterCacheHost {
   @override
-  void initState() {
-    super.initState();
-    _rasterCache?.addListener(_onRasterCacheChanged);
-  }
-
-  @override
-  void dispose() {
-    _rasterCache?.removeListener(_onRasterCacheChanged);
-    _rasterCache?.dispose();
-    super.dispose();
-  }
-
-  void _onRasterCacheChanged() {
-    if (mounted) setState(() {});
-  }
+  ProImageEditorConfigs get configs => widget.configs;
 
   bool get _cutOutsideImageArea =>
       widget.cutOutsideImageArea ??
@@ -165,62 +146,20 @@ class _LayerStackState extends State<LayerStack> {
     );
   }
 
-  /// The stack children: every layer widget in z-order, with each cached run
-  /// preceded by its image and its members told to skip their own paint.
+  /// The stack children, with static paint layers drawn from the cache.
   ///
   /// The stack sits under a `Transform.scale`, so the images are rendered at
   /// the device pixel ratio times that scale to stay one raster pixel per
   /// device pixel.
   List<Widget> _buildLayerChildren(BuildContext context) {
-    final cache = _rasterCache;
-    final layers = widget.layers;
-    if (cache == null || widget.suspendPaintLayerRasterCache) {
-      return [for (final layer in layers) _buildLayerWidget(layer)];
-    }
-
-    final paintEditorConfigs = widget.configs.paintEditor;
-    final editorBodySize = widget.transformHelper.editorBodySize;
-    final pixelRatio =
-        MediaQuery.devicePixelRatioOf(context) * widget.transformHelper.scale;
-    final plan = cache.plan(
-      layers: layers,
-      excludedIds: const {},
-      playTime: null,
-      editorBodySize: editorBodySize,
-      fractionalOffset: paintEditorConfigs.layerFractionalOffset,
-      pixelRatio: pixelRatio,
-      paintEditorConfigs: paintEditorConfigs,
+    return buildRasterCachedLayers(
+      layers: widget.layers,
+      editorBodySize: widget.transformHelper.editorBodySize,
+      pixelRatio:
+          MediaQuery.devicePixelRatioOf(context) * widget.transformHelper.scale,
+      suspend: widget.suspendPaintLayerRasterCache,
+      buildLayer: _buildLayerWidget,
     );
-
-    final imagesByInsertIndex = <int, Widget>{};
-    final cachedIds = <String>{};
-    for (final run in plan.runs) {
-      cache.ensure(
-        run,
-        editorBodySize: editorBodySize,
-        fractionalOffset: paintEditorConfigs.layerFractionalOffset,
-        pixelRatio: pixelRatio,
-        paintEditorConfigs: paintEditorConfigs,
-      );
-      final image = cache.imageFor(run);
-      if (image == null) continue;
-      imagesByInsertIndex[run.insertIndex] = PaintRunImage(
-        key: ValueKey<String>(run.key),
-        image: image,
-        bounds: run.bounds,
-      );
-      cachedIds.addAll(run.layerIds);
-    }
-
-    return [
-      for (var i = 0; i < layers.length; i++) ...[
-        ?imagesByInsertIndex[i],
-        _buildLayerWidget(
-          layers[i],
-          isRasterCached: cachedIds.contains(layers[i].id),
-        ),
-      ],
-    ];
   }
 
   Widget _buildLayerWidget(Layer layer, {bool isRasterCached = false}) {
@@ -248,44 +187,6 @@ class _LayerStackState extends State<LayerStack> {
       imgRatio: imgRatio,
       isRoundCropper: isRoundCropper,
       is90DegRotated: _transformConfigs?.is90DegRotated ?? false,
-    );
-  }
-}
-
-/// One run's cached image, placed where its bottom-most member paints.
-///
-/// Pointer events pass through: the members' own widgets stay mounted and
-/// keep hit-testing the real strokes.
-class PaintRunImage extends StatelessWidget {
-  /// Creates the image widget for a cached run.
-  const PaintRunImage({super.key, required this.image, required this.bounds});
-
-  /// The rendered run.
-  final ui.Image image;
-
-  /// Where the run paints, in editor body coordinates.
-  final Rect bounds;
-
-  @override
-  Widget build(BuildContext context) {
-    return Positioned(
-      left: bounds.left,
-      top: bounds.top,
-      width: bounds.width,
-      height: bounds.height,
-      child: IgnorePointer(
-        // The image is rendered at exactly the device pixel ratio, so at an
-        // integral ratio this is a 1:1 blit; bilinear filtering only matters
-        // on fractional ratios, where nearest-neighbour would shift edges by
-        // a pixel.
-        child: RawImage(
-          image: image,
-          width: bounds.width,
-          height: bounds.height,
-          fit: BoxFit.fill,
-          filterQuality: FilterQuality.low,
-        ),
-      ),
     );
   }
 }

--- a/lib/shared/widgets/layer/layer_widget.dart
+++ b/lib/shared/widgets/layer/layer_widget.dart
@@ -16,6 +16,7 @@ import '/core/models/layers/layer.dart';
 import '/core/services/gesture_manager.dart';
 import '/features/main_editor/services/layer_interaction_manager.dart';
 import '/features/main_editor/services/main_editor_layers_service.dart';
+import '/features/main_editor/services/paint_layer_raster_cache.dart';
 import '/features/paint_editor/enums/paint_editor_enum.dart';
 import '/shared/widgets/layer/enums/layer_widget_type_enum.dart';
 import '/shared/widgets/layer/services/layer_widget_context_menu.dart';
@@ -25,6 +26,7 @@ import '/shared/widgets/layer/widgets/layer_widget_paint_item.dart';
 import '/shared/widgets/layer/widgets/layer_widget_text_item.dart';
 import 'interaction_helper/layer_interaction_helper_widget.dart';
 import 'layer_timeline_visibility.dart';
+import 'widgets/layer_repaint_boundary.dart';
 import 'widgets/layer_widget_custom_item.dart';
 
 /// A widget representing a layer within a design canvas.
@@ -569,6 +571,18 @@ class _LayerContentItem extends StatelessWidget {
       );
     }
 
-    return RepaintBoundary(key: layer.repaintBoundaryKey, child: content);
+    return LayerRepaintBoundary(
+      key: layer.repaintBoundaryKey,
+      // The painters draw nothing while the strokes come from the raster
+      // cache, so a capture has to render them from the model instead.
+      renderContent: skipPaint
+          ? (pixelRatio) => PaintLayerRasterCache.renderLayerContent(
+              layer as PaintLayer,
+              pixelRatio: pixelRatio,
+              paintEditorConfigs: paintEditorConfigs,
+            )
+          : null,
+      child: content,
+    );
   }
 }

--- a/lib/shared/widgets/layer/layer_widget.dart
+++ b/lib/shared/widgets/layer/layer_widget.dart
@@ -43,6 +43,7 @@ class LayerWidget extends StatefulWidget with SimpleConfigsAccess {
     this.enableMouseCursor = true,
     this.callbacks = const ProImageEditorCallbacks(),
     this.playTimeNotifier,
+    this.isRasterCached = false,
   });
   @override
   final ProImageEditorConfigs configs;
@@ -81,6 +82,14 @@ class LayerWidget extends StatefulWidget with SimpleConfigsAccess {
   /// When non-null and the layer has [Layer.startTime] / [Layer.endTime],
   /// the layer is animated in/out based on the current time.
   final ValueNotifier<Duration>? playTimeNotifier;
+
+  /// Whether this paint layer's pixels currently come from the shared raster
+  /// cache, so its own painter must draw nothing.
+  ///
+  /// Everything else — hit-testing, selection, the interaction overlay, the
+  /// repaint-boundary key — stays live. Only meaningful for paint layers; other
+  /// layer types ignore it.
+  final bool isRasterCached;
 
   @override
   State<LayerWidget> createState() => _LayerWidgetState();
@@ -413,6 +422,7 @@ class _LayerWidgetState extends State<LayerWidget>
                       layerType: _layerType,
                       layer: _layer,
                       isSelected: _isSelected,
+                      skipPaint: widget.isRasterCached,
                       enableHitDetection:
                           _layerInteractionManager?.enabledHitDetection ??
                           false,
@@ -488,6 +498,7 @@ class _LayerContentItem extends StatelessWidget {
     required this.layer,
     required this.isSelected,
     required this.enableHitDetection,
+    this.skipPaint = false,
     required this.showMoveCursor,
     required this.onHitChanged,
     required this.emojiEditorConfigs,
@@ -501,6 +512,7 @@ class _LayerContentItem extends StatelessWidget {
   final Layer layer;
   final bool isSelected;
   final bool enableHitDetection;
+  final bool skipPaint;
   final ValueNotifier<bool> showMoveCursor;
   final ValueChanged<bool> onHitChanged;
   final EmojiEditorConfigs emojiEditorConfigs;
@@ -537,6 +549,7 @@ class _LayerContentItem extends StatelessWidget {
           layer: layer as PaintLayer,
           isSelected: isSelected,
           enableHitDetection: enableHitDetection,
+          skipPaint: skipPaint,
           onHitChanged: onHitChanged,
           paintEditorConfigs: paintEditorConfigs,
         );

--- a/lib/shared/widgets/layer/paint_layer_raster_cache_host.dart
+++ b/lib/shared/widgets/layer/paint_layer_raster_cache_host.dart
@@ -1,0 +1,119 @@
+// Flutter imports:
+import 'package:material_ui/material_ui.dart';
+
+import '/core/models/editor_configs/pro_image_editor_configs.dart';
+import '/core/models/layers/layer.dart';
+import '/features/main_editor/services/paint_layer_raster_cache.dart';
+import '/shared/services/content_recorder/controllers/content_recorder_controller.dart';
+import '/shared/services/content_recorder/widgets/content_recorder.dart';
+
+/// Lets the state of a widget that stacks `LayerWidget`s draw its static paint
+/// layers from a [PaintLayerRasterCache].
+///
+/// The mixin owns the cache (when
+/// [MainEditorConfigs.enablePaintLayerRasterCache] is on), rebuilds the host
+/// once an image lands, and knows the two moments every host has to step
+/// aside in:
+///
+/// * while the enclosing [ContentRecorder] reads the tree — a cached image
+///   is rendered at the device pixel ratio and would be upscaled into the
+///   capture, and a cached layer's own repaint boundary is blank;
+/// * while the route the host sits on is animating — hero shuttles fly in
+///   the overlay while their destination widgets are hidden, so the image
+///   would show the strokes a second time at their final spot.
+///
+/// A host adds its own conditions through the `suspend` argument of
+/// [buildRasterCachedLayers].
+mixin PaintLayerRasterCacheHost<T extends StatefulWidget> on State<T> {
+  /// The editor configuration the layers are built with.
+  ProImageEditorConfigs get configs;
+
+  PaintLayerRasterCache? _rasterCache;
+  LiveLayerRequests? _liveLayerRequests;
+  Animation<double>? _routeAnimation;
+
+  /// The cache, or `null` when the feature is off.
+  PaintLayerRasterCache? get rasterCache => _rasterCache;
+
+  /// Whether the cache has to stay out of this build because a capture is
+  /// reading the tree or the route is animating.
+  bool get isRasterCacheSuspended =>
+      (_liveLayerRequests?.value ?? 0) > 0 ||
+      (_routeAnimation?.isAnimating ?? false);
+
+  @override
+  void initState() {
+    super.initState();
+    if (configs.mainEditor.enablePaintLayerRasterCache) {
+      _rasterCache = PaintLayerRasterCache()..addListener(_rebuild);
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_rasterCache == null) return;
+
+    final requests = ContentRecorder.maybeControllerOf(
+      context,
+    )?.liveLayerRequests;
+    if (!identical(requests, _liveLayerRequests)) {
+      _liveLayerRequests?.removeListener(_rebuild);
+      _liveLayerRequests = requests?..addListener(_rebuild);
+    }
+
+    final animation = ModalRoute.of(context)?.animation;
+    if (!identical(animation, _routeAnimation)) {
+      _routeAnimation?.removeStatusListener(_onRouteStatusChanged);
+      _routeAnimation = animation?..addStatusListener(_onRouteStatusChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    _liveLayerRequests?.removeListener(_rebuild);
+    _routeAnimation?.removeStatusListener(_onRouteStatusChanged);
+    _rasterCache?.dispose();
+    super.dispose();
+  }
+
+  void _rebuild() {
+    if (mounted) setState(() {});
+  }
+
+  void _onRouteStatusChanged(AnimationStatus status) => _rebuild();
+
+  /// The stack children for this build: every layer of [layers] in z-order
+  /// through [buildLayer], with each cached run preceded by its image.
+  ///
+  /// Everything renders live when the feature is off, when [suspend] holds
+  /// or while [isRasterCacheSuspended]. [excludedIds] are layers the host
+  /// wants live regardless, [playTime] the video position for timeline
+  /// layers, [pixelRatio] the ratio the images are rendered at.
+  List<Widget> buildRasterCachedLayers({
+    required List<Layer> layers,
+    required Size editorBodySize,
+    required double pixelRatio,
+    required Widget Function(Layer layer, {required bool isRasterCached})
+    buildLayer,
+    Set<String> excludedIds = const {},
+    Duration? playTime,
+    bool suspend = false,
+  }) {
+    final cache = _rasterCache;
+    if (cache == null || suspend || isRasterCacheSuspended) {
+      return [
+        for (final layer in layers) buildLayer(layer, isRasterCached: false),
+      ];
+    }
+    return cache.buildChildren(
+      layers: layers,
+      excludedIds: excludedIds,
+      playTime: playTime,
+      editorBodySize: editorBodySize,
+      pixelRatio: pixelRatio,
+      configs: configs,
+      buildLayer: buildLayer,
+    );
+  }
+}

--- a/lib/shared/widgets/layer/widgets/layer_repaint_boundary.dart
+++ b/lib/shared/widgets/layer/widgets/layer_repaint_boundary.dart
@@ -1,0 +1,28 @@
+// Dart imports:
+import 'dart:ui' as ui;
+
+// Flutter imports:
+import 'package:flutter/widgets.dart';
+
+/// Renders a layer's untransformed content at [pixelRatio].
+typedef LayerContentRenderer = Future<ui.Image> Function(double pixelRatio);
+
+/// The repaint boundary a layer's content paints into — what
+/// `Layer.captureAsPng` reads through `Layer.repaintBoundaryKey`.
+///
+/// While a paint layer is drawn from the shared raster cache its painter
+/// draws nothing here, so a capture of the boundary would be blank;
+/// [renderContent] then supplies the pixels from the layer's model instead.
+/// It is `null` whenever the boundary holds the real paint.
+class LayerRepaintBoundary extends RepaintBoundary {
+  /// Creates the boundary for a layer's content.
+  const LayerRepaintBoundary({
+    super.key,
+    required Widget super.child,
+    this.renderContent,
+  });
+
+  /// Renders the content a capture should read while the boundary itself
+  /// paints nothing, or `null` when the boundary is what to capture.
+  final LayerContentRenderer? renderContent;
+}

--- a/lib/shared/widgets/layer/widgets/layer_widget_paint_item.dart
+++ b/lib/shared/widgets/layer/widgets/layer_widget_paint_item.dart
@@ -15,6 +15,7 @@ class LayerWidgetPaintItem extends StatelessWidget {
     this.isSelected = false,
     this.enableHitDetection = false,
     this.willChange = false,
+    this.skipPaint = false,
     this.onHitChanged,
     required this.paintEditorConfigs,
   });
@@ -32,6 +33,10 @@ class LayerWidgetPaintItem extends StatelessWidget {
 
   /// Whether hit detection is enabled for this layer.
   final bool enableHitDetection;
+
+  /// Whether the strokes are painted by a cached raster elsewhere, so the
+  /// painters here only serve hit-testing. See [DrawPaintItem.skipPaint].
+  final bool skipPaint;
 
   /// Configuration settings for the paint editor.
   final PaintEditorConfigs paintEditorConfigs;
@@ -88,6 +93,7 @@ class LayerWidgetPaintItem extends StatelessWidget {
         item: item,
         scale: layer.scale,
         opacity: canBakeOpacity ? opacity : 1.0,
+        skipPaint: skipPaint,
         selected: isSelected,
         enabledHitDetection: enableHitDetection,
         onHitChanged: onHitChanged,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pro_image_editor
 description: "A Flutter image editor: Seamlessly enhance your images with user-friendly editing features."
-version: 14.1.1
+version: 14.2.0
 homepage: https://github.com/hm21/pro_image_editor/
 repository: https://github.com/hm21/pro_image_editor/
 documentation: https://github.com/hm21/pro_image_editor/

--- a/test/features/main_editor/paint_layer_raster_cache_editor_test.dart
+++ b/test/features/main_editor/paint_layer_raster_cache_editor_test.dart
@@ -131,15 +131,17 @@ void main() {
 
     // Opening a sub-editor flips this flag and rebuilds; the layers render
     // live for the hero flight either way, so the images are dead weight.
-    state.isSubEditorOpen = true;
-    state.setState(() {});
+    state
+      ..isSubEditorOpen = true
+      ..setState(() {});
     await tester.pump();
     expect(cachedByLayer(tester).values, [false, false]);
 
     // Back in the main editor the run has to be rendered anew — its image
     // was released, not merely bypassed — and then takes over again.
-    state.isSubEditorOpen = false;
-    state.setState(() {});
+    state
+      ..isSubEditorOpen = false
+      ..setState(() {});
     await tester.pump();
     expect(cachedByLayer(tester).values, [false, false]);
     await pumpUntil(tester, () => allCached(tester));

--- a/test/features/main_editor/paint_layer_raster_cache_editor_test.dart
+++ b/test/features/main_editor/paint_layer_raster_cache_editor_test.dart
@@ -122,6 +122,30 @@ void main() {
     expect(cachedByLayer(tester).values, [true, true]);
   });
 
+  testWidgets('drops its images while a sub-editor is open', (tester) async {
+    final state = await pumpEditor(tester);
+    await addAndCache(tester, state, [
+      buildPaintLayer(const Offset(-40, 0)),
+      buildPaintLayer(const Offset(40, 0)),
+    ]);
+
+    // Opening a sub-editor flips this flag and rebuilds; the layers render
+    // live for the hero flight either way, so the images are dead weight.
+    state.isSubEditorOpen = true;
+    state.setState(() {});
+    await tester.pump();
+    expect(cachedByLayer(tester).values, [false, false]);
+
+    // Back in the main editor the run has to be rendered anew — its image
+    // was released, not merely bypassed — and then takes over again.
+    state.isSubEditorOpen = false;
+    state.setState(() {});
+    await tester.pump();
+    expect(cachedByLayer(tester).values, [false, false]);
+    await pumpUntil(tester, () => allCached(tester));
+    expect(cachedByLayer(tester).values, [true, true]);
+  });
+
   testWidgets('a selected layer renders live while the rest stay cached', (
     tester,
   ) async {

--- a/test/features/main_editor/paint_layer_raster_cache_editor_test.dart
+++ b/test/features/main_editor/paint_layer_raster_cache_editor_test.dart
@@ -1,0 +1,192 @@
+// Dart imports:
+import 'dart:ui' show ImageByteFormat;
+
+import 'package:flutter/services.dart';
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+// Flutter imports:
+import 'package:material_ui/material_ui.dart';
+// Project imports:
+import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_image_editor/shared/widgets/layer/layer_widget.dart';
+
+import '../../mock/mock_image.dart';
+
+void main() {
+  const configs = ProImageEditorConfigs(
+    progressIndicatorConfigs: ProgressIndicatorConfigs(
+      widgets: ProgressIndicatorWidgets(
+        circularProgressIndicator: SizedBox.shrink(),
+      ),
+    ),
+    imageGeneration: ImageGenerationConfigs(
+      enableIsolateGeneration: false,
+      enableBackgroundGeneration: false,
+    ),
+    mainEditor: MainEditorConfigs(enablePaintLayerRasterCache: true),
+  );
+
+  PaintLayer buildPaintLayer(Offset offset) {
+    return PaintLayer(
+      item: PaintedModel(
+        mode: PaintMode.freeStyle,
+        offsets: const [Offset(0, 0), Offset(10, 20), Offset(20, 5)],
+        erasedOffsets: const [],
+        color: Colors.red,
+        strokeWidth: 4,
+        opacity: 1,
+      ),
+      rawSize: const Size(20, 20),
+      opacity: 1,
+      offset: offset,
+    );
+  }
+
+  Future<ProImageEditorState> pumpEditor(WidgetTester tester) async {
+    final key = GlobalKey<ProImageEditorState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ProImageEditor.memory(
+          mockMemoryImage,
+          key: key,
+          configs: configs,
+          callbacks: ProImageEditorCallbacks(
+            onImageEditingComplete: (Uint8List bytes) async {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return key.currentState!;
+  }
+
+  /// Whether each mounted layer currently draws from the cache, by layer id.
+  Map<String, bool> cachedByLayer(WidgetTester tester) => {
+    for (final widget in tester.widgetList<LayerWidget>(
+      find.byType(LayerWidget),
+    ))
+      widget.layer.id: widget.isRasterCached,
+  };
+
+  /// Pumps until [done] holds, driving the real event loop so the cache's
+  /// raster callback — genuine engine work — can complete.
+  Future<void> pumpUntil(WidgetTester tester, bool Function() done) async {
+    await tester.runAsync(() async {
+      for (var i = 0; i < 100 && !done(); i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await tester.pump();
+      }
+    });
+    await tester.pump();
+  }
+
+  bool allCached(WidgetTester tester) {
+    final cached = cachedByLayer(tester);
+    return cached.isNotEmpty && cached.values.every((value) => value);
+  }
+
+  /// Adds [layers] without selecting them and waits until the cache draws
+  /// them.
+  Future<void> addAndCache(
+    WidgetTester tester,
+    ProImageEditorState state,
+    List<Layer> layers,
+  ) async {
+    for (final layer in layers) {
+      state.addLayer(
+        layer,
+        blockSelectLayer: true,
+        autoCorrectZoomOffset: false,
+        autoCorrectZoomScale: false,
+      );
+    }
+    state.layerInteractionManager.clearSelectedLayers();
+    state.setState(() {});
+    await tester.pump();
+    await pumpUntil(tester, () => allCached(tester));
+  }
+
+  testWidgets('draws static paint layers from one cached image', (
+    tester,
+  ) async {
+    final state = await pumpEditor(tester);
+    final rawImagesBefore = find.byType(RawImage).evaluate().length;
+    await addAndCache(tester, state, [
+      buildPaintLayer(const Offset(-40, 0)),
+      buildPaintLayer(const Offset(40, 0)),
+    ]);
+
+    // One image for the run, on top of whatever the editor drew before.
+    expect(find.byType(RawImage).evaluate().length, rawImagesBefore + 1);
+    // Both layers are still mounted for hit-testing but paint nothing.
+    expect(cachedByLayer(tester).values, [true, true]);
+  });
+
+  testWidgets('a selected layer renders live while the rest stay cached', (
+    tester,
+  ) async {
+    final state = await pumpEditor(tester);
+    final a = buildPaintLayer(const Offset(-40, 0));
+    final b = buildPaintLayer(const Offset(40, 0));
+    await addAndCache(tester, state, [a, b]);
+
+    state.layerInteractionManager.addSelectedLayer(b.id);
+    state.setState(() {});
+    await tester.pump();
+
+    // The image for the remaining run (just `a`) has to be rendered anew;
+    // until then `a` is live as well, so wait for it.
+    await pumpUntil(tester, () => cachedByLayer(tester)[a.id] ?? false);
+
+    expect(cachedByLayer(tester)[a.id], isTrue);
+    expect(cachedByLayer(tester)[b.id], isFalse);
+
+    state.layerInteractionManager.clearSelectedLayers();
+    state.setState(() {});
+    await tester.pump();
+    await pumpUntil(tester, () => allCached(tester));
+
+    expect(cachedByLayer(tester).values, everyElement(isTrue));
+  });
+
+  testWidgets('captures every layer although its paint is cached', (
+    tester,
+  ) async {
+    final state = await pumpEditor(tester);
+    await addAndCache(tester, state, [
+      buildPaintLayer(const Offset(-40, 0)),
+      buildPaintLayer(const Offset(40, 0)),
+    ]);
+    expect(cachedByLayer(tester).values, [true, true]);
+
+    // The capture waits for a frame in which every layer paints live, and
+    // frames only happen when the test pumps them.
+    late final List<ExportedLayer> captured;
+    await tester.runAsync(() async {
+      var done = false;
+      final future = state
+          .captureAllLayersWithMeta(format: ImageByteFormat.rawRgba)
+          .whenComplete(() => done = true);
+      while (!done) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await tester.pump();
+      }
+      captured = await future;
+    });
+
+    expect(captured, hasLength(2));
+    for (final layer in captured) {
+      // A capture taken from a boundary that painted nothing is fully
+      // transparent; a real one carries the red stroke.
+      final bytes = layer.bytes;
+      var opaque = 0;
+      for (var i = 3; i < bytes.length; i += 4) {
+        if (bytes[i] > 0) opaque++;
+      }
+      expect(opaque, greaterThan(0), reason: 'layer ${layer.layer.id}');
+    }
+    // The cache takes over again once the capture is done.
+    await pumpUntil(tester, () => allCached(tester));
+    expect(cachedByLayer(tester).values, [true, true]);
+  });
+}

--- a/test/features/main_editor/paint_layer_raster_cache_editor_test.dart
+++ b/test/features/main_editor/paint_layer_raster_cache_editor_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 // Project imports:
 import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_image_editor/shared/services/content_recorder/widgets/content_recorder.dart';
 import 'package:pro_image_editor/shared/widgets/layer/layer_widget.dart';
 
 import '../../mock/mock_image.dart';
@@ -175,7 +176,72 @@ void main() {
     expect(cachedByLayer(tester).values, everyElement(isTrue));
   });
 
+  /// Runs [action], pumping frames until it completes, and reports whether
+  /// every layer rendered live in one of them.
+  Future<({T result, bool sawLive})> runCapture<T>(
+    WidgetTester tester,
+    Future<T> Function() action,
+  ) async {
+    var sawLive = false;
+    late final T result;
+    await tester.runAsync(() async {
+      var done = false;
+      final future = action().whenComplete(() => done = true);
+      while (!done) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await tester.pump();
+        final cached = cachedByLayer(tester).values;
+        if (cached.isNotEmpty && cached.every((value) => !value)) {
+          sawLive = true;
+        }
+      }
+      result = await future;
+    });
+    return (result: result, sawLive: sawLive);
+  }
+
   testWidgets('captures every layer although its paint is cached', (
+    tester,
+  ) async {
+    final state = await pumpEditor(tester);
+    final layers = [
+      buildPaintLayer(const Offset(-40, 0)),
+      buildPaintLayer(const Offset(40, 0)),
+    ];
+    for (final layer in layers) {
+      state.addLayer(
+        layer,
+        blockSelectLayer: true,
+        autoCorrectZoomOffset: false,
+        autoCorrectZoomScale: false,
+      );
+    }
+    state.layerInteractionManager.clearSelectedLayers();
+    // Live: the cache has not been given a frame to land yet.
+    state.setState(() {});
+    await tester.pump();
+    expect(cachedByLayer(tester).values, [false, false]);
+    Future<List<ExportedLayer>> capture() =>
+        state.captureAllLayersWithMeta(format: ImageByteFormat.rawRgba);
+    final live = (await runCapture(tester, capture)).result;
+
+    await pumpUntil(tester, () => allCached(tester));
+    expect(cachedByLayer(tester).values, [true, true]);
+    final cached = await runCapture(tester, capture);
+
+    // A cached layer paints nothing into its repaint boundary; its capture is
+    // rendered from the model and has to be what the boundary held before.
+    expect(cached.result, hasLength(2));
+    for (var i = 0; i < 2; i++) {
+      expect(cached.result[i].bytes, live[i].bytes, reason: 'layer $i');
+      expect(cached.result[i].bytes.any((byte) => byte > 0), isTrue);
+    }
+    // The capture did not need the cache to step aside.
+    expect(cached.sawLive, isFalse);
+    expect(cachedByLayer(tester).values, [true, true]);
+  });
+
+  testWidgets('captures the canvas from a frame with live layers', (
     tester,
   ) async {
     final state = await pumpEditor(tester);
@@ -183,35 +249,32 @@ void main() {
       buildPaintLayer(const Offset(-40, 0)),
       buildPaintLayer(const Offset(40, 0)),
     ]);
-    expect(cachedByLayer(tester).values, [true, true]);
 
-    // The capture waits for a frame in which every layer paints live, and
-    // frames only happen when the test pumps them.
-    late final List<ExportedLayer> captured;
-    await tester.runAsync(() async {
-      var done = false;
-      final future = state
-          .captureAllLayersWithMeta(format: ImageByteFormat.rawRgba)
-          .whenComplete(() => done = true);
-      while (!done) {
-        await Future<void>.delayed(const Duration(milliseconds: 20));
-        await tester.pump();
-      }
-      captured = await future;
-    });
+    // Every canvas screenshot — state history, final image, thumbnail —
+    // reads the editor's recorder at the output pixel ratio; a cached image
+    // rendered for the screen would be upscaled into it, so the recorder
+    // asks the layers for a live frame first.
+    final recorder = ContentRecorder.maybeControllerOf(
+      tester.element(find.byType(LayerWidget).first),
+    )!;
+    final body = state.sizesManager.bodySize;
+    final capture = await runCapture(
+      tester,
+      () => recorder.getRawRenderedImage(
+        imageInfos: ImageInfos(
+          rawSize: body,
+          renderedSize: body,
+          originalRenderedSize: body,
+          cropRectSize: body,
+          pixelRatio: 1,
+          isRotated: false,
+        ),
+      ),
+    );
 
-    expect(captured, hasLength(2));
-    for (final layer in captured) {
-      // A capture taken from a boundary that painted nothing is fully
-      // transparent; a real one carries the red stroke.
-      final bytes = layer.bytes;
-      var opaque = 0;
-      for (var i = 3; i < bytes.length; i += 4) {
-        if (bytes[i] > 0) opaque++;
-      }
-      expect(opaque, greaterThan(0), reason: 'layer ${layer.layer.id}');
-    }
-    // The cache takes over again once the capture is done.
+    expect(capture.result, isNotNull);
+    capture.result!.dispose();
+    expect(capture.sawLive, isTrue);
     await pumpUntil(tester, () => allCached(tester));
     expect(cachedByLayer(tester).values, [true, true]);
   });

--- a/test/features/main_editor/services/paint_layer_raster_cache_test.dart
+++ b/test/features/main_editor/services/paint_layer_raster_cache_test.dart
@@ -15,7 +15,9 @@ import 'package:pro_image_editor/shared/widgets/layer/layer_widget.dart';
 
 const Size _body = Size(200, 300);
 const Offset _center = Offset(-0.5, -0.5);
-const _configs = PaintEditorConfigs();
+const _configs = ProImageEditorConfigs(
+  paintEditor: PaintEditorConfigs(layerFractionalOffset: _center),
+);
 
 PaintLayer _stroke({
   String? id,
@@ -32,18 +34,21 @@ PaintLayer _stroke({
   Duration? enterDuration,
   List<ErasedOffset> erasedOffsets = const [],
   int points = 12,
+  List<Offset?>? offsets,
+  PaintMode mode = PaintMode.freeStyle,
+  double strokeWidth = 6,
 }) {
-  final offsets = <Offset?>[
+  offsets ??= <Offset?>[
     for (var i = 0; i < points; i++) Offset(4 + i * 5.0, 30 + sin(i / 2) * 20),
   ];
   return PaintLayer(
     id: id,
     item: PaintedModel(
-      mode: PaintMode.freeStyle,
+      mode: mode,
       offsets: offsets,
       erasedOffsets: erasedOffsets,
       color: color,
-      strokeWidth: 6,
+      strokeWidth: strokeWidth,
       opacity: 1,
     ),
     rawSize: const Size(64, 60),
@@ -68,17 +73,39 @@ PaintLayerRasterPlan _plan(
   Set<String> excluded = const {},
   Duration? playTime,
   double pixelRatio = 1,
-  PaintEditorConfigs configs = _configs,
+  ProImageEditorConfigs configs = _configs,
 }) {
   return cache.plan(
     layers: layers,
     excludedIds: excluded,
     playTime: playTime,
     editorBodySize: _body,
-    fractionalOffset: _center,
     pixelRatio: pixelRatio,
-    paintEditorConfigs: configs,
+    configs: configs,
   );
+}
+
+void _ensure(
+  PaintLayerRasterCache cache,
+  PaintLayerRasterRun run, {
+  double pixelRatio = 1,
+}) {
+  cache.ensure(
+    run,
+    editorBodySize: _body,
+    pixelRatio: pixelRatio,
+    configs: _configs,
+  );
+}
+
+/// Pumps the real event loop until [done] holds; rendering is engine work
+/// that only completes inside `runAsync`.
+Future<void> _waitFor(WidgetTester tester, bool Function() done) {
+  return tester.runAsync(() async {
+    while (!done()) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+  });
 }
 
 /// Renders [layers] the way the main editor does — one `LayerWidget` per
@@ -144,9 +171,8 @@ Future<ByteData> _recordCached(PaintLayerRasterPlan plan) async {
     final picture = PaintLayerRasterCache.recordRun(
       run,
       editorBodySize: _body,
-      fractionalOffset: _center,
       pixelRatio: 1,
-      paintEditorConfigs: _configs,
+      configs: _configs,
     );
     final image = await picture.toImage(
       run.bounds.width.ceil(),
@@ -289,17 +315,53 @@ void main() {
 
     test('leaves modes with a custom path builder live', () {
       final cache = PaintLayerRasterCache();
-      final configs = PaintEditorConfigs(
-        customPathBuilders: {
-          PaintMode.freeStyle:
-              ({required item, required scale, required paintEditorConfigs}) =>
-                  throw UnimplementedError(),
-        },
+      final configs = ProImageEditorConfigs(
+        paintEditor: PaintEditorConfigs(
+          customPathBuilders: {
+            PaintMode.freeStyle:
+                ({
+                  required item,
+                  required scale,
+                  required paintEditorConfigs,
+                }) => throw UnimplementedError(),
+          },
+        ),
       );
 
       final plan = _plan(cache, [_stroke()], configs: configs);
 
       expect(plan.runs, isEmpty);
+      cache.dispose();
+    });
+
+    test('leaves timeline layers live under a custom timeline transition', () {
+      final cache = PaintLayerRasterCache();
+      final configs = ProImageEditorConfigs(
+        videoEditor: VideoEditorConfigs(
+          layerTimeline: LayerTimelineConfigs(
+            // Decorates the layer even at full progress, which the cached
+            // strokes could not show.
+            transitionBuilder: (child, animation) =>
+                ColoredBox(color: Colors.red, child: child),
+          ),
+        ),
+      );
+      final timed = _stroke(
+        id: 'timed',
+        startTime: Duration.zero,
+        endTime: const Duration(seconds: 6),
+      );
+      final untimed = _stroke(id: 'untimed');
+
+      final plan = _plan(
+        cache,
+        [timed, untimed],
+        playTime: const Duration(seconds: 1),
+        configs: configs,
+      );
+
+      expect(plan.runs, hasLength(1));
+      expect(plan.runs.single.layerIds, ['untimed']);
       cache.dispose();
     });
 
@@ -314,7 +376,7 @@ void main() {
 
     test('drops a run whose image would exceed maxDimension on one side', () {
       // Well within the pixel budget; only the width is over the limit.
-      final cache = PaintLayerRasterCache(maxDimension: 64);
+      final cache = PaintLayerRasterCache(maxDimension: 50);
 
       final plan = _plan(cache, [_stroke()]);
 
@@ -329,6 +391,27 @@ void main() {
 
       expect(plan.runs, hasLength(1));
       expect(plan.runs.single.layerIds, ['a']);
+      cache.dispose();
+    });
+
+    test('keeps the runs of one plan within maxTotalPixels together', () {
+      final single = _plan(PaintLayerRasterCache(), [_stroke()]).runs.single;
+      // Room for two such images, not three.
+      final cache = PaintLayerRasterCache(
+        maxTotalPixels: single.pixels * 2 + single.pixels ~/ 2,
+      );
+
+      final plan = _plan(cache, [
+        _stroke(id: 'a'),
+        _text(),
+        _stroke(id: 'b'),
+        _text(),
+        _stroke(id: 'c'),
+      ]);
+
+      // A third image could never stay resident, so the run renders live
+      // instead of evicting one of the others on every landing.
+      expect(plan.runs.map((run) => run.layerIds.single), ['a', 'b']);
       cache.dispose();
     });
   });
@@ -373,6 +456,39 @@ void main() {
       );
     });
 
+    test('differs for the same number of points at other positions', () {
+      final baseKey = PaintLayerRasterCache.layerKey(
+        _stroke(id: 'x', offsets: const [Offset(2, 2), Offset(50, 2)]),
+      );
+
+      // A layer keeps its id across history entries, so two states of it can
+      // hold as many points as each other; the image must not be shared.
+      expect(
+        PaintLayerRasterCache.layerKey(
+          _stroke(id: 'x', offsets: const [Offset(2, 2), Offset(2, 50)]),
+        ),
+        isNot(baseKey),
+      );
+
+      final erasedKey = PaintLayerRasterCache.layerKey(
+        _stroke(
+          id: 'x',
+          erasedOffsets: const [ErasedOffset(offset: Offset(5, 5), radius: 4)],
+        ),
+      );
+      expect(
+        PaintLayerRasterCache.layerKey(
+          _stroke(
+            id: 'x',
+            erasedOffsets: const [
+              ErasedOffset(offset: Offset(45, 45), radius: 4),
+            ],
+          ),
+        ),
+        isNot(erasedKey),
+      );
+    });
+
     test('ignores the timeline window, so retiming keeps the raster', () {
       final baseKey = PaintLayerRasterCache.layerKey(_stroke(id: 'x'));
 
@@ -390,6 +506,12 @@ void main() {
   });
 
   group('PaintLayerRasterCache.layerBounds', () {
+    Rect boundsOf(PaintLayer layer) => PaintLayerRasterCache.layerBounds(
+      layer,
+      editorBodySize: _body,
+      fractionalOffset: _center,
+    );
+
     test('covers the rotated box of a transformed layer', () {
       final layer = _stroke(
         offset: const Offset(20, -30),
@@ -397,11 +519,7 @@ void main() {
         rotation: pi / 3,
       );
 
-      final bounds = PaintLayerRasterCache.layerBounds(
-        layer,
-        editorBodySize: _body,
-        fractionalOffset: _center,
-      );
+      final bounds = boundsOf(layer);
 
       final center = Offset(_body.width / 2 + 20, _body.height / 2 - 30);
       final halfDiagonal = layer.size.longestSide * sqrt(2) / 2;
@@ -411,6 +529,47 @@ void main() {
       expect(bounds.width, lessThanOrEqualTo(halfDiagonal * 2 + 10));
       expect(bounds.height, lessThanOrEqualTo(halfDiagonal * 2 + 10));
       expect(bounds.width, greaterThan(layer.size.width));
+    });
+
+    test('reaches past the points for arrowheads and miter joins', () {
+      // A horizontal arrow whose head spreads across the stroke.
+      final arrow = _stroke(
+        mode: PaintMode.freeStyleArrowEnd,
+        offsets: const [Offset(5, 5), Offset(125, 5)],
+        strokeWidth: 10,
+      );
+      final arrowBounds = boundsOf(arrow);
+      final lineY = _body.height / 2 - arrow.size.height / 2 + 5;
+      // The barbs run out to four half-strokes above and below the line,
+      // well past the half stroke a plain line would need.
+      expect(arrowBounds.top, lessThan(lineY - 15));
+      expect(arrowBounds.bottom, greaterThan(lineY + 15));
+
+      // A rectangle's corners are miter joins that overshoot half a stroke.
+      final rect = _stroke(
+        mode: PaintMode.rect,
+        offsets: const [Offset(10, 10), Offset(50, 50)],
+        strokeWidth: 10,
+      );
+      final rectBounds = boundsOf(rect);
+      final rectBox = Rect.fromLTWH(
+        _body.width / 2 - rect.size.width / 2,
+        _body.height / 2 - rect.size.height / 2,
+        rect.size.width,
+        rect.size.height,
+      );
+      expect(rectBounds.left, lessThan(rectBox.left + 10 - 5));
+      expect(rectBounds.right, greaterThan(rectBox.right - 10 + 5));
+    });
+
+    test('follows a flipped layer whose ink sits off the box center', () {
+      const offsets = <Offset?>[Offset(2, 2), Offset(20, 2)];
+      final plain = boundsOf(_stroke(offsets: offsets));
+      final flipped = boundsOf(_stroke(offsets: offsets, flipX: true));
+
+      // The stroke hugs the left edge; mirrored, it hugs the right one.
+      expect(flipped.left, greaterThan(plain.left + 20));
+      expect(flipped.width, closeTo(plain.width, 0.01));
     });
   });
 
@@ -446,6 +605,24 @@ void main() {
           opacity: 0.5,
           color: const Color(0xFF000000),
         ),
+        // Their heads and corners draw past the recorded points; a run that
+        // clipped them would differ from the live render.
+        _stroke(
+          id: 'arrow',
+          mode: PaintMode.freeStyleArrowStartEnd,
+          offsets: const [Offset(4, 30), Offset(60, 30)],
+          strokeWidth: 8,
+          offset: const Offset(20, 120),
+          color: const Color(0xFF00695C),
+        ),
+        _stroke(
+          id: 'rect',
+          mode: PaintMode.rect,
+          offsets: const [Offset(6, 6), Offset(58, 54)],
+          strokeWidth: 10,
+          offset: const Offset(-50, 20),
+          color: const Color(0xFFEF6C00),
+        ),
       ];
       final cache = PaintLayerRasterCache();
       final plan = _plan(cache, layers);
@@ -475,18 +652,8 @@ void main() {
       cache.addListener(() => notified++);
 
       expect(cache.imageFor(run), isNull);
-      cache.ensure(
-        run,
-        editorBodySize: _body,
-        fractionalOffset: _center,
-        pixelRatio: 2,
-        paintEditorConfigs: _configs,
-      );
-      await tester.runAsync(() async {
-        while (notified == 0) {
-          await Future<void>.delayed(const Duration(milliseconds: 10));
-        }
-      });
+      _ensure(cache, run, pixelRatio: 2);
+      await _waitFor(tester, () => notified > 0);
 
       final image = cache.imageFor(run)!;
       expect(image.width, (run.bounds.width * 2).ceil());
@@ -503,23 +670,40 @@ void main() {
       cache.addListener(() => notified++);
 
       for (final run in [first, second]) {
-        cache.ensure(
-          run,
-          editorBodySize: _body,
-          fractionalOffset: _center,
-          pixelRatio: 1,
-          paintEditorConfigs: _configs,
-        );
+        _ensure(cache, run);
         final expected = notified + 1;
-        await tester.runAsync(() async {
-          while (notified < expected) {
-            await Future<void>.delayed(const Duration(milliseconds: 10));
-          }
-        });
+        await _waitFor(tester, () => notified >= expected);
       }
 
       expect(cache.contains(first), isFalse);
       expect(cache.contains(second), isTrue);
+      cache.dispose();
+    });
+
+    testWidgets('never evicts an image the current plan draws', (tester) async {
+      final cache = PaintLayerRasterCache(maxImages: 2);
+      final a = _stroke(id: 'a');
+      final b = _stroke(id: 'b', offset: const Offset(0, 80));
+      final t = _text();
+      final stale = _plan(cache, [_stroke(id: 'stale')]).runs.single;
+      var notified = 0;
+      cache.addListener(() => notified++);
+
+      _ensure(cache, stale);
+      await _waitFor(tester, () => notified >= 1);
+
+      // The current plan needs both of its runs resident. `stale` is the
+      // least recently used image and the one to go; evicting a planned one
+      // would only make the host render it again and evict the next.
+      final plan = _plan(cache, [a, t, b]);
+      for (final run in plan.runs) {
+        _ensure(cache, run);
+        final expected = notified + 1;
+        await _waitFor(tester, () => notified >= expected);
+      }
+
+      expect(cache.contains(stale), isFalse);
+      expect(plan.runs.every(cache.contains), isTrue);
       cache.dispose();
     });
 
@@ -536,18 +720,8 @@ void main() {
       // `ensure` runs on every build; a run the GPU cannot render must not be
       // attempted again on each of them.
       for (var i = 0; i < 3; i++) {
-        cache.ensure(
-          run,
-          editorBodySize: _body,
-          fractionalOffset: _center,
-          pixelRatio: 1,
-          paintEditorConfigs: _configs,
-        );
-        await tester.runAsync(() async {
-          while (cache.isRendering) {
-            await Future<void>.delayed(const Duration(milliseconds: 10));
-          }
-        });
+        _ensure(cache, run);
+        await _waitFor(tester, () => !cache.isRendering);
       }
 
       expect(cache.attempts, 1);

--- a/test/features/main_editor/services/paint_layer_raster_cache_test.dart
+++ b/test/features/main_editor/services/paint_layer_raster_cache_test.dart
@@ -1,0 +1,516 @@
+// Dart imports:
+import 'dart:math';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/rendering.dart' show RenderRepaintBoundary;
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+// Flutter imports:
+import 'package:material_ui/material_ui.dart';
+import 'package:pro_image_editor/features/main_editor/services/paint_layer_raster_cache.dart';
+import 'package:pro_image_editor/features/paint_editor/models/eraser_model.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_image_editor/shared/widgets/layer/layer_widget.dart';
+
+const Size _body = Size(200, 300);
+const Offset _center = Offset(-0.5, -0.5);
+const _configs = PaintEditorConfigs();
+
+PaintLayer _stroke({
+  String? id,
+  Offset offset = Offset.zero,
+  double scale = 1,
+  double rotation = 0,
+  bool flipX = false,
+  bool flipY = false,
+  double opacity = 1,
+  Color color = const Color(0xFF2E7D32),
+  Duration? startTime,
+  Duration? endTime,
+  List<LayerAnimation> animations = const [],
+  Duration? enterDuration,
+  List<ErasedOffset> erasedOffsets = const [],
+  int points = 12,
+}) {
+  final offsets = <Offset?>[
+    for (var i = 0; i < points; i++) Offset(4 + i * 5.0, 30 + sin(i / 2) * 20),
+  ];
+  return PaintLayer(
+    id: id,
+    item: PaintedModel(
+      mode: PaintMode.freeStyle,
+      offsets: offsets,
+      erasedOffsets: erasedOffsets,
+      color: color,
+      strokeWidth: 6,
+      opacity: 1,
+    ),
+    rawSize: const Size(64, 60),
+    opacity: opacity,
+    offset: offset,
+    scale: scale,
+    rotation: rotation,
+    flipX: flipX,
+    flipY: flipY,
+    startTime: startTime,
+    endTime: endTime,
+    enterDuration: enterDuration,
+    animations: animations,
+  );
+}
+
+TextLayer _text() => TextLayer(text: 'hi', offset: Offset.zero);
+
+PaintLayerRasterPlan _plan(
+  PaintLayerRasterCache cache,
+  List<Layer> layers, {
+  Set<String> excluded = const {},
+  Duration? playTime,
+  double pixelRatio = 1,
+  PaintEditorConfigs configs = _configs,
+}) {
+  return cache.plan(
+    layers: layers,
+    excludedIds: excluded,
+    playTime: playTime,
+    editorBodySize: _body,
+    fractionalOffset: _center,
+    pixelRatio: pixelRatio,
+    paintEditorConfigs: configs,
+  );
+}
+
+/// Renders [layers] the way the main editor does — one `LayerWidget` per
+/// layer inside a body-sized stack — and returns the RGBA bytes.
+Future<ByteData> _renderLive(WidgetTester tester, List<Layer> layers) async {
+  final key = GlobalKey();
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Center(
+        child: RepaintBoundary(
+          key: key,
+          child: SizedBox.fromSize(
+            size: _body,
+            child: ColoredBox(
+              color: const Color(0xFFFFFFFF),
+              child: Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  for (final layer in layers)
+                    LayerWidget(
+                      key: layer.key,
+                      layer: layer,
+                      configs: const ProImageEditorConfigs(),
+                      editorBodySize: _body,
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  final boundary =
+      key.currentContext!.findRenderObject()! as RenderRepaintBoundary;
+  // Rasterizing is real engine work, which only completes inside runAsync.
+  final bytes = await tester.runAsync(() async {
+    final image = await boundary.toImage();
+    final bytes = await image.toByteData();
+    image.dispose();
+    return bytes;
+  });
+  return bytes!;
+}
+
+/// Draws the cached image of every run in [plan] onto a white body-sized
+/// canvas, exactly where `_PaintRunImage` positions it, and returns the RGBA
+/// bytes.
+Future<ByteData> _renderCached(
+  WidgetTester tester,
+  PaintLayerRasterPlan plan,
+) async {
+  final bytes = await tester.runAsync(() => _recordCached(plan));
+  return bytes!;
+}
+
+Future<ByteData> _recordCached(PaintLayerRasterPlan plan) async {
+  final recorder = ui.PictureRecorder();
+  final canvas = Canvas(recorder)
+    ..drawRect(Offset.zero & _body, Paint()..color = const Color(0xFFFFFFFF));
+  for (final run in plan.runs) {
+    final picture = PaintLayerRasterCache.recordRun(
+      run,
+      editorBodySize: _body,
+      fractionalOffset: _center,
+      pixelRatio: 1,
+      paintEditorConfigs: _configs,
+    );
+    final image = await picture.toImage(
+      run.bounds.width.ceil(),
+      run.bounds.height.ceil(),
+    );
+    picture.dispose();
+    canvas.drawImage(image, run.bounds.topLeft, Paint());
+    image.dispose();
+  }
+  final image = await recorder.endRecording().toImage(
+    _body.width.toInt(),
+    _body.height.toInt(),
+  );
+  final bytes = await image.toByteData();
+  image.dispose();
+  return bytes!;
+}
+
+/// The share of pixels whose RGBA differs by more than [tolerance] in any
+/// channel, plus a sanity count of ink pixels so an all-white pair cannot
+/// pass by accident.
+({double mismatch, int ink}) _compare(
+  ByteData a,
+  ByteData b, {
+  int tolerance = 24,
+}) {
+  expect(a.lengthInBytes, b.lengthInBytes);
+  var mismatched = 0;
+  var ink = 0;
+  final pixels = a.lengthInBytes ~/ 4;
+  for (var i = 0; i < pixels; i++) {
+    var differs = false;
+    for (var c = 0; c < 4; c++) {
+      final pa = a.getUint8(i * 4 + c);
+      final pb = b.getUint8(i * 4 + c);
+      if ((pa - pb).abs() > tolerance) differs = true;
+    }
+    if (differs) mismatched++;
+    if (a.getUint8(i * 4) != 255 ||
+        a.getUint8(i * 4 + 1) != 255 ||
+        a.getUint8(i * 4 + 2) != 255) {
+      ink++;
+    }
+  }
+  return (mismatch: mismatched / pixels, ink: ink);
+}
+
+void main() {
+  group('PaintLayerRasterCache.plan', () {
+    test('groups consecutive paint layers and splits at other layer types', () {
+      final cache = PaintLayerRasterCache();
+      final a = _stroke(id: 'a');
+      final b = _stroke(id: 'b', offset: const Offset(10, 10));
+      final t = _text();
+      final c = _stroke(id: 'c', offset: const Offset(-20, 40));
+
+      final plan = _plan(cache, [a, b, t, c]);
+
+      expect(plan.runs, hasLength(2));
+      expect(plan.runs[0].layerIds, ['a', 'b']);
+      expect(plan.runs[0].insertIndex, 0);
+      expect(plan.runs[1].layerIds, ['c']);
+      expect(plan.runs[1].insertIndex, 3);
+      cache.dispose();
+    });
+
+    test(
+      'keeps selected, animated, censor and timeline-hidden layers live',
+      () {
+        final cache = PaintLayerRasterCache();
+        final selected = _stroke(id: 'selected');
+        final animated = _stroke(
+          id: 'animated',
+          animations: const [
+            LayerAnimation(
+              type: LayerAnimationType.fade,
+              phase: AnimationPhase.animateIn,
+              duration: Duration(seconds: 1),
+            ),
+          ],
+        );
+        final fading = _stroke(
+          id: 'fading',
+          enterDuration: const Duration(milliseconds: 500),
+        );
+        final later = _stroke(
+          id: 'later',
+          startTime: const Duration(seconds: 4),
+          endTime: const Duration(seconds: 6),
+        );
+        final now = _stroke(
+          id: 'now',
+          startTime: Duration.zero,
+          endTime: const Duration(seconds: 6),
+        );
+        final censor = PaintLayer(
+          item: PaintedModel(
+            mode: PaintMode.blur,
+            offsets: const [Offset.zero, Offset(20, 20)],
+            erasedOffsets: const [],
+            color: Colors.black,
+            strokeWidth: 4,
+            opacity: 1,
+          ),
+          rawSize: const Size(20, 20),
+          opacity: 1,
+        );
+
+        final plan = _plan(
+          cache,
+          [selected, animated, fading, later, now, censor],
+          excluded: {'selected'},
+          playTime: const Duration(seconds: 1),
+        );
+
+        expect(plan.runs, hasLength(1));
+        expect(plan.runs.single.layerIds, ['now']);
+        cache.dispose();
+      },
+    );
+
+    test(
+      'does not cache a merged layer that fades through an Opacity widget',
+      () {
+        final cache = PaintLayerRasterCache();
+        final merged = PaintLayer(
+          items: [_stroke().item, _stroke().item],
+          rawSize: const Size(64, 60),
+          opacity: 0.5,
+        );
+        final single = _stroke(id: 'single', opacity: 0.5);
+
+        final plan = _plan(cache, [merged, single]);
+
+        expect(plan.runs, hasLength(1));
+        expect(plan.runs.single.layerIds, ['single']);
+        cache.dispose();
+      },
+    );
+
+    test('leaves modes with a custom path builder live', () {
+      final cache = PaintLayerRasterCache();
+      final configs = PaintEditorConfigs(
+        customPathBuilders: {
+          PaintMode.freeStyle:
+              ({required item, required scale, required paintEditorConfigs}) =>
+                  throw UnimplementedError(),
+        },
+      );
+
+      final plan = _plan(cache, [_stroke()], configs: configs);
+
+      expect(plan.runs, isEmpty);
+      cache.dispose();
+    });
+
+    test('drops a run whose image would exceed the pixel budget', () {
+      final cache = PaintLayerRasterCache(maxPixels: 1000);
+
+      final plan = _plan(cache, [_stroke()]);
+
+      expect(plan.runs, isEmpty);
+      cache.dispose();
+    });
+
+    test('keeps at most maxImages runs', () {
+      final cache = PaintLayerRasterCache(maxImages: 1);
+
+      final plan = _plan(cache, [_stroke(id: 'a'), _text(), _stroke(id: 'b')]);
+
+      expect(plan.runs, hasLength(1));
+      expect(plan.runs.single.layerIds, ['a']);
+      cache.dispose();
+    });
+  });
+
+  group('PaintLayerRasterCache.layerKey', () {
+    test('changes with geometry, opacity and erased strokes', () {
+      final base = _stroke(id: 'x');
+      final baseKey = PaintLayerRasterCache.layerKey(base);
+
+      expect(
+        PaintLayerRasterCache.layerKey(
+          _stroke(id: 'x', offset: const Offset(1, 0)),
+        ),
+        isNot(baseKey),
+      );
+      expect(
+        PaintLayerRasterCache.layerKey(_stroke(id: 'x', scale: 1.5)),
+        isNot(baseKey),
+      );
+      expect(
+        PaintLayerRasterCache.layerKey(_stroke(id: 'x', rotation: 0.3)),
+        isNot(baseKey),
+      );
+      expect(
+        PaintLayerRasterCache.layerKey(_stroke(id: 'x', flipX: true)),
+        isNot(baseKey),
+      );
+      expect(
+        PaintLayerRasterCache.layerKey(_stroke(id: 'x', opacity: 0.4)),
+        isNot(baseKey),
+      );
+      expect(
+        PaintLayerRasterCache.layerKey(
+          _stroke(
+            id: 'x',
+            erasedOffsets: const [
+              ErasedOffset(offset: Offset(10, 10), radius: 4),
+            ],
+          ),
+        ),
+        isNot(baseKey),
+      );
+    });
+
+    test('ignores the timeline window, so retiming keeps the raster', () {
+      final baseKey = PaintLayerRasterCache.layerKey(_stroke(id: 'x'));
+
+      expect(
+        PaintLayerRasterCache.layerKey(
+          _stroke(
+            id: 'x',
+            startTime: const Duration(seconds: 1),
+            endTime: const Duration(seconds: 2),
+          ),
+        ),
+        baseKey,
+      );
+    });
+  });
+
+  group('PaintLayerRasterCache.layerBounds', () {
+    test('covers the rotated box of a transformed layer', () {
+      final layer = _stroke(
+        offset: const Offset(20, -30),
+        scale: 2,
+        rotation: pi / 3,
+      );
+
+      final bounds = PaintLayerRasterCache.layerBounds(
+        layer,
+        editorBodySize: _body,
+        fractionalOffset: _center,
+      );
+
+      final center = Offset(_body.width / 2 + 20, _body.height / 2 - 30);
+      final halfDiagonal = layer.size.longestSide * sqrt(2) / 2;
+      expect(bounds.contains(center), isTrue);
+      // Every corner of the rotated box lies within its circumscribed circle,
+      // and the bounds must contain them all.
+      expect(bounds.width, lessThanOrEqualTo(halfDiagonal * 2 + 10));
+      expect(bounds.height, lessThanOrEqualTo(halfDiagonal * 2 + 10));
+      expect(bounds.width, greaterThan(layer.size.width));
+    });
+  });
+
+  group('PaintLayerRasterCache.recordRun', () {
+    testWidgets('matches the live LayerWidget render pixel for pixel', (
+      tester,
+    ) async {
+      final layers = <Layer>[
+        _stroke(id: 'plain'),
+        _stroke(
+          id: 'moved',
+          offset: const Offset(30, 60),
+          color: const Color(0xFF1565C0),
+        ),
+        _stroke(
+          id: 'scaled-rotated',
+          offset: const Offset(-40, -70),
+          scale: 1.6,
+          rotation: 0.7,
+          color: const Color(0xFFC62828),
+        ),
+        _stroke(
+          id: 'flipped',
+          offset: const Offset(40, -90),
+          flipX: true,
+          flipY: true,
+          rotation: -0.4,
+          color: const Color(0xFF6A1B9A),
+        ),
+        _stroke(
+          id: 'translucent',
+          offset: const Offset(-30, 90),
+          opacity: 0.5,
+          color: const Color(0xFF000000),
+        ),
+      ];
+      final cache = PaintLayerRasterCache();
+      final plan = _plan(cache, layers);
+      expect(plan.runs, hasLength(1));
+
+      final live = await _renderLive(tester, layers);
+      final cached = await _renderCached(tester, plan);
+
+      final result = _compare(live, cached);
+      // Every layer leaves ink, so a blank pair cannot pass.
+      expect(result.ink, greaterThan(500));
+      // Anti-aliasing at rotated edges differs by a pixel here and there;
+      // anything beyond a fraction of a percent is a placement error.
+      expect(result.mismatch, lessThan(0.0005));
+      cache.dispose();
+    });
+  });
+
+  group('PaintLayerRasterCache.ensure', () {
+    testWidgets('renders an image sized to the run and notifies', (
+      tester,
+    ) async {
+      final cache = PaintLayerRasterCache();
+      final plan = _plan(cache, [_stroke()], pixelRatio: 2);
+      final run = plan.runs.single;
+      var notified = 0;
+      cache.addListener(() => notified++);
+
+      expect(cache.imageFor(run), isNull);
+      cache.ensure(
+        run,
+        editorBodySize: _body,
+        fractionalOffset: _center,
+        pixelRatio: 2,
+        paintEditorConfigs: _configs,
+      );
+      await tester.runAsync(() async {
+        while (notified == 0) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+      });
+
+      final image = cache.imageFor(run)!;
+      expect(image.width, (run.bounds.width * 2).ceil());
+      expect(image.height, (run.bounds.height * 2).ceil());
+      expect(notified, 1);
+      cache.dispose();
+    });
+
+    testWidgets('evicts the oldest image beyond maxImages', (tester) async {
+      final cache = PaintLayerRasterCache(maxImages: 1);
+      final first = _plan(cache, [_stroke(id: 'a')]).runs.single;
+      final second = _plan(cache, [_stroke(id: 'b')]).runs.single;
+      var notified = 0;
+      cache.addListener(() => notified++);
+
+      for (final run in [first, second]) {
+        cache.ensure(
+          run,
+          editorBodySize: _body,
+          fractionalOffset: _center,
+          pixelRatio: 1,
+          paintEditorConfigs: _configs,
+        );
+        final expected = notified + 1;
+        await tester.runAsync(() async {
+          while (notified < expected) {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+          }
+        });
+      }
+
+      expect(cache.contains(first), isFalse);
+      expect(cache.contains(second), isTrue);
+      cache.dispose();
+    });
+  });
+}

--- a/test/features/main_editor/services/paint_layer_raster_cache_test.dart
+++ b/test/features/main_editor/services/paint_layer_raster_cache_test.dart
@@ -312,6 +312,16 @@ void main() {
       cache.dispose();
     });
 
+    test('drops a run whose image would exceed maxDimension on one side', () {
+      // Well within the pixel budget; only the width is over the limit.
+      final cache = PaintLayerRasterCache(maxDimension: 64);
+
+      final plan = _plan(cache, [_stroke()]);
+
+      expect(plan.runs, isEmpty);
+      cache.dispose();
+    });
+
     test('keeps at most maxImages runs', () {
       final cache = PaintLayerRasterCache(maxImages: 1);
 
@@ -512,5 +522,51 @@ void main() {
       expect(cache.contains(second), isTrue);
       cache.dispose();
     });
+
+    testWidgets('reports a failed render once and leaves the run live', (
+      tester,
+    ) async {
+      final cache = _FailingCache();
+      final run = _plan(cache, [_stroke()]).runs.single;
+      final errors = <FlutterErrorDetails>[];
+      final onError = FlutterError.onError;
+      FlutterError.onError = errors.add;
+      addTearDown(() => FlutterError.onError = onError);
+
+      // `ensure` runs on every build; a run the GPU cannot render must not be
+      // attempted again on each of them.
+      for (var i = 0; i < 3; i++) {
+        cache.ensure(
+          run,
+          editorBodySize: _body,
+          fractionalOffset: _center,
+          pixelRatio: 1,
+          paintEditorConfigs: _configs,
+        );
+        await tester.runAsync(() async {
+          while (cache.isRendering) {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+          }
+        });
+      }
+
+      expect(cache.attempts, 1);
+      expect(errors, hasLength(1));
+      expect(cache.imageFor(run), isNull);
+      expect(cache.hasFailed(run), isTrue);
+      cache.dispose();
+    });
   });
+}
+
+/// A cache whose every render fails, the way one past the GPU's texture
+/// limit does.
+class _FailingCache extends PaintLayerRasterCache {
+  int attempts = 0;
+
+  @override
+  Future<ui.Image> toImage(ui.Picture picture, int width, int height) {
+    attempts++;
+    throw StateError('no texture');
+  }
 }

--- a/test/features/paint_editor/painting_canvas_test.dart
+++ b/test/features/paint_editor/painting_canvas_test.dart
@@ -381,5 +381,131 @@ void main() {
         }
       },
     );
+
+    group('eraser sessions', () {
+      // A horizontal stroke through the middle of its box, which the layer
+      // centers on the canvas.
+      PaintLayer stroke() => PaintLayer(
+        item: PaintedModel(
+          mode: PaintMode.freeStyle,
+          offsets: const [Offset(0, 5), Offset(80, 5)],
+          // The partial eraser appends to this list.
+          erasedOffsets: [],
+          color: Colors.red,
+          strokeWidth: 6,
+          opacity: 1,
+        ),
+        rawSize: const Size(80, 10),
+        opacity: 1,
+      );
+
+      Future<GlobalKey<PaintCanvasState>> pumpEraser(
+        WidgetTester tester, {
+        required EraserMode eraserMode,
+        required List<Layer> layers,
+        required void Function() onRemovePartialStart,
+        required void Function(bool hasRemovedAreas) onRemovePartialEnd,
+        void Function(List<String> ids)? onRemoveLayer,
+      }) async {
+        final GlobalKey<PaintCanvasState> canvasKey = GlobalKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: PaintCanvas(
+                layers: layers,
+                key: canvasKey,
+                drawAreaSize: const Size(1000, 1000),
+                editorBodySize: const Size(1000, 1000),
+                layerStackScaleFactor: 1,
+                paintCtrl: PaintController(
+                  color: Colors.red,
+                  mode: PaintMode.eraser,
+                  fill: false,
+                  strokeWidth: 1,
+                  strokeMultiplier: 1,
+                  opacity: 1,
+                ),
+                eraserMode: eraserMode,
+                eraserRadius: 8.0,
+                paintEditorConfigs: const PaintEditorConfigs(),
+                onRefresh: () {},
+                onCreated: (PaintedModel item) {},
+                onRemoveLayer: onRemoveLayer ?? (List<String> value) {},
+                onRemovePartialStart: onRemovePartialStart,
+                onRemovePartialEnd: onRemovePartialEnd,
+                onTap: (TapDownDetails details) {},
+              ),
+            ),
+          ),
+        );
+        return canvasKey;
+      }
+
+      testWidgets('a partial erase that turns into a pinch is still ended', (
+        WidgetTester tester,
+      ) async {
+        var starts = 0;
+        final ends = <bool>[];
+        final canvasKey = await pumpEraser(
+          tester,
+          eraserMode: EraserMode.partial,
+          layers: [stroke()],
+          onRemovePartialStart: () => starts++,
+          onRemovePartialEnd: ends.add,
+        );
+        // The eraser maps pointer positions against `editorBodySize`, so the
+        // stroke sits at that size's center, not at the widget's.
+        final Offset center =
+            tester.getTopLeft(find.byKey(canvasKey)) + const Offset(500, 500);
+
+        // One finger erases across the stroke, then a second one lands: the
+        // gesture becomes a pinch and no pointer-up reaches the eraser path.
+        final TestGesture first = await tester.startGesture(center);
+        expect(starts, 1);
+        await first.moveTo(center + const Offset(10, 0));
+        final TestGesture second = await tester.startGesture(
+          center + const Offset(100, -100),
+        );
+        // The editor is told at once, with what was erased so far, so it
+        // does not wait forever for the end of the session.
+        expect(ends, [true]);
+
+        await first.up();
+        await second.up();
+        expect(ends, [true]);
+        expect(starts, 1);
+      });
+
+      testWidgets('a full-stroke erase records no partial session', (
+        WidgetTester tester,
+      ) async {
+        var starts = 0;
+        var ends = 0;
+        final removed = <String>[];
+        final layer = stroke();
+        final canvasKey = await pumpEraser(
+          tester,
+          eraserMode: EraserMode.object,
+          layers: [layer],
+          onRemovePartialStart: () => starts++,
+          onRemovePartialEnd: (_) => ends++,
+          onRemoveLayer: removed.addAll,
+        );
+        final Offset center =
+            tester.getTopLeft(find.byKey(canvasKey)) + const Offset(500, 500);
+
+        // Removing a whole layer records its own history entry; a copy of
+        // the layers at pointer-down would only add an empty undo step.
+        final TestGesture gesture = await tester.startGesture(
+          center + const Offset(0, 40),
+        );
+        await gesture.moveTo(center);
+        await gesture.up();
+
+        expect(removed, [layer.id]);
+        expect(starts, 0);
+        expect(ends, 0);
+      });
+    });
   });
 }

--- a/test/shared/widgets/layer/layer_stack_raster_cache_test.dart
+++ b/test/shared/widgets/layer/layer_stack_raster_cache_test.dart
@@ -1,13 +1,28 @@
-// Flutter imports:
+// Dart imports:
+import 'dart:async';
+
 // Package imports:
 import 'package:flutter_test/flutter_test.dart';
+// Flutter imports:
 import 'package:material_ui/material_ui.dart';
 import 'package:pro_image_editor/core/models/transform_helper.dart';
+import 'package:pro_image_editor/features/main_editor/services/paint_layer_raster_cache.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_image_editor/shared/services/content_recorder/controllers/content_recorder_controller.dart';
+import 'package:pro_image_editor/shared/services/content_recorder/widgets/content_recorder.dart';
 import 'package:pro_image_editor/shared/widgets/layer/layer_stack.dart';
 import 'package:pro_image_editor/shared/widgets/layer/layer_widget.dart';
 
 const Size _body = Size(200, 300);
+
+const _imageInfos = ImageInfos(
+  rawSize: _body,
+  renderedSize: _body,
+  originalRenderedSize: _body,
+  cropRectSize: _body,
+  pixelRatio: 1,
+  isRotated: false,
+);
 
 PaintLayer _stroke(Offset offset) => PaintLayer(
   item: PaintedModel(
@@ -23,31 +38,47 @@ PaintLayer _stroke(Offset offset) => PaintLayer(
   offset: offset,
 );
 
-Widget _stack(
+Widget _layerStack(
   List<Layer> layers, {
   bool enableCache = true,
   bool suspend = false,
 }) {
+  return LayerStack(
+    configs: ProImageEditorConfigs(
+      mainEditor: MainEditorConfigs(enablePaintLayerRasterCache: enableCache),
+    ),
+    layers: layers,
+    overlayColor: Colors.black,
+    transformHelper: const TransformHelper(
+      editorBodySize: _body,
+      mainBodySize: _body,
+      mainImageSize: _body,
+    ),
+    suspendPaintLayerRasterCache: suspend,
+  );
+}
+
+Widget _stack(
+  List<Layer> layers, {
+  bool enableCache = true,
+  bool suspend = false,
+  ContentRecorderController? recorder,
+}) {
+  Widget stack = _layerStack(
+    layers,
+    enableCache: enableCache,
+    suspend: suspend,
+  );
+  if (recorder != null) {
+    stack = ContentRecorder(
+      controller: recorder,
+      autoDestroyController: false,
+      child: stack,
+    );
+  }
   return MaterialApp(
     home: Center(
-      child: SizedBox.fromSize(
-        size: _body,
-        child: LayerStack(
-          configs: ProImageEditorConfigs(
-            mainEditor: MainEditorConfigs(
-              enablePaintLayerRasterCache: enableCache,
-            ),
-          ),
-          layers: layers,
-          overlayColor: Colors.black,
-          transformHelper: const TransformHelper(
-            editorBodySize: _body,
-            mainBodySize: _body,
-            mainImageSize: _body,
-          ),
-          suspendPaintLayerRasterCache: suspend,
-        ),
-      ),
+      child: SizedBox.fromSize(size: _body, child: stack),
     ),
   );
 }
@@ -56,9 +87,14 @@ Iterable<bool> _cachedFlags(WidgetTester tester) => tester
     .widgetList<LayerWidget>(find.byType(LayerWidget))
     .map((widget) => widget.isRasterCached);
 
+bool _allCached(WidgetTester tester) {
+  final flags = _cachedFlags(tester);
+  return flags.isNotEmpty && flags.every((c) => c);
+}
+
 Future<void> _pumpUntilCached(WidgetTester tester) async {
   await tester.runAsync(() async {
-    for (var i = 0; i < 100 && !_cachedFlags(tester).every((c) => c); i++) {
+    for (var i = 0; i < 100 && !_allCached(tester); i++) {
       await Future<void>.delayed(const Duration(milliseconds: 20));
       await tester.pump();
     }
@@ -109,6 +145,112 @@ void main() {
 
       expect(_cachedFlags(tester), [false]);
       expect(find.byType(PaintRunImage), findsNothing);
+    });
+
+    testWidgets('renders live for the frame the enclosing recorder reads', (
+      tester,
+    ) async {
+      final recorder = ContentRecorderController(
+        configs: const ImageGenerationConfigs(
+          enableIsolateGeneration: false,
+          enableBackgroundGeneration: false,
+        ),
+        isVideoEditor: false,
+        ignoreGeneration: true,
+      );
+      addTearDown(recorder.destroy);
+      final layers = [_stroke(const Offset(-30, 0))];
+      await tester.pumpWidget(_stack(layers, recorder: recorder));
+      await _pumpUntilCached(tester);
+      expect(recorder.liveLayerRequests.hasHost, isTrue);
+
+      // The capture waits for a frame in which the strokes paint live — a
+      // cached image would be upscaled into the output — and the cache takes
+      // over again afterwards. Frames only happen when the test pumps them.
+      var sawLive = false;
+      await tester.runAsync(() async {
+        var done = false;
+        final future = recorder
+            .getRawRenderedImage(imageInfos: _imageInfos)
+            .whenComplete(() => done = true);
+        // The request is raised at once; the host acts on it in the next
+        // frame, and the read follows that frame.
+        expect(recorder.liveLayerRequests.value, 1);
+        expect(done, isFalse);
+        while (!done) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          await tester.pump();
+          if (!_allCached(tester)) sawLive = true;
+        }
+        (await future)?.dispose();
+      });
+
+      expect(sawLive, isTrue);
+      expect(recorder.liveLayerRequests.value, 0);
+      await _pumpUntilCached(tester);
+      expect(_cachedFlags(tester), [true]);
+    });
+
+    testWidgets('does not delay a capture when no host listens', (
+      tester,
+    ) async {
+      final recorder = ContentRecorderController(
+        configs: const ImageGenerationConfigs(
+          enableIsolateGeneration: false,
+          enableBackgroundGeneration: false,
+        ),
+        isVideoEditor: false,
+        ignoreGeneration: true,
+      );
+      addTearDown(recorder.destroy);
+      await tester.pumpWidget(
+        _stack([_stroke(Offset.zero)], enableCache: false, recorder: recorder),
+      );
+
+      expect(recorder.liveLayerRequests.hasHost, isFalse);
+      // Completes without another frame being pumped.
+      final image = await tester.runAsync(
+        () => recorder.getRawRenderedImage(imageInfos: _imageInfos),
+      );
+      expect(image, isNotNull);
+      image!.dispose();
+    });
+
+    testWidgets('renders live while its route is animating', (tester) async {
+      final layers = [_stroke(const Offset(-30, 0))];
+      final navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        MaterialApp(navigatorKey: navigatorKey, home: const SizedBox()),
+      );
+
+      // Hero shuttles fly in the overlay while their destination widgets are
+      // hidden, so a cached image would show the strokes twice until the
+      // transition ends.
+      unawaited(
+        navigatorKey.currentState!.push(
+          PageRouteBuilder<void>(
+            transitionDuration: const Duration(milliseconds: 300),
+            pageBuilder: (_, _, _) => Center(
+              child: SizedBox.fromSize(size: _body, child: _layerStack(layers)),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 100)),
+      );
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(_cachedFlags(tester), [false]);
+      expect(find.byType(PaintRunImage), findsNothing);
+
+      await tester.pumpAndSettle();
+      await _pumpUntilCached(tester);
+
+      expect(_cachedFlags(tester), [true]);
+      expect(find.byType(PaintRunImage), findsOneWidget);
     });
   });
 }

--- a/test/shared/widgets/layer/layer_stack_raster_cache_test.dart
+++ b/test/shared/widgets/layer/layer_stack_raster_cache_test.dart
@@ -1,0 +1,114 @@
+// Flutter imports:
+// Package imports:
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:pro_image_editor/core/models/transform_helper.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:pro_image_editor/shared/widgets/layer/layer_stack.dart';
+import 'package:pro_image_editor/shared/widgets/layer/layer_widget.dart';
+
+const Size _body = Size(200, 300);
+
+PaintLayer _stroke(Offset offset) => PaintLayer(
+  item: PaintedModel(
+    mode: PaintMode.freeStyle,
+    offsets: const [Offset(0, 0), Offset(10, 20), Offset(20, 5)],
+    erasedOffsets: const [],
+    color: Colors.red,
+    strokeWidth: 4,
+    opacity: 1,
+  ),
+  rawSize: const Size(20, 20),
+  opacity: 1,
+  offset: offset,
+);
+
+Widget _stack(
+  List<Layer> layers, {
+  bool enableCache = true,
+  bool suspend = false,
+}) {
+  return MaterialApp(
+    home: Center(
+      child: SizedBox.fromSize(
+        size: _body,
+        child: LayerStack(
+          configs: ProImageEditorConfigs(
+            mainEditor: MainEditorConfigs(
+              enablePaintLayerRasterCache: enableCache,
+            ),
+          ),
+          layers: layers,
+          overlayColor: Colors.black,
+          transformHelper: const TransformHelper(
+            editorBodySize: _body,
+            mainBodySize: _body,
+            mainImageSize: _body,
+          ),
+          suspendPaintLayerRasterCache: suspend,
+        ),
+      ),
+    ),
+  );
+}
+
+Iterable<bool> _cachedFlags(WidgetTester tester) => tester
+    .widgetList<LayerWidget>(find.byType(LayerWidget))
+    .map((widget) => widget.isRasterCached);
+
+Future<void> _pumpUntilCached(WidgetTester tester) async {
+  await tester.runAsync(() async {
+    for (var i = 0; i < 100 && !_cachedFlags(tester).every((c) => c); i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await tester.pump();
+    }
+  });
+  await tester.pump();
+}
+
+void main() {
+  group('LayerStack raster cache', () {
+    testWidgets('draws paint layers from one image once it is rendered', (
+      tester,
+    ) async {
+      final layers = [
+        _stroke(const Offset(-30, 0)),
+        _stroke(const Offset(30, 0)),
+      ];
+      await tester.pumpWidget(_stack(layers));
+
+      // Live until the image lands.
+      expect(_cachedFlags(tester), [false, false]);
+      expect(find.byType(PaintRunImage), findsNothing);
+
+      await _pumpUntilCached(tester);
+
+      expect(_cachedFlags(tester), [true, true]);
+      expect(find.byType(PaintRunImage), findsOneWidget);
+    });
+
+    testWidgets('stays live while suspended', (tester) async {
+      final layers = [_stroke(const Offset(-30, 0))];
+      await tester.pumpWidget(_stack(layers, suspend: true));
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 100)),
+      );
+      await tester.pump();
+
+      expect(_cachedFlags(tester), [false]);
+      expect(find.byType(PaintRunImage), findsNothing);
+    });
+
+    testWidgets('does nothing when the feature is off', (tester) async {
+      final layers = [_stroke(const Offset(-30, 0))];
+      await tester.pumpWidget(_stack(layers, enableCache: false));
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 100)),
+      );
+      await tester.pump();
+
+      expect(_cachedFlags(tester), [false]);
+      expect(find.byType(PaintRunImage), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Every paint layer is a vector path the engine re-strokes on each frame it appears in, and Impeller keeps nothing between frames. On a video canvas the background changes every frame, so a doodle-heavy edit re-renders all of its ink on every one of them. Measured on a Galaxy S25 Ultra with 150 freestyle strokes of 300 points: ~7–10 ms of raster per frame, whether the strokes sit in one merged layer or in a layer each, and regardless of point density — the cost tracks the amount of ink, not the layer count. Older phones spend their whole frame budget on it.

This adds an opt-in `MainEditorConfigs.enablePaintLayerRasterCache`. Consecutive static paint layers (a z-run; a text or sticker layer between two drawings splits them, so stacking order is untouched) are composited into one `ui.Image` and drawn from it until a member changes.

**What stays live**, so nothing ever looks worse than before:
- a layer that is selected or being dragged, scaled or rotated — excluded from the pointer-down on, so it is pixel-exact during the gesture and rejoins the cache once released;
- a layer with a timeline animation or enter/exit fade, and one outside its timeline window;
- everything while the editor is zoomed (the image is rendered for scale 1), while a sub-editor opens (hero flights need painted sources), during a partial erase in the paint editor (the eraser mutates strokes per pointer move), and during every layer capture — `captureAllLayersWithMeta` and `captureLayersOnDone` suspend the cache and wait for a frame in which every layer painted into its own repaint boundary.

Layers keep their widgets: hit-testing, selection, the interaction overlay and the repaint-boundary keys are unchanged; only `DrawPaintItem.paint` is skipped. Rasterization is asynchronous and throttled to one render at a time; a run renders live until its image lands, so the canvas is never blank and there is no stale ghost after a change. Images are bounded per run (8 M px) and in total (16 M px, LRU). The `LayerStack` used by the sub-editors takes part too, so drawing on top of many existing strokes gets the same relief.

Off by default — a direct `Layer.captureAsPng()` on a mounted, cached layer would read an empty boundary, so apps opt in and capture through the editor's capture methods, which handle it.

**Measured** (real `ProImageEditor.video`, 150 strokes × 300 points): raster 3.1 → 1.0 ms per frame during playback and 1.7 → 0.6 ms while retiming a layer. The composite is verified pixel-identical to the live `LayerWidget` render (0.0 % mismatch across translated, scaled, rotated, flipped and translucent layers).

The same change is on `perf/paint-layer-raster-cache-13x` (v13.5.0 + #863), for a 13.6.0 release that apps still on the pre-`material_ui` line can take.

**Related Issue:** Closes #none — motivated by divinevideo/divine-mobile#8032.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
